### PR TITLE
`query_projects()` and `available_query_params()`

### DIFF
--- a/mpcontribs-client/mpcontribs/client/__init__.py
+++ b/mpcontribs-client/mpcontribs/client/__init__.py
@@ -720,6 +720,11 @@ class Client(SwaggerClient):
         setattr(future, "track_id", track_id)
         return future
 
+    def available_query_params(self):
+        resource = self.swagger_spec.resources["contributions"]
+        operation = resource.operations["queryContributions"]
+        return [param.name for param in operation.params.values()]
+
     def get_project(self, name: str = None) -> Type[Dict]:
         """Retrieve full project entry
 
@@ -1277,7 +1282,7 @@ class Client(SwaggerClient):
     ) -> List[dict]:
         """Query contributions
 
-        See `client.contributions.queryContributions()` for keyword arguments used in query.
+        See `client.available_query_params()` for keyword arguments used in query.
 
         Args:
             query (dict): optional query to select contributions
@@ -1332,7 +1337,7 @@ class Client(SwaggerClient):
     ) -> dict:
         """Apply the same update to all contributions in a project (matching query)
 
-        See `client.contributions.queryContributions()` for keyword arguments used in query.
+        See `client.available_query_params()` for keyword arguments used in query.
 
         Args:
             data (dict): update to apply on every matching contribution

--- a/mpcontribs-client/mpcontribs/client/__init__.py
+++ b/mpcontribs-client/mpcontribs/client/__init__.py
@@ -813,7 +813,6 @@ class Client(SwaggerClient):
 
         return ret["data"]
 
-
     def create_project(self, name: str, title: str, authors: str, description: str, url: str):
         """Create a project
 


### PR DESCRIPTION
closes #1486 

@yang-ruoxi when closed, this PR will release a new mpcontribs-client version which contains two additional convenience functions:

- `available_query_params()` lists the contribution query parameters available for the initialized client
- `query_projects()` allows filtering project info by query parameters and/or text search