### PR TITLE
Deprecation warning on client init

### DIFF
--- a/mpcontribs-client/mpcontribs/client/__init__.py
+++ b/mpcontribs-client/mpcontribs/client/__init__.py
@@ -889,6 +889,18 @@ class Client(SwaggerClient):
             project (str): use this project for all operations (query, update, create, delete)
             session (requests.Session): override session for client to use
         """
+
+        logger.warning(
+            """The `mpcontribs-client` package has been deprecated in favor of the main Materials Project (MP) API client `mp-api`.
+To use the MP Contribs client swith up-to-date features, please `pip install 'mp-api[contribs]'`:
+```py
+from mp_api.client import MPRester
+
+with MPRester() as mpr:
+    mpr.contribs.query_contributions(...)
+```"""
+        )
+
         # NOTE bravado future doesn't work with concurrent.futures
         # - Kong forwards consumer headers when api-key used for auth
         # - forward consumer headers when connecting through localhost

--- a/mpcontribs-client/mpcontribs/client/__init__.py
+++ b/mpcontribs-client/mpcontribs/client/__init__.py
@@ -890,18 +890,17 @@ class Client(SwaggerClient):
             session (requests.Session): override session for client to use
         """
 
-        # ruff: disable[E501]
         logger.warning(
-            """The `mpcontribs-client` package has been deprecated in favor of the main Materials Project (MP) API client `mp-api`.
-To use the MP Contribs client swith up-to-date features, please `pip install 'mp-api[contribs]'`:
-```py
-from mp_api.client import MPRester
-
-with MPRester() as mpr:
-    mpr.contribs.query_contributions(...)
-```"""
+            "The `mpcontribs-client` package has been deprecated "
+            "in favor of the main Materials Project (MP) API client `mp-api`. "
+            "To use the MP Contribs client swith up-to-date features, "
+            "please `pip install 'mp-api[contribs]'`:\n"
+            "```py\n"
+            "from mp_api.client import MPRester\n"
+            "with MPRester() as mpr:\n"
+            "    mpr.contribs.query_contributions(...)\n"
+            "```"
         )
-        # ruff: enable[E501]
 
         # NOTE bravado future doesn't work with concurrent.futures
         # - Kong forwards consumer headers when api-key used for auth

--- a/mpcontribs-client/mpcontribs/client/__init__.py
+++ b/mpcontribs-client/mpcontribs/client/__init__.py
@@ -890,6 +890,7 @@ class Client(SwaggerClient):
             session (requests.Session): override session for client to use
         """
 
+        # ruff: disable[E501]
         logger.warning(
             """The `mpcontribs-client` package has been deprecated in favor of the main Materials Project (MP) API client `mp-api`.
 To use the MP Contribs client swith up-to-date features, please `pip install 'mp-api[contribs]'`:
@@ -900,6 +901,7 @@ with MPRester() as mpr:
     mpr.contribs.query_contributions(...)
 ```"""
         )
+        # ruff: enable[E501]
 
         # NOTE bravado future doesn't work with concurrent.futures
         # - Kong forwards consumer headers when api-key used for auth

--- a/mpcontribs-client/mpcontribs/client/__init__.py
+++ b/mpcontribs-client/mpcontribs/client/__init__.py
@@ -891,10 +891,10 @@ class Client(SwaggerClient):
         """
 
         logger.warning(
-            "The `mpcontribs-client` package has been deprecated "
-            "in favor of the main Materials Project (MP) API client `mp-api`. "
-            "To use the MP Contribs client swith up-to-date features, "
-            "please `pip install 'mp-api[contribs]'`:\n"
+            "The `mpcontribs-client` package is entering long-term maintenance. "
+            "All new features will be added to the main Materials Project "
+            "(MP) API client `mp-api`. To use the MP Contribs client with "
+            "up-to-date features, please `pip install 'mp-api[contribs]'`:\n"
             "```py\n"
             "from mp_api.client import MPRester\n"
             "with MPRester() as mpr:\n"


### PR DESCRIPTION
After internal discussion, we will move the MPContribs client to the main API client code ([PR](https://github.com/materialsproject/api/pull/1075)). The current package will go into long-term maintenance for backwards compatibility

Throws a warning to the user informing about these changes