### PR TITLE
Adds build arch arg for contribs api Dockerfile

### DIFF
--- a/mpcontribs-api/Dockerfile
+++ b/mpcontribs-api/Dockerfile
@@ -25,7 +25,7 @@ RUN wget -q https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-
   -O mpcontribs/api/contributions/formulae.json.gz
 
 FROM base
-ARG BUILDARCH
+ARG BUILDARCH=x86_64
 COPY --from=builder /usr/local/lib/python3.11/site-packages /usr/local/lib/python3.11/site-packages
 COPY --from=builder /usr/local/bin /usr/local/bin
 COPY --from=builder /usr/lib/$BUILDARCH-linux-gnu/libsnappy* /usr/lib/$BUILDARCH-linux-gnu/


### PR DESCRIPTION
adds build arch flag for developing on different architectures

arm -> aarch64
intel -> x86_64