### PR TITLE
Fix Measurement.nominal_value -> value breaking change from pint

### DIFF
--- a/mpcontribs-api/mpcontribs/api/contributions/document.py
+++ b/mpcontribs-api/mpcontribs/api/contributions/document.py
@@ -33,7 +33,11 @@ ureg = UnitRegistry(
         lambda s: s.replace("%", " percent "),
     ],
 )
-ureg.formatter.default_format = "~,P"
+if hasattr(ureg,"formatter"):
+    # for newer versions of pint
+    ureg.formatter.default_format = "~,P"
+else:
+    ureg.default_format = "~,P"
 
 if "percent" not in ureg:
     # percent is native in pint >= 0.21

--- a/mpcontribs-api/mpcontribs/api/contributions/document.py
+++ b/mpcontribs-api/mpcontribs/api/contributions/document.py
@@ -33,7 +33,7 @@ ureg = UnitRegistry(
         lambda s: s.replace("%", " percent "),
     ],
 )
-ureg.default_format = "~,P"
+ureg.formatter.default_format = "~,P"
 
 if "percent" not in ureg:
     # percent is native in pint >= 0.21
@@ -100,7 +100,10 @@ def get_quantity(s):
 
     try:
         parts[0] = ufloat_fromstr(parts[0])
-        return ureg.Measurement(*parts)
+        meas = ureg.Measurement(*parts)
+        if not hasattr(meas,"nominal_value") and (val := hasattr(meas,"value")):
+            meas.nominal_value = float(val) # Measurement.value is a `Quantity` object
+        return meas
     except ValueError:
         return None
 


### PR DESCRIPTION
pint removed the `nominal_value` attr of `Measurement` in v20.0, and replaced it with `value`, which returns a different type. Fixed that here, so that `nominal_value` is set on a measurement. Also ensure that the formatting used by `UnitRegistry` doesn't rely on soon-to-be deprecated attrs