### PR TITLE
Migrate to modern pint (and therefore modern numpy)

### DIFF
--- a/mpcontribs-api/mpcontribs/api/contributions/document.py
+++ b/mpcontribs-api/mpcontribs/api/contributions/document.py
@@ -18,8 +18,6 @@ from mongoengine.fields import DateTimeField, ListField
 from boltons.iterutils import remap
 from decimal import Decimal
 from pint import UnitRegistry
-from pint.unit import UnitDefinition
-from pint.converters import ScaleConverter
 from pint.errors import DimensionalityError
 from uncertainties import ufloat_fromstr
 from pymatgen.core import Composition, Element
@@ -37,10 +35,16 @@ ureg = UnitRegistry(
 )
 ureg.default_format = "~,P"
 
-ureg.define(UnitDefinition("percent", "%", (), ScaleConverter(0.01)))
-ureg.define(UnitDefinition("permille", "%%", (), ScaleConverter(0.001)))
-ureg.define(UnitDefinition("ppm", "ppm", (), ScaleConverter(1e-6)))
-ureg.define(UnitDefinition("ppb", "ppb", (), ScaleConverter(1e-9)))
+if "percent" not in ureg:
+    # percent is native in pint >= 0.21
+    ureg.define("percent = 0.01 = %")
+if "permille" not in ureg:
+    # permille is native in pint >= 0.24.2
+    ureg.define("permille = 0.001 = ‰ = %%")
+if "ppm" not in ureg:
+    # ppm is native in pint >= 0.21
+    ureg.define("ppm = 1e-6")
+ureg.define("ppb = 1e-9")
 ureg.define("atom = 1")
 ureg.define("bohr_magneton = e * hbar / (2 * m_e) = µᵇ = µ_B = mu_B")
 ureg.define("electron_mass = 9.1093837015e-31 kg = mₑ = m_e")

--- a/mpcontribs-api/setup.py
+++ b/mpcontribs-api/setup.py
@@ -11,7 +11,7 @@ setup(
     url="https://mpcontribs.org",
     packages=["mpcontribs.api"],
     install_requires=[
-        "numpy<2",
+        "numpy",
         "apispec<6",
         "asn1crypto",
         "blinker",
@@ -32,7 +32,7 @@ setup(
         "more-itertools",
         "nbformat",
         "notebook<7",
-        "pint<0.20",
+        "pint",
         "psycopg2-binary",
         "pymatgen",
         "pyopenssl",

--- a/mpcontribs-client/mpcontribs/client/__init__.py
+++ b/mpcontribs-client/mpcontribs/client/__init__.py
@@ -54,8 +54,6 @@ from urllib3.util.retry import Retry
 from filetype.types.archive import Gz
 from filetype.types.image import Jpeg, Png, Gif, Tiff
 from pint import UnitRegistry
-from pint.unit import UnitDefinition
-from pint.converters import ScaleConverter
 from pint.errors import DimensionalityError
 from tempfile import gettempdir
 from plotly.express._chart_types import line as line_chart
@@ -104,10 +102,16 @@ ureg = UnitRegistry(
         lambda s: s.replace("%", " percent "),
     ],
 )
-ureg.define(UnitDefinition("percent", "%", (), ScaleConverter(0.01)))
-ureg.define(UnitDefinition("permille", "%%", (), ScaleConverter(0.001)))
-ureg.define(UnitDefinition("ppm", "ppm", (), ScaleConverter(1e-6)))
-ureg.define(UnitDefinition("ppb", "ppb", (), ScaleConverter(1e-9)))
+if "percent" not in ureg:
+    # percent is native in pint >= 0.21
+    ureg.define("percent = 0.01 = %")
+if "permille" not in ureg:
+    # permille is native in pint >= 0.24.2
+    ureg.define("permille = 0.001 = ‰ = %%")
+if "ppm" not in ureg:
+    # ppm is native in pint >= 0.21
+    ureg.define("ppm = 1e-6")
+ureg.define("ppb = 1e-9")
 ureg.define("atom = 1")
 ureg.define("bohr_magneton = e * hbar / (2 * m_e) = µᵇ = µ_B = mu_B")
 ureg.define("electron_mass = 9.1093837015e-31 kg = mₑ = m_e")

--- a/mpcontribs-client/setup.py
+++ b/mpcontribs-client/setup.py
@@ -21,7 +21,7 @@ setup(
     url="https://github.com/materialsproject/MPContribs/tree/master/mpcontribs-client",
     packages=["mpcontribs.client"],
     install_requires=[
-        "numpy<2",
+        "numpy",
         "boltons",
         "bravado",
         "filetype",
@@ -29,7 +29,7 @@ setup(
         "ipython",
         "json2html",
         "pandas",
-        "pint<0.20",
+        "pint",
         "plotly",
         "pyIsEmail",
         "pymatgen",


### PR DESCRIPTION
## Summary

Major changes:

- fix 1: allow recent pint versions (and therefore numpy 2)

## Checklist

- [ ] Google format doc strings added. Check with `ruff`.
- [ ] Type annotations included. Check with `mypy`.
- [ ] Tests added for new features/fixes.
- [ ] If applicable, new classes/functions/modules have [`duecredit`](https://github.com/duecredit/duecredit) `@due.dcite` decorators to reference relevant papers by DOI ([example](https://github.com/materialsproject/pymatgen/blob/91dbe6ee9ed01d781a9388bf147648e20c6d58e0/pymatgen/core/lattice.py#L1168-L1172))

Tip: Install `pre-commit` hooks to auto-check types and linting before every commit:

```sh
pip install -U pre-commit
pre-commit install
```
