### PR TITLE
Quota limits

### DIFF
--- a/mpcontribs-api/pyproject.toml
+++ b/mpcontribs-api/pyproject.toml
@@ -13,6 +13,13 @@ include-package-data = true
 where = ["src"]
 include = ["mpcontribs_api*"]
 
+[tool.commitizen]
+name = "cz_conventional_commits"
+tag_format = "v$version"
+version_scheme = "pep440"
+version_provider = "uv"
+update_changelog_on_bump = true
+
 [project]
 name = "mpcontribs-api"
 dynamic = ["version"]

--- a/mpcontribs-api/src/mpcontribs_api/api/v1/router.py
+++ b/mpcontribs-api/src/mpcontribs_api/api/v1/router.py
@@ -1,6 +1,7 @@
 from fastapi import APIRouter
 
 from mpcontribs_api.domains.attachments.router import router as attachments_router
+from mpcontribs_api.domains.consumers.router import router as consumers_router
 from mpcontribs_api.domains.contributions.router import router as contributions_router
 from mpcontribs_api.domains.limits.router import router as limits_router
 from mpcontribs_api.domains.projects.router import router as projects_router
@@ -15,3 +16,11 @@ router.include_router(limits_router, prefix="/limits", tags=["limits"])
 router.include_router(projects_router, prefix="/projects", tags=["projects"])
 router.include_router(structures_router, prefix="/structures", tags=["structures"])
 router.include_router(tables_router, prefix="/tables", tags=["tables"])
+# Admin-only override management. Hidden from the OpenAPI schema (include_in_schema=False) but
+# still routable; every route additionally enforces require_admin.
+router.include_router(
+    consumers_router,
+    prefix="/admin/consumers",
+    tags=["admin"],
+    include_in_schema=False,
+)

--- a/mpcontribs-api/src/mpcontribs_api/app.py
+++ b/mpcontribs-api/src/mpcontribs_api/app.py
@@ -19,6 +19,7 @@ from mpcontribs_api.authz import (
 from mpcontribs_api.config import Settings, get_settings
 from mpcontribs_api.domains._redirects.router import router as redirects_router
 from mpcontribs_api.domains.attachments.models import Attachment
+from mpcontribs_api.domains.consumers.models import Consumer
 from mpcontribs_api.domains.contributions.models import Contribution
 from mpcontribs_api.domains.healthcheck.router import router as healthcheck_router
 from mpcontribs_api.domains.projects.models import Project
@@ -67,6 +68,7 @@ async def _setup_mongo(app: FastAPI, settings: Settings, stack: AsyncExitStack) 
             Attachment,
             Structure,
             Table,
+            Consumer,
         ],
     )
 

--- a/mpcontribs-api/src/mpcontribs_api/authz.py
+++ b/mpcontribs-api/src/mpcontribs_api/authz.py
@@ -38,7 +38,7 @@ class User(BaseModel):
     """User definition derived from request headers.
 
     Attributes:
-        consumer_id (str | None): Kong id, for logging only
+        consumer_id (str | None): Kong id
         username (str | None): the username of the active user - if None, the user is anonymous
         groups (frozenset[str]): the groups the user is part of - used for access control
     """

--- a/mpcontribs-api/src/mpcontribs_api/config.py
+++ b/mpcontribs-api/src/mpcontribs_api/config.py
@@ -5,6 +5,21 @@ from pydantic import BaseModel, Field, SecretStr, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
+class UserSettings(BaseModel):
+    max_projects: int = Field(
+        default=3,
+        description="The maximumum number of projects a single user is allowed to create",
+    )
+    max_unapproved_contributions_per_project: int = Field(
+        default=500,
+        description="The maximum number of unapproved contributions a single user is allowed to have per project",
+    )
+    max_columns: int = Field(
+        default=160,
+        description="The maximum number of columns a project is allowed to have",
+    )
+
+
 class RedisSettings(BaseModel):
     address: SecretStr
     url: SecretStr
@@ -178,6 +193,9 @@ class Settings(BaseSettings):
 
     # MPContribs_otel__*
     otel: ObservabilitySettings = Field(default_factory=ObservabilitySettings)
+
+    # MPContribs_user__*
+    user: UserSettings = Field(default_factory=UserSettings)
 
     # SMTP Settings
     mail_default_sender: str = Field(

--- a/mpcontribs-api/src/mpcontribs_api/config.py
+++ b/mpcontribs-api/src/mpcontribs_api/config.py
@@ -8,7 +8,7 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 class UserSettings(BaseModel):
     max_projects: int = Field(
         default=3,
-        description="The maximumum number of projects a single user is allowed to create",
+        description="The maximum number of projects a single user is allowed to create",
     )
     max_unapproved_contributions_per_project: int = Field(
         default=500,

--- a/mpcontribs-api/src/mpcontribs_api/config.py
+++ b/mpcontribs-api/src/mpcontribs_api/config.py
@@ -194,8 +194,8 @@ class Settings(BaseSettings):
     # MPContribs_otel__*
     otel: ObservabilitySettings = Field(default_factory=ObservabilitySettings)
 
-    # MPContribs_quota__*
-    quota: QuotaLimits = Field(default_factory=QuotaLimits)
+    # MPContribs_consumer__*
+    consumer: QuotaLimits = Field(default_factory=QuotaLimits)
 
     # SMTP Settings
     mail_default_sender: str = Field(

--- a/mpcontribs-api/src/mpcontribs_api/config.py
+++ b/mpcontribs-api/src/mpcontribs_api/config.py
@@ -5,7 +5,7 @@ from pydantic import BaseModel, Field, SecretStr, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
-class UserSettings(BaseModel):
+class QuotaLimits(BaseModel):
     max_projects: int = Field(
         default=3,
         description="The maximum number of projects a single user is allowed to create",
@@ -194,8 +194,8 @@ class Settings(BaseSettings):
     # MPContribs_otel__*
     otel: ObservabilitySettings = Field(default_factory=ObservabilitySettings)
 
-    # MPContribs_user__*
-    user: UserSettings = Field(default_factory=UserSettings)
+    # MPContribs_quota__*
+    quota: QuotaLimits = Field(default_factory=QuotaLimits)
 
     # SMTP Settings
     mail_default_sender: str = Field(

--- a/mpcontribs-api/src/mpcontribs_api/dependencies.py
+++ b/mpcontribs-api/src/mpcontribs_api/dependencies.py
@@ -8,7 +8,7 @@ from pymongo.asynchronous.database import AsyncDatabase
 from types_aiobotocore_s3 import S3Client
 
 from mpcontribs_api.authz import User
-from mpcontribs_api.exceptions import AuthenticationError
+from mpcontribs_api.exceptions import AuthenticationError, PermissionError
 
 
 def get_db(request: Request) -> AsyncDatabase:
@@ -72,3 +72,16 @@ def require_user(user: UserDep) -> User:
         raise AuthenticationError("authentication required")
     return user
 
+
+def require_admin(user: UserDep) -> User:
+    """Require an authenticated admin caller.
+
+    Distinguishes the two failure modes: an anonymous caller gets 401 (authenticate first), while an
+    authenticated non-admin gets 403 (authenticated, but not permitted). Gates the admin-only
+    consumer-override routes.
+    """
+    if user.is_anonymous:
+        raise AuthenticationError("authentication required")
+    if not user.is_admin:
+        raise PermissionError(required_role="admin")
+    return user

--- a/mpcontribs-api/src/mpcontribs_api/domains/consumers/dependencies.py
+++ b/mpcontribs-api/src/mpcontribs_api/domains/consumers/dependencies.py
@@ -1,0 +1,31 @@
+from typing import Annotated
+
+from fastapi import Depends
+
+from mpcontribs_api.dependencies import UserDep
+from mpcontribs_api.domains.consumers.models import ConsumerSettings
+from mpcontribs_api.domains.consumers.repository import MongoDbConsumerRepository
+
+
+def get_scoped_consumers(user: UserDep) -> MongoDbConsumerRepository:
+    return MongoDbConsumerRepository(user)
+
+
+ConsumerDep = Annotated[MongoDbConsumerRepository, Depends(get_scoped_consumers)]
+
+
+async def get_effective_limits(user: UserDep) -> ConsumerSettings:
+    """Resolve the settings in effect for the current caller.
+
+    Returns the ``settings`` of the caller's stored ``Consumer`` override if one exists, otherwise a
+    default ``ConsumerSettings`` (which fills from the env-backed global defaults). Callers with no
+    ``consumer_id`` (anonymous or dev) skip the lookup.
+    """
+    if user.consumer_id is None:
+        return ConsumerSettings()
+
+    override = await MongoDbConsumerRepository(user).get_by_consumer_id(user.consumer_id)
+    return override.settings if override is not None else ConsumerSettings()
+
+
+ConsumerLimitsDep = Annotated[ConsumerSettings, Depends(get_effective_limits)]

--- a/mpcontribs-api/src/mpcontribs_api/domains/consumers/models.py
+++ b/mpcontribs-api/src/mpcontribs_api/domains/consumers/models.py
@@ -17,11 +17,11 @@ class ConsumerSettings(BaseModel):
     (the repository/input paths use ``exclude_unset`` to keep an override partial).
     """
 
-    max_projects: int = Field(default_factory=lambda: get_settings().quota.max_projects, ge=0)
+    max_projects: int = Field(default_factory=lambda: get_settings().consumer.max_projects, ge=0)
     max_unapproved_contributions_per_project: int = Field(
-        default_factory=lambda: get_settings().quota.max_unapproved_contributions_per_project, ge=0
+        default_factory=lambda: get_settings().consumer.max_unapproved_contributions_per_project, ge=0
     )
-    max_columns: int = Field(default_factory=lambda: get_settings().quota.max_columns, ge=0)
+    max_columns: int = Field(default_factory=lambda: get_settings().consumer.max_columns, ge=0)
 
 
 class ConsumerSettingsFilter(BaseFilter):

--- a/mpcontribs-api/src/mpcontribs_api/domains/consumers/models.py
+++ b/mpcontribs-api/src/mpcontribs_api/domains/consumers/models.py
@@ -119,7 +119,7 @@ class ConsumerFilter(BaseFilter):
     consumer_id: str | None = None
     consumer_id__in: list[str] | None = None
 
-    settings: ConsumerSettingsFilter | None = FilterDepends(with_prefix("tables", ConsumerSettingsFilter))
+    settings: ConsumerSettingsFilter | None = FilterDepends(with_prefix("settings", ConsumerSettingsFilter))
 
     # sorting
     order_by: list[str] | None = None

--- a/mpcontribs-api/src/mpcontribs_api/domains/consumers/models.py
+++ b/mpcontribs-api/src/mpcontribs_api/domains/consumers/models.py
@@ -1,0 +1,128 @@
+from beanie import PydanticObjectId
+from fastapi_filter import FilterDepends, with_prefix
+from pydantic import BaseModel, Field
+from pymongo import ASCENDING, IndexModel
+
+from mpcontribs_api.config import get_settings
+from mpcontribs_api.domains._shared.filters import BaseFilter
+from mpcontribs_api.domains._shared.models import BaseDocumentWithInput, DocumentOut
+
+
+class ConsumerSettings(BaseModel):
+    """Per-consumer settings — the effective, fully-resolved values read by the app.
+
+    The quota limits default directly from the env-backed ``config.QuotaLimits`` (so an unset field
+    resolves to its global default), and this model is free to grow settings beyond quota limits.
+    Because unset fields fall back to defaults, admins can supply only the fields they want to change
+    (the repository/input paths use ``exclude_unset`` to keep an override partial).
+    """
+
+    max_projects: int = Field(default_factory=lambda: get_settings().quota.max_projects, ge=0)
+    max_unapproved_contributions_per_project: int = Field(
+        default_factory=lambda: get_settings().quota.max_unapproved_contributions_per_project, ge=0
+    )
+    max_columns: int = Field(default_factory=lambda: get_settings().quota.max_columns, ge=0)
+
+
+class ConsumerSettingsFilter(BaseFilter):
+    max_projects: int | None = None
+    max_projects__gte: int | None = None
+    max_projects__lte: int | None = None
+
+    max_unapproved_contributions_per_project: int | None = None
+    max_unapproved_contributions_per_project__gte: int | None = None
+    max_unapproved_contributions_per_project__lte: int | None = None
+
+    max_columns: int | None = None
+    max_columns__gte: int | None = None
+    max_columns__lte: int | None = None
+
+    # sorting
+    order_by: list[str] | None = None
+
+
+class Consumer(BaseDocumentWithInput[PydanticObjectId]):
+    """Admin-managed, per-consumer overrides of the global quota limits.
+
+    Stored in ``mp_consumers`` and matched to a request by Kong's ``consumer_id``. The quota limits
+    live under ``settings`` (a ``QuotaLimits``); an admin can override a single limit and any field
+    they leave unset inherits the env-backed default, snapshotted onto the document at insert time.
+    """
+
+    consumer_id: str
+    settings: ConsumerSettings = Field(default_factory=ConsumerSettings)
+
+    @classmethod
+    def with_defaults(cls, consumer_id: str = "") -> Consumer:
+        """In-memory Consumer whose ``settings`` carry the env-backed default limits.
+
+        Never persisted; a throwaway ``_id`` is minted only to satisfy the document's required id.
+        """
+        return cls.model_validate({"_id": PydanticObjectId(), "consumer_id": consumer_id})
+
+    @classmethod
+    def from_input_model(cls, data: ConsumerIn) -> Consumer:
+        """Build a stored document from an input payload, minting a fresh server-owned ``_id``.
+
+        Unset fields snapshot the current env defaults (``ConsumerSettings`` fills them from
+        ``config.QuotaLimits``), so the stored document always carries fully-resolved values.
+        """
+        settings = data.settings if data.settings is not None else ConsumerSettings()
+        return cls.model_validate({"_id": PydanticObjectId(), "consumer_id": data.consumer_id, "settings": settings})
+
+    class Settings:
+        name = "mp_consumers"
+        keep_nulls = False
+        indexes = [IndexModel([("consumer_id", ASCENDING)], name="consumer_id", unique=True)]
+
+
+class ConsumerIn(BaseModel):
+    """Admin-supplied payload to create a consumer override.
+
+    Limits left unset inherit the env-backed global defaults.
+    """
+
+    consumer_id: str
+    settings: ConsumerSettings | None = None
+
+
+class ConsumerPatch(BaseModel):
+    """Partial update to a consumer override.
+
+    Only the limits present under ``settings`` are changed; the rest are left as stored.
+    """
+
+    settings: ConsumerSettings | None = None
+
+
+class ConsumerOut(DocumentOut[PydanticObjectId]):
+    """Public-facing representation of a consumer override."""
+
+    consumer_id: str | None = None
+    settings: ConsumerSettings | None = None
+
+    @staticmethod
+    def default_fields() -> list[str]:
+        return [*ConsumerOut.model_fields]
+
+
+class ConsumerFilter(BaseFilter):
+    """Filter fields allowed when listing consumer overrides.
+
+    The quota limits live under ``settings`` on the document, so the flat filter names here are
+    remapped to dotted ``settings.<field>`` Mongo keys in ``_get_filter_conditions``.
+    """
+
+    id: PydanticObjectId | None = None
+    id__in: list[PydanticObjectId] | None = None
+
+    consumer_id: str | None = None
+    consumer_id__in: list[str] | None = None
+
+    settings: ConsumerSettingsFilter | None = FilterDepends(with_prefix("tables", ConsumerSettingsFilter))
+
+    # sorting
+    order_by: list[str] | None = None
+
+    class Constants(BaseFilter.Constants):
+        model = Consumer

--- a/mpcontribs-api/src/mpcontribs_api/domains/consumers/repository.py
+++ b/mpcontribs-api/src/mpcontribs_api/domains/consumers/repository.py
@@ -1,0 +1,93 @@
+from typing import Any
+
+from beanie import UpdateResponse
+from beanie.operators import Set
+
+from mpcontribs_api.authz import User
+from mpcontribs_api.domains._shared.repository import MongoDbRepository
+from mpcontribs_api.domains.consumers.models import (
+    Consumer,
+    ConsumerFilter,
+    ConsumerIn,
+    ConsumerOut,
+    ConsumerPatch,
+)
+from mpcontribs_api.exceptions import ConflictError, NotFoundError
+from mpcontribs_api.pagination import CursorParams
+
+
+class MongoDbConsumerRepository(MongoDbRepository[Consumer, ConsumerIn, ConsumerOut, ConsumerFilter, ConsumerPatch]):
+    """Repository for admin-managed consumer overrides.
+
+    Consumer overrides are an admin-only resource: every route that reaches this repository is
+    gated by ``require_admin``, so no per-user read scope is needed and ``_build_scope`` returns an
+    empty filter (admins see all overrides).
+    """
+
+    document_model = Consumer
+    out_model = ConsumerOut
+
+    @staticmethod
+    def _build_scope(user: User) -> dict[str, Any]:
+        # Admin-only resource (routes enforce ``require_admin``); no visibility filter required.
+        return {}
+
+    async def get_consumers(
+        self,
+        filter: ConsumerFilter,
+        pagination: CursorParams,
+        fields: frozenset[str] | None,
+    ):
+        """List consumer overrides. See ``get_many``."""
+        return await self.get_many(pagination=pagination, filter=filter, fields=fields)
+
+    async def get_consumer_by_id(self, id: str, fields: frozenset[str] | None):
+        """Find a single consumer override by its document id. See ``get_by_id``."""
+        return await self.get_by_id(self._convert_object_id(id), fields)
+
+    async def get_by_consumer_id(self, consumer_id: str) -> Consumer | None:
+        """Return the override document for a Kong ``consumer_id``, or ``None`` if none exists."""
+        return await Consumer.find_one(Consumer.consumer_id == consumer_id)
+
+    async def insert_consumer(self, consumer: ConsumerIn) -> Consumer:
+        """Insert a new override, rejecting a duplicate ``consumer_id`` with a clean 409.
+
+        The unique index on ``consumer_id`` is the hard guarantee; this pre-check turns the common
+        case into a readable conflict instead of a raw driver error.
+        """
+        existing = await self.get_by_consumer_id(consumer.consumer_id)
+        if existing is not None:
+            raise ConflictError(
+                "An override for this consumer already exists",
+                consumer_id=consumer.consumer_id,
+            )
+        return await self.insert_one(consumer)
+
+    async def patch_consumer_by_id(self, id: str, update: ConsumerPatch) -> Consumer:
+        """Partially update an override's limits by document id.
+
+        The limits live under a nested ``settings`` sub-document; the update is flattened to dotted
+        ``settings.<field>`` keys so a partial patch changes only the named limits and leaves the
+        siblings intact (a plain ``$set`` of ``settings`` would replace the whole sub-document).
+        """
+        object_id = self._convert_object_id(id)
+        overrides = update.settings.model_dump(exclude_unset=True) if update.settings else {}
+        dotted = {f"settings.{field}": value for field, value in overrides.items()}
+        if not dotted:
+            # Empty patch is a no-op that still returns the existing document (consistent behavior).
+            existing = await Consumer.find_one(Consumer.id == object_id)
+            if existing is None:
+                raise NotFoundError(self._not_found(id))
+            return existing
+
+        updated = await Consumer.find_one(Consumer.id == object_id).update(
+            Set(dotted),
+            response_type=UpdateResponse.NEW_DOCUMENT,
+        )  # pyright: ignore[reportGeneralTypeIssues] # beanie UpdateQuery is awaitable, but pyright doesn't see it
+        if updated is None:
+            raise NotFoundError(self._not_found(id))
+        return updated
+
+    async def delete_consumer_by_id(self, id: str) -> None:
+        """Delete an override by document id. See ``delete_by_id``."""
+        await self.delete_by_id(self._convert_object_id(id))

--- a/mpcontribs-api/src/mpcontribs_api/domains/consumers/router.py
+++ b/mpcontribs-api/src/mpcontribs_api/domains/consumers/router.py
@@ -1,0 +1,72 @@
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, Response, status
+from fastapi_filter import FilterDepends
+
+from mpcontribs_api.dependencies import require_admin
+from mpcontribs_api.domains._shared.types import FieldSelector
+from mpcontribs_api.domains.consumers.dependencies import ConsumerDep
+from mpcontribs_api.domains.consumers.models import (
+    ConsumerFilter,
+    ConsumerIn,
+    ConsumerOut,
+    ConsumerPatch,
+)
+from mpcontribs_api.pagination import CursorParams
+
+# Admin-only override management. Every route depends on ``require_admin``; the router as a whole is
+# mounted with ``include_in_schema=False`` (see api/v1/router.py) so it is hidden from the OpenAPI
+# spec while remaining reachable by callers that know the path.
+router = APIRouter(dependencies=[Depends(require_admin)])
+
+
+@router.get("")
+async def get_consumers(
+    repo: ConsumerDep,
+    pagination: Annotated[CursorParams, Depends()],
+    filter: ConsumerFilter = FilterDepends(ConsumerFilter),
+    fields: FieldSelector = ConsumerOut.default_fields(),
+):
+    """List consumer overrides (admin only)."""
+    selected = ConsumerOut.parse_fields(fields)
+    return await repo.get_consumers(filter=filter, pagination=pagination, fields=selected)
+
+
+@router.get("/{id}")
+async def get_consumer_by_id(
+    id: str,
+    repo: ConsumerDep,
+    fields: FieldSelector = ConsumerOut.default_fields(),
+):
+    """Get a single consumer override by document id (admin only)."""
+    selected = ConsumerOut.parse_fields(fields)
+    return await repo.get_consumer_by_id(id=id, fields=selected)
+
+
+@router.post("", response_model=ConsumerOut, status_code=status.HTTP_201_CREATED)
+async def create_consumer(
+    repo: ConsumerDep,
+    consumer: ConsumerIn,
+):
+    """Create a new consumer override, rejecting a duplicate ``consumer_id`` with 409 (admin only)."""
+    return await repo.insert_consumer(consumer)
+
+
+@router.patch("/{id}", response_model=ConsumerOut)
+async def patch_consumer_by_id(
+    repo: ConsumerDep,
+    id: str,
+    update: ConsumerPatch,
+):
+    """Partially update a consumer override by document id (admin only)."""
+    return await repo.patch_consumer_by_id(id=id, update=update)
+
+
+@router.delete("/{id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_consumer_by_id(
+    repo: ConsumerDep,
+    id: str,
+):
+    """Delete a consumer override by document id (admin only)."""
+    await repo.delete_consumer_by_id(id=id)
+    return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/mpcontribs-api/src/mpcontribs_api/domains/contributions/dependencies.py
+++ b/mpcontribs-api/src/mpcontribs_api/domains/contributions/dependencies.py
@@ -4,6 +4,7 @@ from fastapi import Depends
 
 from mpcontribs_api.dependencies import MongoClientDep, UserDep
 from mpcontribs_api.domains.attachments.repository import MongoDbAttachmentRepository
+from mpcontribs_api.domains.consumers.dependencies import ConsumerLimitsDep
 from mpcontribs_api.domains.contributions.repository import (
     MongoDbContributionRepository,
 )
@@ -20,15 +21,20 @@ def get_scoped_contributions(user: UserDep) -> MongoDbContributionRepository:
 ContributionDep = Annotated[MongoDbContributionRepository, Depends(get_scoped_contributions)]
 
 
-def get_contribution_service(user: UserDep, client: MongoClientDep) -> ContributionService:
+def get_contribution_service(
+    user: UserDep,
+    client: MongoClientDep,
+    limits: ConsumerLimitsDep,
+) -> ContributionService:
     return ContributionService(
         client=client,
         user=user,
-        projects=MongoDbProjectRepository(user),
+        projects=MongoDbProjectRepository(user, limits),
         contributions=MongoDbContributionRepository(user),
         structures=MongoDbStructureRepository(user),
         attachments=MongoDbAttachmentRepository(user),
         tables=MongoDbTableRepository(user),
+        limits=limits,
     )
 
 

--- a/mpcontribs-api/src/mpcontribs_api/domains/contributions/repository.py
+++ b/mpcontribs-api/src/mpcontribs_api/domains/contributions/repository.py
@@ -48,14 +48,12 @@ class MongoDbContributionRepository(
     async def count_contributions_for_project(self, project_name: str) -> int:
         """Count contributions already stored for a project.
 
-        Unscoped on purpose: the unapproved-contribution quota is a property of the project as a
+        Unscoped: the unapproved-contribution quota is a property of the project as a
         whole, not of what the current user can see. The cap comparison lives in the service.
         """
         return await self.document_model.find(self.document_model.project == project_name).count()
 
-    async def existing_versioned_keys(
-        self, keys: list[tuple[str, str, int]]
-    ) -> set[tuple[str, str, int]]:
+    async def existing_versioned_keys(self, keys: list[tuple[str, str, int]]) -> set[tuple[str, str, int]]:
         """Return which ``(project, identifier, version)`` triples already have a stored document.
 
         Args:
@@ -66,9 +64,7 @@ class MongoDbContributionRepository(
         """
         if not keys:
             return set()
-        match: dict[str, Any] = {
-            "$or": [{"project": p, "identifier": i, "version": v} for p, i, v in keys]
-        }
+        match: dict[str, Any] = {"$or": [{"project": p, "identifier": i, "version": v} for p, i, v in keys]}
         collection = self.document_model.get_pymongo_collection()
         existing: set[tuple[str, str, int]] = set()
         async for doc in collection.find(match, {"project": 1, "identifier": 1, "version": 1}):

--- a/mpcontribs-api/src/mpcontribs_api/domains/contributions/repository.py
+++ b/mpcontribs-api/src/mpcontribs_api/domains/contributions/repository.py
@@ -45,6 +45,14 @@ class MongoDbContributionRepository(
             ors.append({"project": {"$in": sorted(user.writable_projects)}})
         return {"$or": ors}
 
+    async def count_contributions_for_project(self, project_name: str) -> int:
+        """Count contributions already stored for a project.
+
+        Unscoped on purpose: the unapproved-contribution quota is a property of the project as a
+        whole, not of what the current user can see. The cap comparison lives in the service.
+        """
+        return await self.document_model.find(self.document_model.project == project_name).count()
+
     async def get_contributions(
         self,
         filter: ContributionFilter,

--- a/mpcontribs-api/src/mpcontribs_api/domains/contributions/repository.py
+++ b/mpcontribs-api/src/mpcontribs_api/domains/contributions/repository.py
@@ -53,6 +53,28 @@ class MongoDbContributionRepository(
         """
         return await self.document_model.find(self.document_model.project == project_name).count()
 
+    async def existing_versioned_keys(
+        self, keys: list[tuple[str, str, int]]
+    ) -> set[tuple[str, str, int]]:
+        """Return which ``(project, identifier, version)`` triples already have a stored document.
+
+        Args:
+            keys: (project, identifier, version) triples to test
+
+        Returns:
+            set[tuple[str, str, int]]: the subset of ``keys`` that already exist
+        """
+        if not keys:
+            return set()
+        match: dict[str, Any] = {
+            "$or": [{"project": p, "identifier": i, "version": v} for p, i, v in keys]
+        }
+        collection = self.document_model.get_pymongo_collection()
+        existing: set[tuple[str, str, int]] = set()
+        async for doc in collection.find(match, {"project": 1, "identifier": 1, "version": 1}):
+            existing.add((doc["project"], doc["identifier"], doc["version"]))
+        return existing
+
     async def get_contributions(
         self,
         filter: ContributionFilter,

--- a/mpcontribs-api/src/mpcontribs_api/domains/contributions/repository.py
+++ b/mpcontribs-api/src/mpcontribs_api/domains/contributions/repository.py
@@ -48,7 +48,7 @@ class MongoDbContributionRepository(
     async def count_contributions_for_project(self, project_name: str) -> int:
         """Count contributions already stored for a project.
 
-        Unscoped: the unapproved-contribution quota is a property of the project as a
+        Unscoped on purpose: the unapproved-contribution quota is a property of the project as a
         whole, not of what the current user can see. The cap comparison lives in the service.
         """
         return await self.document_model.find(self.document_model.project == project_name).count()
@@ -67,7 +67,7 @@ class MongoDbContributionRepository(
         match: dict[str, Any] = {"$or": [{"project": p, "identifier": i, "version": v} for p, i, v in keys]}
         collection = self.document_model.get_pymongo_collection()
         existing: set[tuple[str, str, int]] = set()
-        async for doc in collection.find(match, {"project": 1, "identifier": 1, "version": 1}):
+        async for doc in collection.find(match, {"_id": 0, "project": 1, "identifier": 1, "version": 1}):
             existing.add((doc["project"], doc["identifier"], doc["version"]))
         return existing
 

--- a/mpcontribs-api/src/mpcontribs_api/domains/contributions/router.py
+++ b/mpcontribs-api/src/mpcontribs_api/domains/contributions/router.py
@@ -131,8 +131,8 @@ async def get_contribution_by_id(
 
 
 @router.put("/{id}", dependencies=[Depends(require_user)])
-async def upsert_contribution_by_id(repo: ContributionDep, id: str, contribution: ContributionIn):
-    return await repo.upsert_contribution_by_id(id=id, contribution=contribution)
+async def upsert_contribution_by_id(service: ContributionServiceDep, id: str, contribution: ContributionIn):
+    return await service.upsert_contribution_by_id(id=id, contribution=contribution)
 
 
 @router.patch("/{id}", dependencies=[Depends(require_user)])

--- a/mpcontribs-api/src/mpcontribs_api/domains/contributions/router.py
+++ b/mpcontribs-api/src/mpcontribs_api/domains/contributions/router.py
@@ -7,6 +7,7 @@ from fastapi_filter import FilterDepends
 from mpcontribs_api.config import get_settings
 from mpcontribs_api.dependencies import S3Dep, require_user
 from mpcontribs_api.domains._shared.bulk import BulkWriteSummary
+from mpcontribs_api.domains._shared.models import DeleteResponse
 from mpcontribs_api.domains._shared.types import (
     DownloadFormat,
     FieldSelector,
@@ -57,12 +58,15 @@ async def get_contributions(
     return await repo.get_contributions(pagination=pagination, filter=filter, fields=selected)
 
 
-@router.delete("", dependencies=[Depends(require_user)])
+@router.delete("", response_model=DeleteResponse, dependencies=[Depends(require_user)])
 async def delete_contributions(
     repo: ContributionDep,
     filter: ContributionFilter = FilterDepends(ContributionFilter),
-):
-    return await repo.delete_contributions(filter=filter)
+) -> DeleteResponse:
+    # The repository returns a raw pymongo DeleteResult (or None when the filter matched nothing);
+    # convert it to the typed DeleteResponse so the endpoint has a stable, serializable contract.
+    result = await repo.delete_contributions(filter=filter)
+    return DeleteResponse.from_delete_result(result) if result is not None else DeleteResponse(num_deleted=0)
 
 
 # TODO: Might want to take contributions in from request body and run model_validate_json on it (much faster)

--- a/mpcontribs-api/src/mpcontribs_api/domains/contributions/service.py
+++ b/mpcontribs-api/src/mpcontribs_api/domains/contributions/service.py
@@ -89,6 +89,8 @@ class ContributionService:
         project = await self._projects.get_by_id(project_id, fields=frozenset({"is_approved"}))
         if not project or project.is_approved:
             return None
+        # Soft limit: this count feeds a non-atomic check-then-write, so concurrent writes to the
+        # same project can overshoot the cap by a bounded amount. Acceptable for an anti-abuse quota.
         return await self._contributions.count_contributions_for_project(project_id)
 
     async def insert_contributions(

--- a/mpcontribs-api/src/mpcontribs_api/domains/contributions/service.py
+++ b/mpcontribs-api/src/mpcontribs_api/domains/contributions/service.py
@@ -580,16 +580,18 @@ class ContributionService:
         return BulkWriteSummary[Contribution](total=len(contributions), succeeded=succeeded, failed=failed)
 
     async def upsert_contribution_by_id(self, id: str, contribution: ContributionIn) -> Contribution:
-        """Upsert a single contribution by document id, enforcing the unapproved-project quota.
-
-        Updating an existing (in-scope) contribution is always allowed. When ``id`` matches nothing
-        the repository inserts a new document, so the same unapproved cap that bounds inserts is
-        applied first: a new contribution for an unapproved project already at (or over) the cap is
-        rejected before the write.
+        """Upsert a single contribution by document id, enforcing write authorization and the quota.
 
         Raises:
-            PermissionError: inserting a new contribution would exceed the unapproved cap
+            PermissionError: the caller may not write the target project, or inserting a new
+                contribution would exceed the unapproved cap
         """
+        if not self._user.can_write(contribution.project):
+            raise PermissionError(
+                f"not authorized to write to project '{contribution.project}'",
+                project=contribution.project,
+            )
+
         existing = await self._contributions.get_contribution_by_id(id, fields=frozenset({"id"}))
         if existing is None:
             stored = await self._unapproved_stored_count(contribution.project)

--- a/mpcontribs-api/src/mpcontribs_api/domains/contributions/service.py
+++ b/mpcontribs-api/src/mpcontribs_api/domains/contributions/service.py
@@ -75,6 +75,23 @@ class ContributionService:
             "tables": self._tables,
         }
 
+    async def _remaining_unapproved_quota(self, project_id: str) -> int | None:
+        """How many more contributions may be added to ``project_id`` in this batch.
+
+        Returns ``None`` when the quota does not apply — the project is approved, or it could not
+        be read in the current scope (existence/permission is enforced on insert, not here).
+
+        For an unapproved project the cap is on the project's total contribution count, so the
+        remaining allowance is ``cap - existing`` (clamped at zero). The ``+ 1`` mirrors the
+        previous per-insert gate, which rejected only once the stored count exceeded the cap.
+        """
+        project = await self._projects.get_by_id(project_id, fields=frozenset({"is_approved"}))
+        if not project or project.is_approved:
+            return None
+        cap = get_settings().user.max_unapproved_contributions_per_project
+        existing = await self._contributions.count_contributions_for_project(project_id)
+        return max(0, cap - existing + 1)
+
     async def insert_contributions(
         self,
         contributions: list[ContributionIn],
@@ -104,12 +121,26 @@ class ContributionService:
         no_comp = [item for item in plan if not item.contribution.has_components()]
         with_comp = [item for item in plan if item.contribution.has_components()]
 
-        no_comp_succeeded, no_comp_failed = await self._insert_no_components(no_comp)
-        with_comp_succeeded, with_comp_failed = await self._insert_with_components(with_comp)
+        # Reject contributions that exceed the component limit
+        oversize_failures, remaining_indices = self._split_oversize(contributions)
+        # Reject contributions that are being added to an unapproved project and cause the project to exceed the
+        # contribution limit
+        quota_failures, remaining_indices = await self._split_quota_exceeded(remaining_indices, contributions)
+        no_comp_indices = [i for i in remaining_indices if not contributions[i].has_components()]
+        with_comp_indices = [i for i in remaining_indices if contributions[i].has_components()]
+
+        no_comp_succeeded, no_comp_failed = await self._insert_no_components(
+            indices=no_comp_indices,
+            contributions=contributions,
+        )
+        with_comp_succeeded, with_comp_failed = await self._insert_with_components(
+            indices=with_comp_indices,
+            contributions=contributions,
+        )
 
         succeeded = [doc for _, doc in sorted(no_comp_succeeded + with_comp_succeeded, key=lambda p: p[0])]
         failed = sorted(
-            failures + no_comp_failed + with_comp_failed,
+            oversize_failures + quota_failures + no_comp_failed + with_comp_failed,
             key=lambda f: f.index,
         )
         return BulkWriteSummary[Contribution](total=len(contributions), succeeded=succeeded, failed=failed)
@@ -295,27 +326,41 @@ class ContributionService:
                 remaining.append(i)
         return oversize, remaining
 
-    async def _split_contributions(
-        self, contributions: list[ContributionIn], *, is_upsert: bool
-    ) -> tuple[list[BulkFailure], list[ResolvedWrite]]:
-        """Common method for validating contribution write failure logic and resolving versions.
+    async def _split_quota_exceeded(
+        self,
+        indices: list[int],
+        contributions: list[ContributionIn],
+    ) -> tuple[list[BulkFailure], list[int]]:
+        """Trim each unapproved project's in-batch contributions to its remaining quota.
 
-        Runs the cheap, local, index-based filters first (authorization, then component-count cap)
-        so guaranteed failures never reach the DB; ``_split_non_unique`` runs last and turns the
-        remaining indices into a write plan carrying each resolved version.
-
-        Returns:
-            tuple of (failures and their reasons, a ``ResolvedWrite`` per contribution to write)
+        The unapproved-contribution cap is on a project's total count, so the batch's own additions
+        count toward it: a project with N slots left accepts the first N contributions for it (input
+        order) and rejects the rest. Rejections are non-terminal — they land in ``failed`` while the
+        rest of the batch proceeds, mirroring ``_split_oversize``. The policy is evaluated once per
+        distinct project.
         """
-        # Per-item project authorization (see _split_unauthorized for the per-item vs fail-fast
-        # decision). Only authorized items reach Mongo; the rest are reported in ``failed``.
-        unauthorized_failures, authorized_indices = self._split_unauthorized(range(len(contributions)), contributions)
-        # Reject contributions that have too many components associated with them.
-        oversize_failures, sized_indices = self._split_oversize(authorized_indices, contributions)
-        # Verify identifiers/uniqueness within a project and resolve each version, depending on
-        # project.unique_identifiers and whether this is an insert or upsert.
-        non_unique_failures, plan = await self._split_non_unique(sized_indices, contributions, is_upsert=is_upsert)
-        return (unauthorized_failures + oversize_failures + non_unique_failures, plan)
+        by_project: dict[str, list[int]] = defaultdict(list)
+        for i in indices:
+            by_project[contributions[i].project].append(i)
+
+        cap = get_settings().user.max_unapproved_contributions_per_project
+        failures: list[BulkFailure] = []
+        remaining: list[int] = []
+        for project_id, project_indices in by_project.items():
+            quota = await self._remaining_unapproved_quota(project_id)
+            if quota is None:
+                remaining.extend(project_indices)
+                continue
+            remaining.extend(project_indices[:quota])
+            exc = PermissionError(
+                "Attempted to add more than the allowed number of unapproved contributions",
+                project=project_id,
+                max_contribs=cap,
+            )
+            failures.extend(
+                bulk_failure_from_exception(i, contributions[i].identifiers(), exc) for i in project_indices[quota:]
+            )
+        return failures, sorted(remaining)
 
     async def _insert_no_components(
         self,

--- a/mpcontribs-api/src/mpcontribs_api/domains/contributions/service.py
+++ b/mpcontribs-api/src/mpcontribs_api/domains/contributions/service.py
@@ -32,6 +32,10 @@ from mpcontribs_api.pagination import CursorParams
 
 logger = structlog.get_logger(__name__)
 
+# Upper bound on rejected identifiers attached to a single quota-breach log line, so an
+# adversarial mega-batch can't blow up the log payload. The counts are always exact.
+_QUOTA_LOG_IDENTIFIER_CAP = 100
+
 
 @dataclass(frozen=True, slots=True)
 class ResolvedWrite:
@@ -75,22 +79,17 @@ class ContributionService:
             "tables": self._tables,
         }
 
-    async def _remaining_unapproved_quota(self, project_id: str) -> int | None:
-        """How many more contributions may be added to ``project_id`` in this batch.
+    async def _unapproved_stored_count(self, project_id: str) -> int | None:
+        """Contributions already stored for an unapproved ``project_id``, else ``None``.
 
         Returns ``None`` when the quota does not apply — the project is approved, or it could not
-        be read in the current scope (existence/permission is enforced on insert, not here).
-
-        For an unapproved project the cap is on the project's total contribution count, so the
-        remaining allowance is ``cap - existing`` (clamped at zero). The ``+ 1`` mirrors the
-        previous per-insert gate, which rejected only once the stored count exceeded the cap.
+        be read in the current scope (existence/permission is enforced on insert, not here). The
+        caller turns the count into a remaining allowance against the cap.
         """
         project = await self._projects.get_by_id(project_id, fields=frozenset({"is_approved"}))
         if not project or project.is_approved:
             return None
-        cap = get_settings().user.max_unapproved_contributions_per_project
-        existing = await self._contributions.count_contributions_for_project(project_id)
-        return max(0, cap - existing + 1)
+        return await self._contributions.count_contributions_for_project(project_id)
 
     async def insert_contributions(
         self,
@@ -337,7 +336,11 @@ class ContributionService:
         count toward it: a project with N slots left accepts the first N contributions for it (input
         order) and rejects the rest. Rejections are non-terminal — they land in ``failed`` while the
         rest of the batch proceeds, mirroring ``_split_oversize``. The policy is evaluated once per
-        distinct project.
+        distinct project, and each breach is logged for audit/abuse monitoring (the response is a
+        200 with embedded failures, so the access log alone cannot surface it).
+
+        The ``+ 1`` in the allowance mirrors the previous per-insert gate, which rejected only once
+        the stored count exceeded the cap.
         """
         by_project: dict[str, list[int]] = defaultdict(list)
         for i in indices:
@@ -347,20 +350,51 @@ class ContributionService:
         failures: list[BulkFailure] = []
         remaining: list[int] = []
         for project_id, project_indices in by_project.items():
-            quota = await self._remaining_unapproved_quota(project_id)
-            if quota is None:
+            stored = await self._unapproved_stored_count(project_id)
+            if stored is None:
                 remaining.extend(project_indices)
                 continue
-            remaining.extend(project_indices[:quota])
+            allowed = max(0, cap - stored + 1)
+            accepted, rejected = project_indices[:allowed], project_indices[allowed:]
+            remaining.extend(accepted)
+            if not rejected:
+                continue
+            self._log_quota_exceeded(project_id, contributions, cap, stored, len(accepted), rejected)
             exc = PermissionError(
                 "Attempted to add more than the allowed number of unapproved contributions",
                 project=project_id,
                 max_contribs=cap,
             )
-            failures.extend(
-                bulk_failure_from_exception(i, contributions[i].identifiers(), exc) for i in project_indices[quota:]
-            )
+            failures.extend(bulk_failure_from_exception(i, contributions[i].identifiers(), exc) for i in rejected)
         return failures, sorted(remaining)
+
+    @staticmethod
+    def _log_quota_exceeded(
+        project_id: str,
+        contributions: list[ContributionIn],
+        cap: int,
+        stored: int,
+        accepted: int,
+        rejected: list[int],
+    ) -> None:
+        """Emit a structured audit event for an unapproved-project quota breach.
+
+        Request/user correlation (``consumer_id``, ``request_id``, ``trace_id``) is merged from the
+        per-request contextvars, so only the domain-specific dimensions are added here. The rejected
+        identifier list is capped to keep a pathological batch from bloating a single log line.
+        """
+        rejected_identifiers = [contributions[i].identifier for i in rejected[:_QUOTA_LOG_IDENTIFIER_CAP]]
+        logger.warning(
+            "contribution.unapproved_quota_exceeded",
+            project=project_id,
+            max_allowed=cap,
+            stored=stored,
+            attempted=accepted + len(rejected),
+            accepted=accepted,
+            rejected=len(rejected),
+            rejected_identifiers=rejected_identifiers,
+            rejected_identifiers_truncated=len(rejected) > _QUOTA_LOG_IDENTIFIER_CAP,
+        )
 
     async def _insert_no_components(
         self,

--- a/mpcontribs-api/src/mpcontribs_api/domains/contributions/service.py
+++ b/mpcontribs-api/src/mpcontribs_api/domains/contributions/service.py
@@ -332,7 +332,7 @@ class ContributionService:
                 continue
             # Upserts against an existing row are updates (no new document); only absent keys count.
             existing = await self._existing_keys(items) if is_upsert else set()
-            allowed = max(0, cap - stored + 1)
+            allowed = max(0, cap - stored)
             rejected: list[ResolvedWrite] = []
             for item in items:
                 key = (item.contribution.project, item.contribution.identifier, item.version)
@@ -594,7 +594,7 @@ class ContributionService:
         if existing is None:
             stored = await self._unapproved_stored_count(contribution.project)
             cap = get_settings().user.max_unapproved_contributions_per_project
-            if stored is not None and stored > cap:
+            if stored is not None and stored >= cap:
                 logger.warning(
                     "contribution.unapproved_quota_exceeded",
                     project=contribution.project,

--- a/mpcontribs-api/src/mpcontribs_api/domains/contributions/service.py
+++ b/mpcontribs-api/src/mpcontribs_api/domains/contributions/service.py
@@ -120,26 +120,12 @@ class ContributionService:
         no_comp = [item for item in plan if not item.contribution.has_components()]
         with_comp = [item for item in plan if item.contribution.has_components()]
 
-        # Reject contributions that exceed the component limit
-        oversize_failures, remaining_indices = self._split_oversize(contributions)
-        # Reject contributions that are being added to an unapproved project and cause the project to exceed the
-        # contribution limit
-        quota_failures, remaining_indices = await self._split_quota_exceeded(remaining_indices, contributions)
-        no_comp_indices = [i for i in remaining_indices if not contributions[i].has_components()]
-        with_comp_indices = [i for i in remaining_indices if contributions[i].has_components()]
-
-        no_comp_succeeded, no_comp_failed = await self._insert_no_components(
-            indices=no_comp_indices,
-            contributions=contributions,
-        )
-        with_comp_succeeded, with_comp_failed = await self._insert_with_components(
-            indices=with_comp_indices,
-            contributions=contributions,
-        )
+        no_comp_succeeded, no_comp_failed = await self._insert_no_components(no_comp)
+        with_comp_succeeded, with_comp_failed = await self._insert_with_components(with_comp)
 
         succeeded = [doc for _, doc in sorted(no_comp_succeeded + with_comp_succeeded, key=lambda p: p[0])]
         failed = sorted(
-            oversize_failures + quota_failures + no_comp_failed + with_comp_failed,
+            failures + no_comp_failed + with_comp_failed,
             key=lambda f: f.index,
         )
         return BulkWriteSummary[Contribution](total=len(contributions), succeeded=succeeded, failed=failed)
@@ -327,55 +313,62 @@ class ContributionService:
 
     async def _split_quota_exceeded(
         self,
-        indices: list[int],
-        contributions: list[ContributionIn],
-    ) -> tuple[list[BulkFailure], list[int]]:
-        """Trim each unapproved project's in-batch contributions to its remaining quota.
-
-        The unapproved-contribution cap is on a project's total count, so the batch's own additions
-        count toward it: a project with N slots left accepts the first N contributions for it (input
-        order) and rejects the rest. Rejections are non-terminal — they land in ``failed`` while the
-        rest of the batch proceeds, mirroring ``_split_oversize``. The policy is evaluated once per
-        distinct project, and each breach is logged for audit/abuse monitoring (the response is a
-        200 with embedded failures, so the access log alone cannot surface it).
-
-        The ``+ 1`` in the allowance mirrors the previous per-insert gate, which rejected only once
-        the stored count exceeded the cap.
-        """
-        by_project: dict[str, list[int]] = defaultdict(list)
-        for i in indices:
-            by_project[contributions[i].project].append(i)
+        plan: list[ResolvedWrite],
+        *,
+        is_upsert: bool,
+    ) -> tuple[list[BulkFailure], list[ResolvedWrite]]:
+        """Trim each unapproved project's newly-created contributions to its remaining quota."""
+        by_project: dict[str, list[ResolvedWrite]] = defaultdict(list)
+        for item in plan:
+            by_project[item.contribution.project].append(item)
 
         cap = get_settings().user.max_unapproved_contributions_per_project
         failures: list[BulkFailure] = []
-        remaining: list[int] = []
-        for project_id, project_indices in by_project.items():
+        survivors: list[ResolvedWrite] = []
+        for project_id, items in by_project.items():
             stored = await self._unapproved_stored_count(project_id)
             if stored is None:
-                remaining.extend(project_indices)
+                survivors.extend(items)
                 continue
+            # Upserts against an existing row are updates (no new document); only absent keys count.
+            existing = await self._existing_keys(items) if is_upsert else set()
             allowed = max(0, cap - stored + 1)
-            accepted, rejected = project_indices[:allowed], project_indices[allowed:]
-            remaining.extend(accepted)
+            rejected: list[ResolvedWrite] = []
+            for item in items:
+                key = (item.contribution.project, item.contribution.identifier, item.version)
+                if key in existing:
+                    survivors.append(item)
+                elif allowed > 0:
+                    survivors.append(item)
+                    allowed -= 1
+                else:
+                    rejected.append(item)
             if not rejected:
                 continue
-            self._log_quota_exceeded(project_id, contributions, cap, stored, len(accepted), rejected)
+            self._log_quota_exceeded(project_id, cap, stored, len(items) - len(rejected), rejected)
             exc = PermissionError(
                 "Attempted to add more than the allowed number of unapproved contributions",
                 project=project_id,
                 max_contribs=cap,
             )
-            failures.extend(bulk_failure_from_exception(i, contributions[i].identifiers(), exc) for i in rejected)
-        return failures, sorted(remaining)
+            failures.extend(
+                bulk_failure_from_exception(item.index, item.contribution.identifiers(), exc) for item in rejected
+            )
+        survivors.sort(key=lambda item: item.index)
+        return failures, survivors
+
+    async def _existing_keys(self, items: list[ResolvedWrite]) -> set[tuple[str, str, int]]:
+        """Return which of ``items``' ``(project, identifier, version)`` keys already exist."""
+        keys = [(item.contribution.project, item.contribution.identifier, item.version) for item in items]
+        return await self._contributions.existing_versioned_keys(keys)
 
     @staticmethod
     def _log_quota_exceeded(
         project_id: str,
-        contributions: list[ContributionIn],
         cap: int,
         stored: int,
         accepted: int,
-        rejected: list[int],
+        rejected: list[ResolvedWrite],
     ) -> None:
         """Emit a structured audit event for an unapproved-project quota breach.
 
@@ -383,7 +376,7 @@ class ContributionService:
         per-request contextvars, so only the domain-specific dimensions are added here. The rejected
         identifier list is capped to keep a pathological batch from bloating a single log line.
         """
-        rejected_identifiers = [contributions[i].identifier for i in rejected[:_QUOTA_LOG_IDENTIFIER_CAP]]
+        rejected_identifiers = [item.contribution.identifier for item in rejected[:_QUOTA_LOG_IDENTIFIER_CAP]]
         logger.warning(
             "contribution.unapproved_quota_exceeded",
             project=project_id,
@@ -395,6 +388,31 @@ class ContributionService:
             rejected_identifiers=rejected_identifiers,
             rejected_identifiers_truncated=len(rejected) > _QUOTA_LOG_IDENTIFIER_CAP,
         )
+
+    async def _split_contributions(
+        self, contributions: list[ContributionIn], *, is_upsert: bool
+    ) -> tuple[list[BulkFailure], list[ResolvedWrite]]:
+        """Common method for validating contribution write failure logic and resolving versions.
+
+        Runs the cheap, local, index-based filters first (authorization, then component-count cap)
+        so guaranteed failures never reach the DB; ``_split_non_unique`` then turns the survivors
+        into a write plan carrying each resolved version, and the unapproved-contribution quota runs
+        last on that plan.
+
+        Returns:
+            tuple of (failures and their reasons, a ``ResolvedWrite`` per contribution to write)
+        """
+        # Per-item project authorization (see _split_unauthorized for the per-item vs fail-fast
+        # decision). Only authorized items reach Mongo; the rest are reported in ``failed``.
+        unauthorized_failures, authorized_indices = self._split_unauthorized(range(len(contributions)), contributions)
+        # Reject contributions that have too many components associated with them.
+        oversize_failures, sized_indices = self._split_oversize(authorized_indices, contributions)
+        # Verify identifiers/uniqueness within a project and resolve each version, depending on
+        # project.unique_identifiers and whether this is an insert or upsert.
+        non_unique_failures, plan = await self._split_non_unique(sized_indices, contributions, is_upsert=is_upsert)
+        # Reject writes that would push an unapproved project past its contribution cap.
+        quota_failures, plan = await self._split_quota_exceeded(plan, is_upsert=is_upsert)
+        return (unauthorized_failures + oversize_failures + non_unique_failures + quota_failures, plan)
 
     async def _insert_no_components(
         self,
@@ -560,6 +578,40 @@ class ContributionService:
         succeeded = [r for r in results if not isinstance(r, BulkFailure)]
         failed = failures + [r for r in results if isinstance(r, BulkFailure)]
         return BulkWriteSummary[Contribution](total=len(contributions), succeeded=succeeded, failed=failed)
+
+    async def upsert_contribution_by_id(self, id: str, contribution: ContributionIn) -> Contribution:
+        """Upsert a single contribution by document id, enforcing the unapproved-project quota.
+
+        Updating an existing (in-scope) contribution is always allowed. When ``id`` matches nothing
+        the repository inserts a new document, so the same unapproved cap that bounds inserts is
+        applied first: a new contribution for an unapproved project already at (or over) the cap is
+        rejected before the write.
+
+        Raises:
+            PermissionError: inserting a new contribution would exceed the unapproved cap
+        """
+        existing = await self._contributions.get_contribution_by_id(id, fields=frozenset({"id"}))
+        if existing is None:
+            stored = await self._unapproved_stored_count(contribution.project)
+            cap = get_settings().user.max_unapproved_contributions_per_project
+            if stored is not None and stored > cap:
+                logger.warning(
+                    "contribution.unapproved_quota_exceeded",
+                    project=contribution.project,
+                    max_allowed=cap,
+                    stored=stored,
+                    attempted=1,
+                    accepted=0,
+                    rejected=1,
+                    rejected_identifiers=[contribution.identifier],
+                    rejected_identifiers_truncated=False,
+                )
+                raise PermissionError(
+                    "Attempted to add more than the allowed number of unapproved contributions",
+                    project=contribution.project,
+                    max_contribs=cap,
+                )
+        return await self._contributions.upsert_contribution_by_id(id, contribution)
 
     async def delete_contributions(self, filter: ContributionFilter) -> BulkDeleteSummary:
         """Delete a contribution and all of its child components

--- a/mpcontribs-api/src/mpcontribs_api/domains/contributions/service.py
+++ b/mpcontribs-api/src/mpcontribs_api/domains/contributions/service.py
@@ -602,8 +602,8 @@ class ContributionService:
             stored = await self._unapproved_stored_count(contribution.project)
             cap = self._limits.max_unapproved_contributions_per_project
             if stored is not None and stored >= cap:
-                logger.warning(
-                    "contribution.unapproved_quota_exceeded",
+                raise PermissionError(
+                    "Attempted to add more than the allowed number of unapproved contributions",
                     project=contribution.project,
                     max_allowed=cap,
                     stored=stored,
@@ -612,11 +612,6 @@ class ContributionService:
                     rejected=1,
                     rejected_identifiers=[contribution.identifier],
                     rejected_identifiers_truncated=False,
-                )
-                raise PermissionError(
-                    "Attempted to add more than the allowed number of unapproved contributions",
-                    project=contribution.project,
-                    max_contribs=cap,
                 )
         return await self._contributions.upsert_contribution_by_id(id, contribution)
 

--- a/mpcontribs-api/src/mpcontribs_api/domains/contributions/service.py
+++ b/mpcontribs-api/src/mpcontribs_api/domains/contributions/service.py
@@ -354,7 +354,7 @@ class ContributionService:
             exc = PermissionError(
                 "Attempted to add more than the allowed number of unapproved contributions",
                 project=project_id,
-                max_contribs=cap,
+                max_allowed=cap,
             )
             failures.extend(
                 bulk_failure_from_exception(item.index, item.contribution.identifiers(), exc) for item in rejected

--- a/mpcontribs-api/src/mpcontribs_api/domains/contributions/service.py
+++ b/mpcontribs-api/src/mpcontribs_api/domains/contributions/service.py
@@ -20,6 +20,7 @@ from mpcontribs_api.domains._shared.bulk import (
 )
 from mpcontribs_api.domains._shared.repository import MongoDbRepository
 from mpcontribs_api.domains.attachments.repository import MongoDbAttachmentRepository
+from mpcontribs_api.domains.consumers.models import ConsumerSettings
 from mpcontribs_api.domains.contributions.models import Contribution, ContributionFilter, ContributionIn
 from mpcontribs_api.domains.contributions.repository import MongoDbContributionRepository
 from mpcontribs_api.domains.projects.repository import MongoDbProjectRepository
@@ -61,6 +62,7 @@ class ContributionService:
         attachments: MongoDbAttachmentRepository,
         tables: MongoDbTableRepository,
         settings: MongoSettings | None = None,
+        limits: ConsumerSettings | None = None,
     ):
         self._client = client
         self._user = user
@@ -70,6 +72,7 @@ class ContributionService:
         self._attachments = attachments
         self._tables = tables
         self._settings = settings or get_settings().mongo
+        self._limits = limits or ConsumerSettings()
 
     @property
     def _children(self) -> dict[str, MongoDbRepository]:
@@ -324,7 +327,7 @@ class ContributionService:
         for item in plan:
             by_project[item.contribution.project].append(item)
 
-        cap = get_settings().user.max_unapproved_contributions_per_project
+        cap = self._limits.max_unapproved_contributions_per_project
         failures: list[BulkFailure] = []
         survivors: list[ResolvedWrite] = []
         for project_id, items in by_project.items():
@@ -597,7 +600,7 @@ class ContributionService:
         existing = await self._contributions.get_contribution_by_id(id, fields=frozenset({"id"}))
         if existing is None:
             stored = await self._unapproved_stored_count(contribution.project)
-            cap = get_settings().user.max_unapproved_contributions_per_project
+            cap = self._limits.max_unapproved_contributions_per_project
             if stored is not None and stored >= cap:
                 logger.warning(
                     "contribution.unapproved_quota_exceeded",

--- a/mpcontribs-api/src/mpcontribs_api/domains/projects/dependencies.py
+++ b/mpcontribs-api/src/mpcontribs_api/domains/projects/dependencies.py
@@ -3,13 +3,14 @@ from typing import Annotated
 from fastapi import Depends
 
 from mpcontribs_api.dependencies import UserDep
+from mpcontribs_api.domains.consumers.dependencies import ConsumerLimitsDep
 from mpcontribs_api.domains.projects.repository import (
     MongoDbProjectRepository,
 )
 
 
-def get_scoped_projects(user: UserDep) -> MongoDbProjectRepository:
-    return MongoDbProjectRepository(user)
+def get_scoped_projects(user: UserDep, limits: ConsumerLimitsDep) -> MongoDbProjectRepository:
+    return MongoDbProjectRepository(user, limits)
 
 
 ProjectDep = Annotated[MongoDbProjectRepository, Depends(get_scoped_projects)]

--- a/mpcontribs-api/src/mpcontribs_api/domains/projects/models.py
+++ b/mpcontribs-api/src/mpcontribs_api/domains/projects/models.py
@@ -2,12 +2,11 @@ from __future__ import annotations
 
 from typing import Any, Literal
 
-from fastapi_filter.contrib.beanie import Filter
 from pydantic import BaseModel, ConfigDict, Field, HttpUrl, field_validator
 
 from mpcontribs_api import pagination
-from mpcontribs_api.domains._shared.filters import BaseFilter
 from mpcontribs_api.config import get_settings
+from mpcontribs_api.domains._shared.filters import BaseFilter
 from mpcontribs_api.domains._shared.models import BaseDocumentWithInput, DocumentOut
 from mpcontribs_api.domains._shared.types import PrefixedEmail, ShortStr
 from mpcontribs_api.exceptions import ValidationError

--- a/mpcontribs-api/src/mpcontribs_api/domains/projects/models.py
+++ b/mpcontribs-api/src/mpcontribs_api/domains/projects/models.py
@@ -11,7 +11,20 @@ from mpcontribs_api.domains._shared.models import BaseDocumentWithInput, Documen
 from mpcontribs_api.domains._shared.types import PrefixedEmail, ShortStr
 from mpcontribs_api.exceptions import ValidationError
 
-settings = get_settings()
+
+def _validate_column_limit(columns: Any) -> Any:
+    """Reject input carrying more than the configured column cap.
+
+    Allows legacy docs that exceed cap to be returned without raising an error.
+    """
+    if isinstance(columns, list):
+        max_columns = get_settings().user.max_columns
+        if len(columns) > max_columns:
+            raise ValidationError(
+                f"columns cannot have more than {max_columns} entries",
+                column_length=len(columns),
+            )
+    return columns
 
 
 class Column(BaseModel):
@@ -75,16 +88,6 @@ class Project(BaseDocumentWithInput[ShortStr]):
         Needs override over parent class since Project.id is a simple str
         """
         return pagination.decode_cursor(cursor)
-
-    @field_validator("columns", mode="before")
-    @classmethod
-    def limit_column_length(cls, c: list[Column]) -> list[Column]:
-        if len(c) > settings.user.max_columns:
-            raise ValidationError(
-                f"columns cannot have more than {settings.user.max_columns} entries",
-                column_length=len(c),
-            )
-        return c
 
     class Settings:
         name = "projects"
@@ -152,7 +155,10 @@ class ProjectFilter(BaseFilter):
 class ProjectIn(Project):
     """Representation of user-supplied input."""
 
-    pass
+    @field_validator("columns", mode="before")
+    @classmethod
+    def limit_column_length(cls, c: Any) -> Any:
+        return _validate_column_limit(c)
 
 
 class ProjectPatch(BaseModel):
@@ -173,10 +179,5 @@ class ProjectPatch(BaseModel):
 
     @field_validator("columns", mode="before")
     @classmethod
-    def limit_column_length(cls, c: list[Column]) -> list[Column]:
-        if len(c) > settings.user.max_columns:
-            raise ValidationError(
-                f"columns cannot have more than {settings.user.max_columns} entries",
-                column_length=len(c),
-            )
-        return c
+    def limit_column_length(cls, c: Any) -> Any:
+        return _validate_column_limit(c)

--- a/mpcontribs-api/src/mpcontribs_api/domains/projects/models.py
+++ b/mpcontribs-api/src/mpcontribs_api/domains/projects/models.py
@@ -2,12 +2,17 @@ from __future__ import annotations
 
 from typing import Any, Literal
 
-from pydantic import BaseModel, ConfigDict, Field, HttpUrl
+from fastapi_filter.contrib.beanie import Filter
+from pydantic import BaseModel, ConfigDict, Field, HttpUrl, field_validator
 
 from mpcontribs_api import pagination
 from mpcontribs_api.domains._shared.filters import BaseFilter
+from mpcontribs_api.config import get_settings
 from mpcontribs_api.domains._shared.models import BaseDocumentWithInput, DocumentOut
 from mpcontribs_api.domains._shared.types import PrefixedEmail, ShortStr
+from mpcontribs_api.exceptions import ValidationError
+
+settings = get_settings()
 
 
 class Column(BaseModel):
@@ -71,6 +76,16 @@ class Project(BaseDocumentWithInput[ShortStr]):
         Needs override over parent class since Project.id is a simple str
         """
         return pagination.decode_cursor(cursor)
+
+    @field_validator("columns", mode="before")
+    @classmethod
+    def limit_column_length(cls, c: list[Column]) -> list[Column]:
+        if len(c) > settings.user.max_columns:
+            raise ValidationError(
+                f"columns cannot have more than {settings.user.max_columns} entries",
+                column_length=len(c),
+            )
+        return c
 
     class Settings:
         name = "projects"
@@ -156,3 +171,13 @@ class ProjectPatch(BaseModel):
     is_public: bool = False
     is_approved: bool = False
     license: Literal["CCA4", "CCPD"] | None = None
+
+    @field_validator("columns", mode="before")
+    @classmethod
+    def limit_column_length(cls, c: list[Column]) -> list[Column]:
+        if len(c) > settings.user.max_columns:
+            raise ValidationError(
+                f"columns cannot have more than {settings.user.max_columns} entries",
+                column_length=len(c),
+            )
+        return c

--- a/mpcontribs-api/src/mpcontribs_api/domains/projects/models.py
+++ b/mpcontribs-api/src/mpcontribs_api/domains/projects/models.py
@@ -1,30 +1,24 @@
-from __future__ import annotations
-
 from typing import Any, Literal
 
-from pydantic import BaseModel, ConfigDict, Field, HttpUrl, field_validator
+from pydantic import BaseModel, ConfigDict, Field, HttpUrl
 
 from mpcontribs_api import pagination
-from mpcontribs_api.config import get_settings
 from mpcontribs_api.domains._shared.filters import BaseFilter
 from mpcontribs_api.domains._shared.models import BaseDocumentWithInput, DocumentOut
 from mpcontribs_api.domains._shared.types import PrefixedEmail, ShortStr
 from mpcontribs_api.exceptions import ValidationError
 
 
-def _validate_column_limit(columns: Any) -> Any:
-    """Reject input carrying more than the configured column cap.
+def check_column_limit(columns: Any, max_columns: int) -> None:
+    """Reject a *write* carrying more columns than ``max_columns`` allows.
 
     Allows legacy docs that exceed cap to be returned without raising an error.
     """
-    if isinstance(columns, list):
-        max_columns = get_settings().user.max_columns
-        if len(columns) > max_columns:
-            raise ValidationError(
-                f"columns cannot have more than {max_columns} entries",
-                column_length=len(columns),
-            )
-    return columns
+    if isinstance(columns, list) and len(columns) > max_columns:
+        raise ValidationError(
+            f"columns cannot have more than {max_columns} entries",
+            column_length=len(columns),
+        )
 
 
 class Column(BaseModel):
@@ -155,11 +149,6 @@ class ProjectFilter(BaseFilter):
 class ProjectIn(Project):
     """Representation of user-supplied input."""
 
-    @field_validator("columns", mode="before")
-    @classmethod
-    def limit_column_length(cls, c: Any) -> Any:
-        return _validate_column_limit(c)
-
 
 class ProjectPatch(BaseModel):
     """Nullable Project representation of user-supplied data for partial update (patch)."""
@@ -176,8 +165,3 @@ class ProjectPatch(BaseModel):
     is_public: bool = False
     is_approved: bool = False
     license: Literal["CCA4", "CCPD"] | None = None
-
-    @field_validator("columns", mode="before")
-    @classmethod
-    def limit_column_length(cls, c: Any) -> Any:
-        return _validate_column_limit(c)

--- a/mpcontribs-api/src/mpcontribs_api/domains/projects/models.py
+++ b/mpcontribs-api/src/mpcontribs_api/domains/projects/models.py
@@ -9,7 +9,7 @@ from mpcontribs_api.domains._shared.types import PrefixedEmail, ShortStr
 from mpcontribs_api.exceptions import ValidationError
 
 
-def check_column_limit(columns: Any, max_columns: int) -> None:
+def validate_column_limit(columns: Any, max_columns: int) -> None:
     """Reject a *write* carrying more columns than ``max_columns`` allows.
 
     Allows legacy docs that exceed cap to be returned without raising an error.

--- a/mpcontribs-api/src/mpcontribs_api/domains/projects/repository.py
+++ b/mpcontribs-api/src/mpcontribs_api/domains/projects/repository.py
@@ -49,6 +49,8 @@ class MongoDbProjectRepository(MongoDbRepository[Project, ProjectIn, ProjectOut,
     async def _check_num_projects(self, owner: str):
         """Reject a *new* project that would push ``owner`` past the per-user cap."""
         settings = get_settings()
+        # Soft limit: this count-then-insert is not atomic, so concurrent creates by the same owner
+        # can overshoot the cap by a bounded amount. Acceptable for an anti-abuse quota.
         result = await Project.find(Project.owner == owner).count()
         if result >= settings.user.max_projects:
             raise PermissionError(

--- a/mpcontribs-api/src/mpcontribs_api/domains/projects/repository.py
+++ b/mpcontribs-api/src/mpcontribs_api/domains/projects/repository.py
@@ -1,6 +1,7 @@
 from typing import Any
 
 from mpcontribs_api.authz import User
+from mpcontribs_api.config import get_settings
 from mpcontribs_api.domains._shared.repository import MongoDbRepository
 from mpcontribs_api.domains.projects.models import (
     Project,
@@ -45,6 +46,16 @@ class MongoDbProjectRepository(MongoDbRepository[Project, ProjectIn, ProjectOut,
                 ors.append({"_id": {"$in": sorted(user.groups)}})
         return {"$or": ors}
 
+    async def _check_num_projects(self, data: ProjectIn):
+        settings = get_settings()
+        result = await Project.find(Project.owner == data.owner).count()
+        if result > settings.user.max_projects:
+            raise PermissionError(
+                f"Cannot be owner of more than {settings.user.max_projects} projects",
+                owner=data.owner,
+                num_projects=result,
+            )
+
     async def get_projects(
         self,
         filter: ProjectFilter,
@@ -84,6 +95,7 @@ class MongoDbProjectRepository(MongoDbRepository[Project, ProjectIn, ProjectOut,
 
     async def insert_project(self, project: ProjectIn) -> Project:
         """Insert a new project, rejecting a duplicate id. See ``insert_one``."""
+        await self._check_num_projects(project)
         return await self.insert_one(project)
 
     async def patch_project_by_id(self, id: str, update: ProjectPatch) -> Project:
@@ -120,6 +132,8 @@ class MongoDbProjectRepository(MongoDbRepository[Project, ProjectIn, ProjectOut,
         # The route enforces authentication, so an anonymous caller should never reach here.
         if self._user.username is None:
             raise PermissionError(required_role="authenticated")
+
+        await self._check_num_projects(data)
 
         existing = await self.document_model.find_one(self.document_model.id == id)
         project = self.document_model.from_input_model(data)

--- a/mpcontribs-api/src/mpcontribs_api/domains/projects/repository.py
+++ b/mpcontribs-api/src/mpcontribs_api/domains/projects/repository.py
@@ -46,13 +46,14 @@ class MongoDbProjectRepository(MongoDbRepository[Project, ProjectIn, ProjectOut,
                 ors.append({"_id": {"$in": sorted(user.groups)}})
         return {"$or": ors}
 
-    async def _check_num_projects(self, data: ProjectIn):
+    async def _check_num_projects(self, owner: str):
+        """Reject a *new* project that would push ``owner`` past the per-user cap."""
         settings = get_settings()
-        result = await Project.find(Project.owner == data.owner).count()
-        if result > settings.user.max_projects:
+        result = await Project.find(Project.owner == owner).count()
+        if result >= settings.user.max_projects:
             raise PermissionError(
                 f"Cannot be owner of more than {settings.user.max_projects} projects",
-                owner=data.owner,
+                owner=owner,
                 num_projects=result,
             )
 
@@ -95,7 +96,7 @@ class MongoDbProjectRepository(MongoDbRepository[Project, ProjectIn, ProjectOut,
 
     async def insert_project(self, project: ProjectIn) -> Project:
         """Insert a new project, rejecting a duplicate id. See ``insert_one``."""
-        await self._check_num_projects(project)
+        await self._check_num_projects(project.owner)
         return await self.insert_one(project)
 
     async def patch_project_by_id(self, id: str, update: ProjectPatch) -> Project:
@@ -133,17 +134,18 @@ class MongoDbProjectRepository(MongoDbRepository[Project, ProjectIn, ProjectOut,
         if self._user.username is None:
             raise PermissionError(required_role="authenticated")
 
-        await self._check_num_projects(data)
-
         existing = await self.document_model.find_one(self.document_model.id == id)
         project = self.document_model.from_input_model(data)
         project.id = id
         if existing is not None:
             if not (self._user.is_admin or existing.owner == self._user.username):
                 raise PermissionError(required_role="owner-or-admin")
-            # Ownership is immutable via upsert; keep the original owner.
+            # Ownership is immutable via upsert; keep the original owner. Updating an existing
+            # project does not create a new one, so the per-user project cap does not apply.
             project.owner = existing.owner
         else:
-            # New project: the caller owns it, regardless of the submitted owner.
+            # New project: the caller owns it, regardless of the submitted owner. Enforce the
+            # per-user cap against the caller before creating another project under their name.
             project.owner = self._user.username
+            await self._check_num_projects(self._user.username)
         return await project.save()

--- a/mpcontribs-api/src/mpcontribs_api/domains/projects/repository.py
+++ b/mpcontribs-api/src/mpcontribs_api/domains/projects/repository.py
@@ -1,14 +1,15 @@
 from typing import Any
 
 from mpcontribs_api.authz import User
-from mpcontribs_api.config import get_settings
 from mpcontribs_api.domains._shared.repository import MongoDbRepository
+from mpcontribs_api.domains.consumers.models import ConsumerSettings
 from mpcontribs_api.domains.projects.models import (
     Project,
     ProjectFilter,
     ProjectIn,
     ProjectOut,
     ProjectPatch,
+    check_column_limit,
 )
 from mpcontribs_api.exceptions import PermissionError
 from mpcontribs_api.pagination import CursorParams
@@ -30,9 +31,10 @@ class MongoDbProjectRepository(MongoDbRepository[Project, ProjectIn, ProjectOut,
     document_model = Project
     out_model = ProjectOut
 
-    def __init__(self, user: User) -> None:
+    def __init__(self, user: User, limits: ConsumerSettings | None = None) -> None:
         super().__init__(user)
         self._user = user
+        self._limits = limits or ConsumerSettings()
 
     @staticmethod
     def _build_scope(user: User) -> dict[str, Any]:
@@ -48,13 +50,13 @@ class MongoDbProjectRepository(MongoDbRepository[Project, ProjectIn, ProjectOut,
 
     async def _check_num_projects(self, owner: str):
         """Reject a *new* project that would push ``owner`` past the per-user cap."""
-        settings = get_settings()
+        max_projects = self._limits.max_projects
         # Soft limit: this count-then-insert is not atomic, so concurrent creates by the same owner
         # can overshoot the cap by a bounded amount. Acceptable for an anti-abuse quota.
         result = await Project.find(Project.owner == owner).count()
-        if result >= settings.user.max_projects:
+        if result >= max_projects:
             raise PermissionError(
-                f"Cannot be owner of more than {settings.user.max_projects} projects",
+                f"Cannot be owner of more than {max_projects} projects",
                 owner=owner,
                 num_projects=result,
             )
@@ -98,11 +100,16 @@ class MongoDbProjectRepository(MongoDbRepository[Project, ProjectIn, ProjectOut,
 
     async def insert_project(self, project: ProjectIn) -> Project:
         """Insert a new project, rejecting a duplicate id. See ``insert_one``."""
+        check_column_limit(project.columns, self._limits.max_columns)
         await self._check_num_projects(project.owner)
         return await self.insert_one(project)
 
     async def patch_project_by_id(self, id: str, update: ProjectPatch) -> Project:
         """Partially update a project by id, scoped to the current user. See ``patch``."""
+        # Only enforce the column cap when the caller actually sends columns; an unset field is a
+        # no-op and must not be checked against its empty default.
+        if "columns" in update.model_fields_set:
+            check_column_limit(update.columns, self._limits.max_columns)
         return await self.patch(id, update)
 
     async def delete_project_by_id(self, id: str) -> None:
@@ -136,6 +143,7 @@ class MongoDbProjectRepository(MongoDbRepository[Project, ProjectIn, ProjectOut,
         if self._user.username is None:
             raise PermissionError(required_role="authenticated")
 
+        check_column_limit(data.columns, self._limits.max_columns)
         existing = await self.document_model.find_one(self.document_model.id == id)
         project = self.document_model.from_input_model(data)
         project.id = id

--- a/mpcontribs-api/src/mpcontribs_api/domains/projects/repository.py
+++ b/mpcontribs-api/src/mpcontribs_api/domains/projects/repository.py
@@ -9,7 +9,7 @@ from mpcontribs_api.domains.projects.models import (
     ProjectIn,
     ProjectOut,
     ProjectPatch,
-    check_column_limit,
+    validate_column_limit,
 )
 from mpcontribs_api.exceptions import PermissionError
 from mpcontribs_api.pagination import CursorParams
@@ -100,7 +100,7 @@ class MongoDbProjectRepository(MongoDbRepository[Project, ProjectIn, ProjectOut,
 
     async def insert_project(self, project: ProjectIn) -> Project:
         """Insert a new project, rejecting a duplicate id. See ``insert_one``."""
-        check_column_limit(project.columns, self._limits.max_columns)
+        validate_column_limit(project.columns, self._limits.max_columns)
         await self._check_num_projects(project.owner)
         return await self.insert_one(project)
 
@@ -109,7 +109,7 @@ class MongoDbProjectRepository(MongoDbRepository[Project, ProjectIn, ProjectOut,
         # Only enforce the column cap when the caller actually sends columns; an unset field is a
         # no-op and must not be checked against its empty default.
         if "columns" in update.model_fields_set:
-            check_column_limit(update.columns, self._limits.max_columns)
+            validate_column_limit(update.columns, self._limits.max_columns)
         return await self.patch(id, update)
 
     async def delete_project_by_id(self, id: str) -> None:
@@ -143,7 +143,7 @@ class MongoDbProjectRepository(MongoDbRepository[Project, ProjectIn, ProjectOut,
         if self._user.username is None:
             raise PermissionError(required_role="authenticated")
 
-        check_column_limit(data.columns, self._limits.max_columns)
+        validate_column_limit(data.columns, self._limits.max_columns)
         existing = await self.document_model.find_one(self.document_model.id == id)
         project = self.document_model.from_input_model(data)
         project.id = id

--- a/mpcontribs-api/src/mpcontribs_api/exceptions.py
+++ b/mpcontribs-api/src/mpcontribs_api/exceptions.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import logging
 from collections.abc import Sequence
 from typing import Any

--- a/mpcontribs-api/src/mpcontribs_api/exceptions.py
+++ b/mpcontribs-api/src/mpcontribs_api/exceptions.py
@@ -91,6 +91,7 @@ class DownloadError(AppError):
     error_code = "download_error"
     log_level = logging.WARNING
 
+
 def error_body(error_code: str, message: str, **public_context) -> dict:
     body: dict[str, Any] = {"error": {"code": error_code, "message": message}}
     if public_context:

--- a/mpcontribs-api/src/mpcontribs_api/projection.py
+++ b/mpcontribs-api/src/mpcontribs_api/projection.py
@@ -5,8 +5,6 @@ Ie. data.band_gap.something will be properly retrieved and populated into the re
     SparseFieldsModel
 """
 
-from __future__ import annotations
-
 from collections.abc import Iterator
 from functools import lru_cache
 from typing import (

--- a/mpcontribs-api/tests/integration/conftest.py
+++ b/mpcontribs-api/tests/integration/conftest.py
@@ -9,7 +9,7 @@ from mpcontribs_api.exceptions import register_exception_handlers
 from mpcontribs_api.middleware import RequestContextMiddleware
 
 
-@pytest.fixture(autouse=True, scope="session")
+@pytest.fixture(autouse=True)
 def _mock_beanie_collection():
     """Stub Beanie's collection check for mock-based integration tests.
 
@@ -19,6 +19,11 @@ def _mock_beanie_collection():
 
     The tests/integration/db/ conftest overrides this fixture with a no-op so
     DB tests still get the real Beanie collection after init_beanie().
+
+    Function-scoped (not session): the patch must be torn down after each mock-based test so it
+    can never leak into the real-DB tests that share this process. A session-scoped patch, once
+    entered by any route test, stayed active and silently turned the DB tests' collections into
+    MagicMocks — making their inserts vanish depending on collection order.
     """
     import beanie
 

--- a/mpcontribs-api/tests/integration/conftest.py
+++ b/mpcontribs-api/tests/integration/conftest.py
@@ -96,6 +96,14 @@ def test_app() -> FastAPI:
 @pytest.fixture
 def client(test_app: FastAPI):
     """Function-scoped client; dependency overrides are cleared after each test."""
+    from mpcontribs_api.domains.consumers.dependencies import get_effective_limits
+    from mpcontribs_api.domains.consumers.models import ConsumerSettings
+
+    # Mock-based integration tests run without a database. Resolving per-consumer limits normally
+    # awaits the (mocked) consumers collection, which would 500 the request before it reaches the
+    # code under test. Default the dependency to the global-default limits; tests that specifically
+    # assert override behavior can install their own override.
+    test_app.dependency_overrides[get_effective_limits] = lambda: ConsumerSettings()
     with TestClient(test_app, raise_server_exceptions=False) as c:
         yield c
     test_app.dependency_overrides.clear()

--- a/mpcontribs-api/tests/integration/db/conftest.py
+++ b/mpcontribs-api/tests/integration/db/conftest.py
@@ -21,13 +21,16 @@ pytestmark = [
 ]
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(autouse=True)
 def _mock_beanie_collection():
     """Override the parent integration conftest's Beanie mock.
 
     DB tests initialise Beanie for real via init_beanie(), so the mock must not
     intercept get_pymongo_collection().  Defining this fixture here (same name,
     no patch) causes pytest to use this no-op instead of the parent's version.
+
+    Autouse + function-scoped so it deterministically shadows the parent patch for every DB test,
+    regardless of the order route tests and DB tests are collected in.
     """
     yield
 

--- a/mpcontribs-api/tests/integration/db/conftest.py
+++ b/mpcontribs-api/tests/integration/db/conftest.py
@@ -5,6 +5,7 @@ from pymongo import AsyncMongoClient
 
 from mpcontribs_api.config import get_settings
 from mpcontribs_api.domains.attachments.models import Attachment
+from mpcontribs_api.domains.consumers.models import Consumer
 from mpcontribs_api.domains.contributions.models import Contribution
 from mpcontribs_api.domains.projects.models import Project
 from mpcontribs_api.domains.structures.models import Structure
@@ -66,7 +67,7 @@ async def db(mongo_client):
     database = mongo_client[settings.mongo.db_name]
     await init_beanie(
         database=database,
-        document_models=[Project, Contribution, Structure, Table, Attachment],
+        document_models=[Project, Contribution, Structure, Table, Attachment, Consumer],
     )
     yield database
 
@@ -97,3 +98,10 @@ async def clean_components(db):
     yield
     for collection in ("structures", "tables", "attachments"):
         await db[collection].delete_many({})
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def clean_consumers(db):
+    await db["mp_consumers"].delete_many({})
+    yield
+    await db["mp_consumers"].delete_many({})

--- a/mpcontribs-api/tests/integration/db/test_consumers_repository.py
+++ b/mpcontribs-api/tests/integration/db/test_consumers_repository.py
@@ -1,0 +1,153 @@
+import pytest
+
+from mpcontribs_api.authz import User
+from mpcontribs_api.config import get_settings
+from mpcontribs_api.domains.consumers.dependencies import get_effective_limits
+from mpcontribs_api.domains.consumers.models import (
+    Consumer,
+    ConsumerIn,
+    ConsumerPatch,
+    ConsumerSettings,
+)
+from mpcontribs_api.domains.consumers.repository import MongoDbConsumerRepository
+from mpcontribs_api.exceptions import ConflictError, NotFoundError
+
+# Same loop-scope contract as the other db suites (see test_projects_repository).
+pytestmark = [pytest.mark.db, pytest.mark.asyncio(loop_scope="session")]
+
+
+ADMIN = User(username="google:admin@example.com", groups=frozenset({"admin"}))
+
+
+def _repo() -> MongoDbConsumerRepository:
+    # Consumer management is admin-only and unscoped, so the acting user is immaterial here.
+    return MongoDbConsumerRepository(ADMIN)
+
+
+# ---------------------------------------------------------------------------
+# insert_consumer / get_by_consumer_id
+# ---------------------------------------------------------------------------
+
+
+class TestInsertAndLookup:
+    async def test_insert_then_lookup_by_consumer_id(self, db):
+        await _repo().insert_consumer(ConsumerIn(consumer_id="kong-1"))
+        found = await _repo().get_by_consumer_id("kong-1")
+        assert found is not None
+        assert found.consumer_id == "kong-1"
+
+    async def test_duplicate_consumer_id_raises_conflict(self, db):
+        await _repo().insert_consumer(ConsumerIn(consumer_id="kong-dup"))
+        with pytest.raises(ConflictError):
+            await _repo().insert_consumer(ConsumerIn(consumer_id="kong-dup"))
+
+    async def test_lookup_missing_returns_none(self, db):
+        assert await _repo().get_by_consumer_id("kong-absent") is None
+
+    async def test_partial_override_snapshots_defaults_for_siblings(self, db):
+        # Admin overrides only max_projects; the stored document must carry a fully-resolved
+        # settings block, with untouched limits snapshotted from the global defaults.
+        await _repo().insert_consumer(
+            ConsumerIn(consumer_id="kong-partial", settings=ConsumerSettings(max_projects=1))
+        )
+        stored = await _repo().get_by_consumer_id("kong-partial")
+        assert stored is not None
+        assert stored.settings.max_projects == 1
+        assert stored.settings.max_columns == get_settings().consumer.max_columns
+
+
+# ---------------------------------------------------------------------------
+# get_consumer_by_id (document id)
+# ---------------------------------------------------------------------------
+
+
+class TestGetByDocumentId:
+    async def test_returns_out_model(self, db):
+        created = await _repo().insert_consumer(ConsumerIn(consumer_id="kong-doc"))
+        result = await _repo().get_consumer_by_id(id=str(created.id), fields=None)
+        assert result is not None
+        assert result.consumer_id == "kong-doc"
+
+    async def test_missing_returns_none(self, db):
+        from beanie import PydanticObjectId
+
+        result = await _repo().get_consumer_by_id(id=str(PydanticObjectId()), fields=None)
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# patch_consumer_by_id — partial, sibling-preserving
+# ---------------------------------------------------------------------------
+
+
+class TestPatchConsumer:
+    async def test_patch_changes_only_named_limit(self, db):
+        created = await _repo().insert_consumer(ConsumerIn(consumer_id="kong-patch"))
+        original_columns = created.settings.max_columns
+
+        updated = await _repo().patch_consumer_by_id(
+            id=str(created.id),
+            update=ConsumerPatch(settings=ConsumerSettings(max_projects=1)),
+        )
+        assert updated.settings.max_projects == 1
+        # Sibling limit untouched: a nested-key $set, not a whole-subdocument replace.
+        assert updated.settings.max_columns == original_columns
+
+    async def test_empty_patch_returns_existing_unchanged(self, db):
+        created = await _repo().insert_consumer(ConsumerIn(consumer_id="kong-noop"))
+        result = await _repo().patch_consumer_by_id(id=str(created.id), update=ConsumerPatch())
+        assert result.consumer_id == "kong-noop"
+        assert result.settings.max_projects == created.settings.max_projects
+
+    async def test_patch_missing_raises_not_found(self, db):
+        from beanie import PydanticObjectId
+
+        with pytest.raises(NotFoundError):
+            await _repo().patch_consumer_by_id(
+                id=str(PydanticObjectId()),
+                update=ConsumerPatch(settings=ConsumerSettings(max_projects=1)),
+            )
+
+
+# ---------------------------------------------------------------------------
+# delete_consumer_by_id
+# ---------------------------------------------------------------------------
+
+
+class TestDeleteConsumer:
+    async def test_delete_removes_override(self, db):
+        created = await _repo().insert_consumer(ConsumerIn(consumer_id="kong-del"))
+        await _repo().delete_consumer_by_id(id=str(created.id))
+        assert await _repo().get_by_consumer_id("kong-del") is None
+
+    async def test_delete_missing_raises_not_found(self, db):
+        from beanie import PydanticObjectId
+
+        with pytest.raises(NotFoundError):
+            await _repo().delete_consumer_by_id(id=str(PydanticObjectId()))
+
+
+# ---------------------------------------------------------------------------
+# get_effective_limits — the resolution actually consumed by the write paths
+# ---------------------------------------------------------------------------
+
+
+class TestEffectiveLimits:
+    async def test_no_consumer_id_returns_defaults_without_lookup(self, db):
+        # A caller with no Kong consumer_id (anonymous/dev) never touches the override collection.
+        user = User(username="google:alice@example.com", groups=frozenset())
+        limits = await get_effective_limits(user)
+        assert limits.max_projects == get_settings().consumer.max_projects
+
+    async def test_stored_override_is_returned(self, db):
+        await _repo().insert_consumer(
+            ConsumerIn(consumer_id="kong-eff", settings=ConsumerSettings(max_projects=42))
+        )
+        user = User(consumer_id="kong-eff", username="google:alice@example.com", groups=frozenset())
+        limits = await get_effective_limits(user)
+        assert limits.max_projects == 42
+
+    async def test_consumer_id_without_override_falls_back_to_defaults(self, db):
+        user = User(consumer_id="kong-unknown", username="google:alice@example.com", groups=frozenset())
+        limits = await get_effective_limits(user)
+        assert limits.max_projects == get_settings().consumer.max_projects

--- a/mpcontribs-api/tests/integration/db/test_projects_repository.py
+++ b/mpcontribs-api/tests/integration/db/test_projects_repository.py
@@ -387,3 +387,54 @@ class TestUpsertProjectAuthorization:
         await _repo(ALICE).upsert_project_by_id(id="auth-preserve", data=data)
         found = await Project.find_one(Project.id == "auth-preserve")
         assert found.owner == "google:alice@example.com"
+
+
+# ---------------------------------------------------------------------------
+# Per-user project-count quota (max_projects)
+# ---------------------------------------------------------------------------
+
+
+ALICE_EMAIL = "google:alice@example.com"
+
+
+class TestProjectCountQuota:
+    async def test_insert_can_reach_exactly_cap(self, db, monkeypatch):
+        # The cap is inclusive: a user may own up to (not fewer than) max_projects.
+        from mpcontribs_api.config import get_settings
+
+        monkeypatch.setattr(get_settings().user, "max_projects", 2)
+        await _insert("cap-1", owner=ALICE_EMAIL)
+        await _insert("cap-2", owner=ALICE_EMAIL)
+        assert await Project.find(Project.owner == ALICE_EMAIL).count() == 2
+
+    async def test_insert_over_cap_rejected(self, db, monkeypatch):
+        from mpcontribs_api.config import get_settings
+        from mpcontribs_api.exceptions import PermissionError as AppPermissionError
+
+        monkeypatch.setattr(get_settings().user, "max_projects", 2)
+        await _insert("cap-a", owner=ALICE_EMAIL)
+        await _insert("cap-b", owner=ALICE_EMAIL)
+        with pytest.raises(AppPermissionError):
+            await _insert("cap-c", owner=ALICE_EMAIL)
+
+    async def test_upsert_new_project_over_cap_rejected(self, db, monkeypatch):
+        # A brand-new project via upsert is counted against the caller's cap.
+        from mpcontribs_api.config import get_settings
+        from mpcontribs_api.exceptions import PermissionError as AppPermissionError
+
+        monkeypatch.setattr(get_settings().user, "max_projects", 1)
+        await _insert("owned-1", owner=ALICE_EMAIL)
+        data = _project_in("new-proj", owner=ALICE_EMAIL)
+        with pytest.raises(AppPermissionError):
+            await _repo(ALICE).upsert_project_by_id(id="new-proj", data=data)
+
+    async def test_upsert_existing_project_allowed_at_cap(self, db, monkeypatch):
+        # Regression: updating a project you already own must never be blocked by the cap, even
+        # when you are exactly at it. Only *new* projects count against the quota.
+        from mpcontribs_api.config import get_settings
+
+        monkeypatch.setattr(get_settings().user, "max_projects", 1)
+        await _insert("owned-only", owner=ALICE_EMAIL)
+        data = _project_in("owned-only", owner=ALICE_EMAIL, title="Updated Title")
+        result = await _repo(ALICE).upsert_project_by_id(id="owned-only", data=data)
+        assert result.title == "Updated Title"

--- a/mpcontribs-api/tests/integration/db/test_projects_repository.py
+++ b/mpcontribs-api/tests/integration/db/test_projects_repository.py
@@ -1,9 +1,10 @@
 import pytest
 
 from mpcontribs_api.authz import User
+from mpcontribs_api.domains.consumers.models import ConsumerSettings
 from mpcontribs_api.domains.projects.models import Project, ProjectIn, ProjectOut, ProjectPatch, Stats
 from mpcontribs_api.domains.projects.repository import MongoDbProjectRepository
-from mpcontribs_api.exceptions import ConflictError, NotFoundError
+from mpcontribs_api.exceptions import ConflictError, NotFoundError, ValidationError
 from mpcontribs_api.pagination import CursorParams
 
 # All tests in this module share the session event loop so they can reuse the
@@ -23,8 +24,13 @@ ALICE = User(username="google:alice@example.com", groups=frozenset({"mp-team"}))
 ANON = User()
 
 
-def _repo(user: User) -> MongoDbProjectRepository:
-    return MongoDbProjectRepository(user)
+def _repo(user: User, limits: ConsumerSettings | None = None) -> MongoDbProjectRepository:
+    return MongoDbProjectRepository(user, limits)
+
+
+def _cols(n: int) -> list[dict[str, str]]:
+    """n column definitions (coerced into Column by ProjectIn/ProjectPatch)."""
+    return [{"path": f"data.col_{i}"} for i in range(n)]
 
 
 def _project_in(id: str, **overrides) -> ProjectIn:
@@ -219,26 +225,28 @@ class TestFieldProjection:
 
 class TestPagination:
     async def test_limit_is_respected(self, db):
+        # Distinct owners: pagination is orthogonal to the per-owner project cap, so keep every
+        # project under its own owner rather than tripping max_projects.
         for i in range(5):
-            await _insert(f"pag-limit-{i:02d}", is_public=True, is_approved=True)
+            await _insert(f"pag-limit-{i:02d}", owner=f"google:pager{i}@example.com", is_public=True, is_approved=True)
         page = await _repo(ADMIN).get_projects(filter=_noop_filter(), pagination=CursorParams(limit=3), fields=None)
         assert len(page.items) == 3
 
     async def test_next_cursor_set_when_more_items(self, db):
         for i in range(4):
-            await _insert(f"pag-cursor-{i:02d}", is_public=True, is_approved=True)
+            await _insert(f"pag-cursor-{i:02d}", owner=f"google:pager{i}@example.com", is_public=True, is_approved=True)
         page = await _repo(ADMIN).get_projects(filter=_noop_filter(), pagination=CursorParams(limit=2), fields=None)
         assert page.next_cursor is not None
 
     async def test_next_cursor_none_on_last_page(self, db):
         for i in range(3):
-            await _insert(f"pag-last-{i:02d}", is_public=True, is_approved=True)
+            await _insert(f"pag-last-{i:02d}", owner=f"google:pager{i}@example.com", is_public=True, is_approved=True)
         page = await _repo(ADMIN).get_projects(filter=_noop_filter(), pagination=CursorParams(limit=10), fields=None)
         assert page.next_cursor is None
 
     async def test_cursor_fetches_next_page(self, db):
         for i in range(4):
-            await _insert(f"pag-next-{i:02d}", is_public=True, is_approved=True)
+            await _insert(f"pag-next-{i:02d}", owner=f"google:pager{i}@example.com", is_public=True, is_approved=True)
         page1 = await _repo(ADMIN).get_projects(filter=_noop_filter(), pagination=CursorParams(limit=2), fields=None)
         assert page1.next_cursor is not None
         page2 = await _repo(ADMIN).get_projects(
@@ -250,7 +258,7 @@ class TestPagination:
 
     async def test_all_items_covered_across_pages(self, db):
         for i in range(5):
-            await _insert(f"pag-all-{i:02d}", is_public=True, is_approved=True)
+            await _insert(f"pag-all-{i:02d}", owner=f"google:pager{i}@example.com", is_public=True, is_approved=True)
         all_ids: set[str] = set()
         cursor = None
         while True:
@@ -402,7 +410,7 @@ class TestProjectCountQuota:
         # The cap is inclusive: a user may own up to (not fewer than) max_projects.
         from mpcontribs_api.config import get_settings
 
-        monkeypatch.setattr(get_settings().user, "max_projects", 2)
+        monkeypatch.setattr(get_settings().consumer, "max_projects", 2)
         await _insert("cap-1", owner=ALICE_EMAIL)
         await _insert("cap-2", owner=ALICE_EMAIL)
         assert await Project.find(Project.owner == ALICE_EMAIL).count() == 2
@@ -411,7 +419,7 @@ class TestProjectCountQuota:
         from mpcontribs_api.config import get_settings
         from mpcontribs_api.exceptions import PermissionError as AppPermissionError
 
-        monkeypatch.setattr(get_settings().user, "max_projects", 2)
+        monkeypatch.setattr(get_settings().consumer, "max_projects", 2)
         await _insert("cap-a", owner=ALICE_EMAIL)
         await _insert("cap-b", owner=ALICE_EMAIL)
         with pytest.raises(AppPermissionError):
@@ -422,7 +430,7 @@ class TestProjectCountQuota:
         from mpcontribs_api.config import get_settings
         from mpcontribs_api.exceptions import PermissionError as AppPermissionError
 
-        monkeypatch.setattr(get_settings().user, "max_projects", 1)
+        monkeypatch.setattr(get_settings().consumer, "max_projects", 1)
         await _insert("owned-1", owner=ALICE_EMAIL)
         data = _project_in("new-proj", owner=ALICE_EMAIL)
         with pytest.raises(AppPermissionError):
@@ -433,8 +441,64 @@ class TestProjectCountQuota:
         # when you are exactly at it. Only *new* projects count against the quota.
         from mpcontribs_api.config import get_settings
 
-        monkeypatch.setattr(get_settings().user, "max_projects", 1)
+        monkeypatch.setattr(get_settings().consumer, "max_projects", 1)
         await _insert("owned-only", owner=ALICE_EMAIL)
         data = _project_in("owned-only", owner=ALICE_EMAIL, title="Updated Title")
         result = await _repo(ALICE).upsert_project_by_id(id="owned-only", data=data)
         assert result.title == "Updated Title"
+
+    async def test_injected_consumer_override_lowers_cap(self, db):
+        # A per-consumer override resolves to a ConsumerSettings injected into the repo; the cap it
+        # carries is enforced without touching global config. Here the override tightens the cap to 1.
+        repo = _repo(ALICE, ConsumerSettings(max_projects=1))
+        await repo.insert_project(_project_in("override-1", owner=ALICE_EMAIL))
+        from mpcontribs_api.exceptions import PermissionError as AppPermissionError
+
+        with pytest.raises(AppPermissionError):
+            await repo.insert_project(_project_in("override-2", owner=ALICE_EMAIL))
+
+
+# ---------------------------------------------------------------------------
+# Per-project column-count quota (max_columns) — repository enforcement
+#
+# The cap moved off the ProjectIn/ProjectPatch models onto the repository, which checks each write
+# against the caller's effective ``max_columns``. These tests drive that limit via an injected
+# ``ConsumerSettings`` — the same object a per-consumer override resolves to in production.
+# ---------------------------------------------------------------------------
+
+
+class TestColumnLimitEnforcement:
+    async def test_insert_at_cap_allowed(self, db):
+        # Inclusive cap: exactly max_columns is accepted.
+        repo = _repo(ADMIN, ConsumerSettings(max_columns=2))
+        await repo.insert_project(_project_in("cols-ok", columns=_cols(2)))
+        found = await Project.find_one(Project.id == "cols-ok")
+        assert found is not None
+        assert len(found.columns) == 2
+
+    async def test_insert_over_cap_rejected(self, db):
+        repo = _repo(ADMIN, ConsumerSettings(max_columns=2))
+        with pytest.raises(ValidationError):
+            await repo.insert_project(_project_in("cols-over", columns=_cols(3)))
+        assert await Project.find_one(Project.id == "cols-over") is None
+
+    async def test_patch_over_cap_rejected(self, db):
+        await _insert("cols-patch")  # created under the generous default cap
+        repo = _repo(ADMIN, ConsumerSettings(max_columns=2))
+        with pytest.raises(ValidationError):
+            await repo.patch_project_by_id("cols-patch", ProjectPatch(columns=_cols(3)))
+
+    async def test_patch_without_columns_not_checked(self, db):
+        # A columns-less patch (e.g. a title edit) must not be measured against the cap, even when
+        # the stored document already carries more columns than the current cap allows.
+        await _insert("cols-title", columns=_cols(5))
+        repo = _repo(ADMIN, ConsumerSettings(max_columns=2))
+        result = await repo.patch_project_by_id("cols-title", ProjectPatch(title="New Title"))
+        assert result.title == "New Title"
+
+    async def test_upsert_over_cap_rejected(self, db):
+        repo = _repo(ALICE, ConsumerSettings(max_columns=2))
+        data = _project_in("cols-upsert", owner=ALICE_EMAIL, columns=_cols(3))
+        with pytest.raises(ValidationError):
+            await repo.upsert_project_by_id("cols-upsert", data)
+        assert await Project.find_one(Project.id == "cols-upsert") is None

--- a/mpcontribs-api/tests/integration/test_contributions_routes.py
+++ b/mpcontribs-api/tests/integration/test_contributions_routes.py
@@ -145,8 +145,8 @@ class TestContributionByIdRouting:
         r = client.patch(f"/api/v1/contributions/{PydanticObjectId()}", json={"formula": "H2O"})
         assert r.status_code == 200
 
-    def test_put_by_id_conventional_path(self, client, contribution_repo):
-        contribution_repo.upsert_contribution_by_id.return_value = SAMPLE_OUT
+    def test_put_by_id_conventional_path(self, client, contribution_service):
+        contribution_service.upsert_contribution_by_id.return_value = SAMPLE_OUT
         r = client.put(f"/api/v1/contributions/{PydanticObjectId()}", json=_valid_contribution_body())
         assert r.status_code == 200
 
@@ -278,14 +278,14 @@ class TestContributionMutationsRequireAuth:
         r = client.delete(f"/api/v1/contributions/{PydanticObjectId()}", headers=FORCE_ANON_HEADERS)
         assert r.status_code == 401
 
-    def test_put_by_id_anon_401(self, client, contribution_repo):
+    def test_put_by_id_anon_401(self, client, contribution_service):
         r = client.put(
             f"/api/v1/contributions/{PydanticObjectId()}",
             json=_valid_contribution_body(),
             headers=FORCE_ANON_HEADERS,
         )
         assert r.status_code == 401
-        contribution_repo.upsert_contribution_by_id.assert_not_called()
+        contribution_service.upsert_contribution_by_id.assert_not_called()
 
     def test_patch_by_id_anon_401(self, client, contribution_repo):
         r = client.patch(

--- a/mpcontribs-api/tests/unit/domains/test_consumers_models.py
+++ b/mpcontribs-api/tests/unit/domains/test_consumers_models.py
@@ -1,0 +1,73 @@
+import pytest
+
+from mpcontribs_api.config import get_settings
+from mpcontribs_api.domains.consumers.models import (
+    Consumer,
+    ConsumerIn,
+    ConsumerSettings,
+)
+
+# ---------------------------------------------------------------------------
+# ConsumerSettings — the effective, fully-resolved limits.
+#
+# Every field defaults from the env-backed global ``config.consumer`` block, so an admin can supply
+# only the fields they want to change and the rest inherit the global default. This is the mechanism
+# behind per-consumer overrides, so its resolution rules are worth pinning.
+# ---------------------------------------------------------------------------
+
+
+class TestConsumerSettingsDefaults:
+    def test_unset_fields_fall_back_to_global_defaults(self):
+        settings = ConsumerSettings()
+        globals_ = get_settings().consumer
+        assert settings.max_projects == globals_.max_projects
+        assert settings.max_unapproved_contributions_per_project == globals_.max_unapproved_contributions_per_project
+        assert settings.max_columns == globals_.max_columns
+
+    def test_partial_override_keeps_other_defaults(self):
+        # Overriding one limit must not disturb the siblings — they still resolve to the global.
+        settings = ConsumerSettings(max_projects=99)
+        assert settings.max_projects == 99
+        assert settings.max_columns == get_settings().consumer.max_columns
+
+    def test_only_explicit_field_is_marked_set(self):
+        # patch_consumer_by_id relies on exclude_unset to touch only the named limit, so a partial
+        # override must report exactly the fields the admin supplied.
+        settings = ConsumerSettings(max_columns=5)
+        assert settings.model_dump(exclude_unset=True) == {"max_columns": 5}
+
+    def test_defaults_track_global_config(self, monkeypatch):
+        # A ConsumerSettings built after the global default changes must reflect the new value —
+        # the fallback is read at construction time, not import time.
+        monkeypatch.setattr(get_settings().consumer, "max_projects", 42)
+        assert ConsumerSettings().max_projects == 42
+
+    def test_negative_limit_rejected(self):
+        # Limits are counts; ``ge=0`` guards against a nonsensical negative override.
+        with pytest.raises(ValueError):
+            ConsumerSettings(max_projects=-1)
+
+
+# ---------------------------------------------------------------------------
+# Consumer document construction
+# ---------------------------------------------------------------------------
+
+
+class TestConsumerConstruction:
+    def test_with_defaults_snapshots_global_limits(self):
+        consumer = Consumer.with_defaults("kong-123")
+        assert consumer.consumer_id == "kong-123"
+        assert consumer.settings.max_projects == get_settings().consumer.max_projects
+
+    def test_from_input_model_fills_defaults_when_settings_omitted(self):
+        # An admin who supplies no settings gets a fully-resolved snapshot of the global defaults.
+        consumer = Consumer.from_input_model(ConsumerIn(consumer_id="kong-x"))
+        assert consumer.consumer_id == "kong-x"
+        assert consumer.settings.max_columns == get_settings().consumer.max_columns
+
+    def test_from_input_model_preserves_supplied_override(self):
+        payload = ConsumerIn(consumer_id="kong-y", settings=ConsumerSettings(max_projects=7))
+        consumer = Consumer.from_input_model(payload)
+        assert consumer.settings.max_projects == 7
+        # Server mints its own id regardless of input.
+        assert consumer.id is not None

--- a/mpcontribs-api/tests/unit/domains/test_contribution_service.py
+++ b/mpcontribs-api/tests/unit/domains/test_contribution_service.py
@@ -1063,6 +1063,63 @@ class TestWriteAuthorization:
         assert [f.error_code for f in summary.failed] == ["permission_denied"]
         contrib_repo.upsert_contribution_by_identifiers.assert_not_called()
 
+    async def test_upsert_by_id_rejects_unauthorized_project(self):
+        # A member of "allowed" cannot write "forbidden" through the by-id endpoint. The check runs
+        # before any DB access, so neither the existence read nor the write is attempted — closing
+        # the gap where the upsert's unscoped insert branch would create the contribution anyway.
+        svc, contrib_repo, *_ = _make_service(user=_member_user("allowed"))
+
+        with pytest.raises(PermissionError, match="forbidden"):
+            await svc.upsert_contribution_by_id("someid", _contrib_in(project="forbidden"))
+
+        contrib_repo.get_contribution_by_id.assert_not_called()
+        contrib_repo.upsert_contribution_by_id.assert_not_called()
+
+    async def test_upsert_by_id_unauthorized_cannot_overwrite_public_contribution(self):
+        # Defense against overwriting a project's public contribution you don't own: even though the
+        # repository read scope would admit a public row, authorization is enforced up front.
+        svc, contrib_repo, *_ = _make_service(user=_member_user("allowed"))
+        # An existing (readable) contribution must not lower the bar — authz still rejects the write.
+        contrib_repo.get_contribution_by_id.return_value = MagicMock(spec=Contribution)
+
+        with pytest.raises(PermissionError, match="forbidden"):
+            await svc.upsert_contribution_by_id("someid", _contrib_in(project="forbidden"))
+
+        contrib_repo.upsert_contribution_by_id.assert_not_called()
+
+    async def test_upsert_by_id_anonymous_authorized_for_nothing(self):
+        svc, contrib_repo, *_ = _make_service(user=User())  # anonymous: no username, no groups
+
+        with pytest.raises(PermissionError):
+            await svc.upsert_contribution_by_id("someid", _contrib_in(project="any"))
+
+        contrib_repo.get_contribution_by_id.assert_not_called()
+        contrib_repo.upsert_contribution_by_id.assert_not_called()
+
+    async def test_upsert_by_id_authorized_member_proceeds(self):
+        # A member writing to their own project passes authorization; updating an existing row is
+        # not gated by the quota, so the write goes through.
+        contrib_repo = AsyncMock()
+        contrib_repo.get_contribution_by_id.return_value = MagicMock(spec=Contribution)  # exists -> update
+        contrib_repo.upsert_contribution_by_id.return_value = MagicMock(spec=Contribution)
+        svc, *_ = _make_service(
+            contributions=contrib_repo, projects=_unapproved_projects_repo(), user=_member_user("allowed")
+        )
+
+        await svc.upsert_contribution_by_id("someid", _contrib_in(project="allowed"))
+
+        contrib_repo.upsert_contribution_by_id.assert_called_once()
+
+    async def test_upsert_by_id_admin_bypasses_authorization(self):
+        contrib_repo = AsyncMock()
+        contrib_repo.get_contribution_by_id.return_value = MagicMock(spec=Contribution)
+        contrib_repo.upsert_contribution_by_id.return_value = MagicMock(spec=Contribution)
+        svc, *_ = _make_service(contributions=contrib_repo, projects=_approved_projects_repo())  # admin default
+
+        await svc.upsert_contribution_by_id("someid", _contrib_in(project="anything"))
+
+        contrib_repo.upsert_contribution_by_id.assert_called_once()
+
 
 # ---------------------------------------------------------------------------
 # Process-wide write_slots semaphore is honored

--- a/mpcontribs-api/tests/unit/domains/test_contribution_service.py
+++ b/mpcontribs-api/tests/unit/domains/test_contribution_service.py
@@ -148,6 +148,7 @@ def _make_service(
     tables=None,
     attachments=None,
     client=None,
+    projects=None,
     settings: MongoSettings | None = None,
     write_slots: asyncio.Semaphore | None = None,
     user: User | None = None,
@@ -179,6 +180,20 @@ def _make_service(
         settings=settings or _make_mongo_settings(),
     )
     return svc, contrib_repo, struct_repo, table_repo, attach_repo, client
+
+
+def _approved_projects_repo() -> AsyncMock:
+    """A projects repo whose every project reads as approved (quota does not apply)."""
+    repo = AsyncMock()
+    repo.get_by_id = AsyncMock(return_value=MagicMock(is_approved=True))
+    return repo
+
+
+def _unapproved_projects_repo() -> AsyncMock:
+    """A projects repo whose every project reads as unapproved (quota applies)."""
+    repo = AsyncMock()
+    repo.get_by_id = AsyncMock(return_value=MagicMock(is_approved=False))
+    return repo
 
 
 def _fake_structure() -> Structure:
@@ -255,6 +270,89 @@ class TestInsertContributionsPreChecks:
         struct_repo.insert_components.assert_not_called()
         # And the in-pool contribution did go through the no-component fast path
         contrib_repo.insert_many_contributions.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# insert_contributions — unapproved-contribution quota
+# ---------------------------------------------------------------------------
+
+
+def _projects_repo_by_approval(approval: dict[str, bool]) -> AsyncMock:
+    """Projects repo whose ``get_by_id`` reports approval per project id from ``approval``."""
+    repo = AsyncMock()
+
+    async def _get_by_id(project_id, fields=None):
+        return MagicMock(is_approved=approval[project_id])
+
+    repo.get_by_id = AsyncMock(side_effect=_get_by_id)
+    return repo
+
+
+class TestInsertContributionsUnapprovedQuota:
+    async def test_unapproved_project_at_capacity_fails_all(self, monkeypatch):
+        monkeypatch.setattr(get_settings().user, "max_unapproved_contributions_per_project", 2)
+        contrib_repo = AsyncMock()
+        contrib_repo.insert_many_contributions.return_value = None
+        contrib_repo.count_contributions_for_project.return_value = 5  # already over cap
+        svc, *_ = _make_service(contributions=contrib_repo, projects=_unapproved_projects_repo())
+
+        summary = await svc.insert_contributions([_contrib_in(identifier=f"mp-{i}") for i in range(3)])
+
+        assert summary.total == 3
+        assert [f.index for f in summary.failed] == [0, 1, 2]
+        assert all(f.error_code == "permission_denied" for f in summary.failed)
+        assert summary.succeeded == []
+        contrib_repo.insert_many_contributions.assert_not_called()
+
+    async def test_batch_trimmed_to_remaining_capacity(self, monkeypatch):
+        # cap 5, 4 already stored -> remaining = 5 - 4 + 1 = 2 slots for this batch
+        monkeypatch.setattr(get_settings().user, "max_unapproved_contributions_per_project", 5)
+        contrib_repo = AsyncMock()
+        contrib_repo.insert_many_contributions.return_value = None
+        contrib_repo.count_contributions_for_project.return_value = 4
+        svc, *_ = _make_service(contributions=contrib_repo, projects=_unapproved_projects_repo())
+
+        summary = await svc.insert_contributions([_contrib_in(identifier=f"mp-{i}") for i in range(4)])
+
+        assert summary.total == 4
+        assert len(summary.succeeded) == 2
+        assert [f.index for f in summary.failed] == [2, 3]
+        # Only the two accepted contributions reached the database
+        inserted = contrib_repo.insert_many_contributions.call_args[0][0]
+        assert len(inserted) == 2
+
+    async def test_approved_project_is_unlimited(self, monkeypatch):
+        monkeypatch.setattr(get_settings().user, "max_unapproved_contributions_per_project", 1)
+        contrib_repo = AsyncMock()
+        contrib_repo.insert_many_contributions.return_value = None
+        svc, *_ = _make_service(contributions=contrib_repo, projects=_approved_projects_repo())
+
+        summary = await svc.insert_contributions([_contrib_in(identifier=f"mp-{i}") for i in range(3)])
+
+        assert len(summary.succeeded) == 3
+        assert summary.failed == []
+        # Approved short-circuits before counting stored contributions
+        contrib_repo.count_contributions_for_project.assert_not_called()
+
+    async def test_quota_evaluated_per_project(self, monkeypatch):
+        monkeypatch.setattr(get_settings().user, "max_unapproved_contributions_per_project", 2)
+        contrib_repo = AsyncMock()
+        contrib_repo.insert_many_contributions.return_value = None
+        contrib_repo.count_contributions_for_project.return_value = 99  # only consulted for the unapproved one
+        projects = _projects_repo_by_approval({"ok": True, "bad": False})
+        svc, *_ = _make_service(contributions=contrib_repo, projects=projects)
+
+        contribs = [
+            _contrib_in(project="ok", identifier="a"),
+            _contrib_in(project="bad", identifier="b"),
+            _contrib_in(project="ok", identifier="c"),
+        ]
+        summary = await svc.insert_contributions(contribs)
+
+        assert [f.index for f in summary.failed] == [1]
+        assert len(summary.succeeded) == 2
+        inserted_ids = {d.identifier for d in contrib_repo.insert_many_contributions.call_args[0][0]}
+        assert inserted_ids == {"a", "c"}
 
 
 # ---------------------------------------------------------------------------

--- a/mpcontribs-api/tests/unit/domains/test_contribution_service.py
+++ b/mpcontribs-api/tests/unit/domains/test_contribution_service.py
@@ -308,11 +308,11 @@ class TestInsertContributionsUnapprovedQuota:
         contrib_repo.insert_many_contributions.assert_not_called()
 
     async def test_batch_trimmed_to_remaining_capacity(self, monkeypatch):
-        # cap 5, 4 already stored -> remaining = 5 - 4 + 1 = 2 slots for this batch
+        # cap 5, 3 already stored -> remaining = 5 - 3 = 2 slots for this batch
         monkeypatch.setattr(get_settings().user, "max_unapproved_contributions_per_project", 5)
         contrib_repo = AsyncMock()
         contrib_repo.insert_many_contributions.return_value = None
-        contrib_repo.count_contributions_for_project.return_value = 4
+        contrib_repo.count_contributions_for_project.return_value = 3
         svc, *_ = _make_service(contributions=contrib_repo, projects=_unapproved_projects_repo())
 
         summary = await svc.insert_contributions([_contrib_in(identifier=f"mp-{i}") for i in range(4)])
@@ -323,6 +323,34 @@ class TestInsertContributionsUnapprovedQuota:
         # Only the two accepted contributions reached the database
         inserted = contrib_repo.insert_many_contributions.call_args[0][0]
         assert len(inserted) == 2
+
+    async def test_batch_may_fill_project_to_exactly_cap(self, monkeypatch):
+        # cap 3, 2 stored -> exactly one slot; the batch fills the project to the cap, not past it.
+        monkeypatch.setattr(get_settings().user, "max_unapproved_contributions_per_project", 3)
+        contrib_repo = AsyncMock()
+        contrib_repo.insert_many_contributions.return_value = None
+        contrib_repo.count_contributions_for_project.return_value = 2
+        svc, *_ = _make_service(contributions=contrib_repo, projects=_unapproved_projects_repo())
+
+        summary = await svc.insert_contributions([_contrib_in(identifier=f"mp-{i}") for i in range(2)])
+
+        assert summary.total == 2
+        assert len(summary.succeeded) == 1
+        assert [f.index for f in summary.failed] == [1]
+
+    async def test_batch_at_exactly_cap_rejects_all_new(self, monkeypatch):
+        # cap 3, 3 stored -> zero remaining slots; a project already at the cap admits nothing new.
+        monkeypatch.setattr(get_settings().user, "max_unapproved_contributions_per_project", 3)
+        contrib_repo = AsyncMock()
+        contrib_repo.insert_many_contributions.return_value = None
+        contrib_repo.count_contributions_for_project.return_value = 3
+        svc, *_ = _make_service(contributions=contrib_repo, projects=_unapproved_projects_repo())
+
+        summary = await svc.insert_contributions([_contrib_in(identifier=f"mp-{i}") for i in range(2)])
+
+        assert [f.index for f in summary.failed] == [0, 1]
+        assert summary.succeeded == []
+        contrib_repo.insert_many_contributions.assert_not_called()
 
     async def test_approved_project_is_unlimited(self, monkeypatch):
         monkeypatch.setattr(get_settings().user, "max_unapproved_contributions_per_project", 1)
@@ -398,8 +426,8 @@ class TestInsertContributionsUnapprovedQuota:
 
 class TestUpsertContributionsUnapprovedQuota:
     async def test_only_new_documents_count_against_cap(self, monkeypatch):
-        # cap 2, 2 stored -> one slot for a new document; updating an existing one is free.
-        monkeypatch.setattr(get_settings().user, "max_unapproved_contributions_per_project", 2)
+        # cap 3, 2 stored -> one slot for a new document; updating an existing one is free.
+        monkeypatch.setattr(get_settings().user, "max_unapproved_contributions_per_project", 3)
         contrib_repo = AsyncMock()
         contrib_repo.upsert_contribution_by_identifiers.return_value = MagicMock(spec=Contribution)
         contrib_repo.count_contributions_for_project.return_value = 2
@@ -489,6 +517,19 @@ class TestUpsertContributionByIdQuota:
         await svc.upsert_contribution_by_id("someid", _contrib_in())
 
         contrib_repo.upsert_contribution_by_id.assert_called_once()
+
+    async def test_new_insert_at_exactly_cap_rejected(self, monkeypatch):
+        # stored == cap: the project is full, so a brand-new document is rejected (no cap+1 slack).
+        monkeypatch.setattr(get_settings().user, "max_unapproved_contributions_per_project", 2)
+        contrib_repo = AsyncMock()
+        contrib_repo.get_contribution_by_id.return_value = None
+        contrib_repo.count_contributions_for_project.return_value = 2
+        svc, *_ = _make_service(contributions=contrib_repo, projects=_unapproved_projects_repo())
+
+        with pytest.raises(PermissionError):
+            await svc.upsert_contribution_by_id("someid", _contrib_in())
+
+        contrib_repo.upsert_contribution_by_id.assert_not_called()
 
     async def test_new_insert_approved_project_unlimited(self, monkeypatch):
         monkeypatch.setattr(get_settings().user, "max_unapproved_contributions_per_project", 1)

--- a/mpcontribs-api/tests/unit/domains/test_contribution_service.py
+++ b/mpcontribs-api/tests/unit/domains/test_contribution_service.py
@@ -8,10 +8,10 @@ from pymatgen.core import Element
 from pymongo.errors import BulkWriteError
 
 from mpcontribs_api.authz import ADMIN_GROUP, User
-from mpcontribs_api.config import MongoSettings
+from mpcontribs_api.config import MongoSettings, get_settings
 from mpcontribs_api.domains.attachments.models import Attachment, AttachmentIn
-from mpcontribs_api.domains.contributions.models import Contribution, ContributionIn
 from mpcontribs_api.domains.contributions import service as service_module
+from mpcontribs_api.domains.contributions.models import Contribution, ContributionIn
 from mpcontribs_api.domains.contributions.service import ContributionService
 from mpcontribs_api.domains.structures.models import (
     Lattice,
@@ -22,7 +22,7 @@ from mpcontribs_api.domains.structures.models import (
     StructureIn,
 )
 from mpcontribs_api.domains.tables.models import Attributes, Labels, Table, TableIn
-from mpcontribs_api.exceptions import ConflictError, ValidationError
+from mpcontribs_api.exceptions import ConflictError, PermissionError, ValidationError
 
 pytestmark = pytest.mark.asyncio
 
@@ -153,7 +153,6 @@ def _make_service(
     settings: MongoSettings | None = None,
     write_slots: asyncio.Semaphore | None = None,
     user: User | None = None,
-    projects=None,
     unique_identifiers: bool = True,
 ) -> tuple[ContributionService, AsyncMock, AsyncMock, AsyncMock, AsyncMock, MagicMock]:
     contrib_repo = contributions or AsyncMock()
@@ -187,6 +186,7 @@ def _approved_projects_repo() -> AsyncMock:
     """A projects repo whose every project reads as approved (quota does not apply)."""
     repo = AsyncMock()
     repo.get_by_id = AsyncMock(return_value=MagicMock(is_approved=True))
+    repo.unique_identifiers_by_id.side_effect = lambda ids: {pid: True for pid in ids}
     return repo
 
 
@@ -194,6 +194,7 @@ def _unapproved_projects_repo() -> AsyncMock:
     """A projects repo whose every project reads as unapproved (quota applies)."""
     repo = AsyncMock()
     repo.get_by_id = AsyncMock(return_value=MagicMock(is_approved=False))
+    repo.unique_identifiers_by_id.side_effect = lambda ids: {pid: True for pid in ids}
     return repo
 
 
@@ -286,6 +287,7 @@ def _projects_repo_by_approval(approval: dict[str, bool]) -> AsyncMock:
         return MagicMock(is_approved=approval[project_id])
 
     repo.get_by_id = AsyncMock(side_effect=_get_by_id)
+    repo.unique_identifiers_by_id.side_effect = lambda ids: {pid: True for pid in ids}
     return repo
 
 
@@ -387,6 +389,118 @@ class TestInsertContributionsUnapprovedQuota:
             await svc.insert_contributions([_contrib_in(identifier=f"mp-{i}") for i in range(3)])
 
         warn.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# upsert_contributions — unapproved-contribution quota (new docs only)
+# ---------------------------------------------------------------------------
+
+
+class TestUpsertContributionsUnapprovedQuota:
+    async def test_only_new_documents_count_against_cap(self, monkeypatch):
+        # cap 2, 2 stored -> one slot for a new document; updating an existing one is free.
+        monkeypatch.setattr(get_settings().user, "max_unapproved_contributions_per_project", 2)
+        contrib_repo = AsyncMock()
+        contrib_repo.upsert_contribution_by_identifiers.return_value = MagicMock(spec=Contribution)
+        contrib_repo.count_contributions_for_project.return_value = 2
+        contrib_repo.existing_versioned_keys.return_value = {("proj", "a", 1)}  # 'a' already exists
+        svc, *_ = _make_service(contributions=contrib_repo, projects=_unapproved_projects_repo())
+
+        contribs = [
+            _contrib_in(identifier="a"),  # update of an existing contribution -> always allowed
+            _contrib_in(identifier="b"),  # new -> consumes the one remaining slot
+            _contrib_in(identifier="c"),  # new -> over cap, rejected
+        ]
+        summary = await svc.upsert_contributions(contribs)
+
+        assert len(summary.succeeded) == 2
+        assert [f.index for f in summary.failed] == [2]
+        assert summary.failed[0].error_code == "permission_denied"
+        upserted = {c.args[1].identifier for c in contrib_repo.upsert_contribution_by_identifiers.call_args_list}
+        assert upserted == {"a", "b"}
+
+    async def test_pure_updates_are_never_capped(self, monkeypatch):
+        monkeypatch.setattr(get_settings().user, "max_unapproved_contributions_per_project", 1)
+        contrib_repo = AsyncMock()
+        contrib_repo.upsert_contribution_by_identifiers.return_value = MagicMock(spec=Contribution)
+        contrib_repo.count_contributions_for_project.return_value = 99  # far over cap
+        contrib_repo.existing_versioned_keys.return_value = {("proj", f"mp-{i}", 1) for i in range(3)}
+        svc, *_ = _make_service(contributions=contrib_repo, projects=_unapproved_projects_repo())
+
+        summary = await svc.upsert_contributions([_contrib_in(identifier=f"mp-{i}") for i in range(3)])
+
+        assert len(summary.succeeded) == 3
+        assert summary.failed == []
+        assert contrib_repo.upsert_contribution_by_identifiers.call_count == 3
+
+    async def test_approved_project_skips_quota(self, monkeypatch):
+        monkeypatch.setattr(get_settings().user, "max_unapproved_contributions_per_project", 1)
+        contrib_repo = AsyncMock()
+        contrib_repo.upsert_contribution_by_identifiers.return_value = MagicMock(spec=Contribution)
+        svc, *_ = _make_service(contributions=contrib_repo, projects=_approved_projects_repo())
+
+        summary = await svc.upsert_contributions([_contrib_in(identifier=f"mp-{i}") for i in range(3)])
+
+        assert len(summary.succeeded) == 3
+        assert summary.failed == []
+        contrib_repo.count_contributions_for_project.assert_not_called()
+        contrib_repo.existing_versioned_keys.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# upsert_contribution_by_id — single-record quota
+# ---------------------------------------------------------------------------
+
+
+class TestUpsertContributionByIdQuota:
+    async def test_update_existing_allowed_even_over_cap(self, monkeypatch):
+        monkeypatch.setattr(get_settings().user, "max_unapproved_contributions_per_project", 1)
+        contrib_repo = AsyncMock()
+        contrib_repo.get_contribution_by_id.return_value = MagicMock(spec=Contribution)  # id exists -> update
+        contrib_repo.count_contributions_for_project.return_value = 99
+        contrib_repo.upsert_contribution_by_id.return_value = MagicMock(spec=Contribution)
+        svc, *_ = _make_service(contributions=contrib_repo, projects=_unapproved_projects_repo())
+
+        await svc.upsert_contribution_by_id("someid", _contrib_in())
+
+        contrib_repo.upsert_contribution_by_id.assert_called_once()
+        contrib_repo.count_contributions_for_project.assert_not_called()
+
+    async def test_new_insert_over_cap_rejected(self, monkeypatch):
+        monkeypatch.setattr(get_settings().user, "max_unapproved_contributions_per_project", 2)
+        contrib_repo = AsyncMock()
+        contrib_repo.get_contribution_by_id.return_value = None  # id absent -> would insert
+        contrib_repo.count_contributions_for_project.return_value = 5  # over cap
+        svc, *_ = _make_service(contributions=contrib_repo, projects=_unapproved_projects_repo())
+
+        with pytest.raises(PermissionError):
+            await svc.upsert_contribution_by_id("someid", _contrib_in())
+
+        contrib_repo.upsert_contribution_by_id.assert_not_called()
+
+    async def test_new_insert_under_cap_allowed(self, monkeypatch):
+        monkeypatch.setattr(get_settings().user, "max_unapproved_contributions_per_project", 5)
+        contrib_repo = AsyncMock()
+        contrib_repo.get_contribution_by_id.return_value = None
+        contrib_repo.count_contributions_for_project.return_value = 1
+        contrib_repo.upsert_contribution_by_id.return_value = MagicMock(spec=Contribution)
+        svc, *_ = _make_service(contributions=contrib_repo, projects=_unapproved_projects_repo())
+
+        await svc.upsert_contribution_by_id("someid", _contrib_in())
+
+        contrib_repo.upsert_contribution_by_id.assert_called_once()
+
+    async def test_new_insert_approved_project_unlimited(self, monkeypatch):
+        monkeypatch.setattr(get_settings().user, "max_unapproved_contributions_per_project", 1)
+        contrib_repo = AsyncMock()
+        contrib_repo.get_contribution_by_id.return_value = None
+        contrib_repo.upsert_contribution_by_id.return_value = MagicMock(spec=Contribution)
+        svc, *_ = _make_service(contributions=contrib_repo, projects=_approved_projects_repo())
+
+        await svc.upsert_contribution_by_id("someid", _contrib_in())
+
+        contrib_repo.upsert_contribution_by_id.assert_called_once()
+        contrib_repo.count_contributions_for_project.assert_not_called()
 
 
 # ---------------------------------------------------------------------------

--- a/mpcontribs-api/tests/unit/domains/test_contribution_service.py
+++ b/mpcontribs-api/tests/unit/domains/test_contribution_service.py
@@ -1,5 +1,5 @@
 import asyncio
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import polars as pl
 import pytest
@@ -11,6 +11,7 @@ from mpcontribs_api.authz import ADMIN_GROUP, User
 from mpcontribs_api.config import MongoSettings
 from mpcontribs_api.domains.attachments.models import Attachment, AttachmentIn
 from mpcontribs_api.domains.contributions.models import Contribution, ContributionIn
+from mpcontribs_api.domains.contributions import service as service_module
 from mpcontribs_api.domains.contributions.service import ContributionService
 from mpcontribs_api.domains.structures.models import (
     Lattice,
@@ -353,6 +354,39 @@ class TestInsertContributionsUnapprovedQuota:
         assert len(summary.succeeded) == 2
         inserted_ids = {d.identifier for d in contrib_repo.insert_many_contributions.call_args[0][0]}
         assert inserted_ids == {"a", "c"}
+
+    async def test_breach_emits_structured_audit_log(self, monkeypatch):
+        monkeypatch.setattr(get_settings().user, "max_unapproved_contributions_per_project", 2)
+        contrib_repo = AsyncMock()
+        contrib_repo.insert_many_contributions.return_value = None
+        contrib_repo.count_contributions_for_project.return_value = 5
+        svc, *_ = _make_service(contributions=contrib_repo, projects=_unapproved_projects_repo())
+
+        with patch.object(service_module.logger, "warning") as warn:
+            await svc.insert_contributions([_contrib_in(project="p", identifier=f"mp-{i}") for i in range(3)])
+
+        warn.assert_called_once()
+        event, kwargs = warn.call_args.args[0], warn.call_args.kwargs
+        assert event == "contribution.unapproved_quota_exceeded"
+        assert kwargs["project"] == "p"
+        assert kwargs["max_allowed"] == 2
+        assert kwargs["stored"] == 5
+        assert kwargs["attempted"] == 3
+        assert kwargs["accepted"] == 0
+        assert kwargs["rejected"] == 3
+        assert kwargs["rejected_identifiers"] == ["mp-0", "mp-1", "mp-2"]
+        assert kwargs["rejected_identifiers_truncated"] is False
+
+    async def test_approved_project_emits_no_audit_log(self, monkeypatch):
+        monkeypatch.setattr(get_settings().user, "max_unapproved_contributions_per_project", 1)
+        contrib_repo = AsyncMock()
+        contrib_repo.insert_many_contributions.return_value = None
+        svc, *_ = _make_service(contributions=contrib_repo, projects=_approved_projects_repo())
+
+        with patch.object(service_module.logger, "warning") as warn:
+            await svc.insert_contributions([_contrib_in(identifier=f"mp-{i}") for i in range(3)])
+
+        warn.assert_not_called()
 
 
 # ---------------------------------------------------------------------------

--- a/mpcontribs-api/tests/unit/domains/test_contribution_service.py
+++ b/mpcontribs-api/tests/unit/domains/test_contribution_service.py
@@ -293,7 +293,7 @@ def _projects_repo_by_approval(approval: dict[str, bool]) -> AsyncMock:
 
 class TestInsertContributionsUnapprovedQuota:
     async def test_unapproved_project_at_capacity_fails_all(self, monkeypatch):
-        monkeypatch.setattr(get_settings().user, "max_unapproved_contributions_per_project", 2)
+        monkeypatch.setattr(get_settings().consumer, "max_unapproved_contributions_per_project", 2)
         contrib_repo = AsyncMock()
         contrib_repo.insert_many_contributions.return_value = None
         contrib_repo.count_contributions_for_project.return_value = 5  # already over cap
@@ -309,7 +309,7 @@ class TestInsertContributionsUnapprovedQuota:
 
     async def test_batch_trimmed_to_remaining_capacity(self, monkeypatch):
         # cap 5, 3 already stored -> remaining = 5 - 3 = 2 slots for this batch
-        monkeypatch.setattr(get_settings().user, "max_unapproved_contributions_per_project", 5)
+        monkeypatch.setattr(get_settings().consumer, "max_unapproved_contributions_per_project", 5)
         contrib_repo = AsyncMock()
         contrib_repo.insert_many_contributions.return_value = None
         contrib_repo.count_contributions_for_project.return_value = 3
@@ -326,7 +326,7 @@ class TestInsertContributionsUnapprovedQuota:
 
     async def test_batch_may_fill_project_to_exactly_cap(self, monkeypatch):
         # cap 3, 2 stored -> exactly one slot; the batch fills the project to the cap, not past it.
-        monkeypatch.setattr(get_settings().user, "max_unapproved_contributions_per_project", 3)
+        monkeypatch.setattr(get_settings().consumer, "max_unapproved_contributions_per_project", 3)
         contrib_repo = AsyncMock()
         contrib_repo.insert_many_contributions.return_value = None
         contrib_repo.count_contributions_for_project.return_value = 2
@@ -340,7 +340,7 @@ class TestInsertContributionsUnapprovedQuota:
 
     async def test_batch_at_exactly_cap_rejects_all_new(self, monkeypatch):
         # cap 3, 3 stored -> zero remaining slots; a project already at the cap admits nothing new.
-        monkeypatch.setattr(get_settings().user, "max_unapproved_contributions_per_project", 3)
+        monkeypatch.setattr(get_settings().consumer, "max_unapproved_contributions_per_project", 3)
         contrib_repo = AsyncMock()
         contrib_repo.insert_many_contributions.return_value = None
         contrib_repo.count_contributions_for_project.return_value = 3
@@ -353,7 +353,7 @@ class TestInsertContributionsUnapprovedQuota:
         contrib_repo.insert_many_contributions.assert_not_called()
 
     async def test_approved_project_is_unlimited(self, monkeypatch):
-        monkeypatch.setattr(get_settings().user, "max_unapproved_contributions_per_project", 1)
+        monkeypatch.setattr(get_settings().consumer, "max_unapproved_contributions_per_project", 1)
         contrib_repo = AsyncMock()
         contrib_repo.insert_many_contributions.return_value = None
         svc, *_ = _make_service(contributions=contrib_repo, projects=_approved_projects_repo())
@@ -366,7 +366,7 @@ class TestInsertContributionsUnapprovedQuota:
         contrib_repo.count_contributions_for_project.assert_not_called()
 
     async def test_quota_evaluated_per_project(self, monkeypatch):
-        monkeypatch.setattr(get_settings().user, "max_unapproved_contributions_per_project", 2)
+        monkeypatch.setattr(get_settings().consumer, "max_unapproved_contributions_per_project", 2)
         contrib_repo = AsyncMock()
         contrib_repo.insert_many_contributions.return_value = None
         contrib_repo.count_contributions_for_project.return_value = 99  # only consulted for the unapproved one
@@ -386,7 +386,7 @@ class TestInsertContributionsUnapprovedQuota:
         assert inserted_ids == {"a", "c"}
 
     async def test_breach_emits_structured_audit_log(self, monkeypatch):
-        monkeypatch.setattr(get_settings().user, "max_unapproved_contributions_per_project", 2)
+        monkeypatch.setattr(get_settings().consumer, "max_unapproved_contributions_per_project", 2)
         contrib_repo = AsyncMock()
         contrib_repo.insert_many_contributions.return_value = None
         contrib_repo.count_contributions_for_project.return_value = 5
@@ -408,7 +408,7 @@ class TestInsertContributionsUnapprovedQuota:
         assert kwargs["rejected_identifiers_truncated"] is False
 
     async def test_approved_project_emits_no_audit_log(self, monkeypatch):
-        monkeypatch.setattr(get_settings().user, "max_unapproved_contributions_per_project", 1)
+        monkeypatch.setattr(get_settings().consumer, "max_unapproved_contributions_per_project", 1)
         contrib_repo = AsyncMock()
         contrib_repo.insert_many_contributions.return_value = None
         svc, *_ = _make_service(contributions=contrib_repo, projects=_approved_projects_repo())
@@ -427,7 +427,7 @@ class TestInsertContributionsUnapprovedQuota:
 class TestUpsertContributionsUnapprovedQuota:
     async def test_only_new_documents_count_against_cap(self, monkeypatch):
         # cap 3, 2 stored -> one slot for a new document; updating an existing one is free.
-        monkeypatch.setattr(get_settings().user, "max_unapproved_contributions_per_project", 3)
+        monkeypatch.setattr(get_settings().consumer, "max_unapproved_contributions_per_project", 3)
         contrib_repo = AsyncMock()
         contrib_repo.upsert_contribution_by_identifiers.return_value = MagicMock(spec=Contribution)
         contrib_repo.count_contributions_for_project.return_value = 2
@@ -448,7 +448,7 @@ class TestUpsertContributionsUnapprovedQuota:
         assert upserted == {"a", "b"}
 
     async def test_pure_updates_are_never_capped(self, monkeypatch):
-        monkeypatch.setattr(get_settings().user, "max_unapproved_contributions_per_project", 1)
+        monkeypatch.setattr(get_settings().consumer, "max_unapproved_contributions_per_project", 1)
         contrib_repo = AsyncMock()
         contrib_repo.upsert_contribution_by_identifiers.return_value = MagicMock(spec=Contribution)
         contrib_repo.count_contributions_for_project.return_value = 99  # far over cap
@@ -462,7 +462,7 @@ class TestUpsertContributionsUnapprovedQuota:
         assert contrib_repo.upsert_contribution_by_identifiers.call_count == 3
 
     async def test_approved_project_skips_quota(self, monkeypatch):
-        monkeypatch.setattr(get_settings().user, "max_unapproved_contributions_per_project", 1)
+        monkeypatch.setattr(get_settings().consumer, "max_unapproved_contributions_per_project", 1)
         contrib_repo = AsyncMock()
         contrib_repo.upsert_contribution_by_identifiers.return_value = MagicMock(spec=Contribution)
         svc, *_ = _make_service(contributions=contrib_repo, projects=_approved_projects_repo())
@@ -482,7 +482,7 @@ class TestUpsertContributionsUnapprovedQuota:
 
 class TestUpsertContributionByIdQuota:
     async def test_update_existing_allowed_even_over_cap(self, monkeypatch):
-        monkeypatch.setattr(get_settings().user, "max_unapproved_contributions_per_project", 1)
+        monkeypatch.setattr(get_settings().consumer, "max_unapproved_contributions_per_project", 1)
         contrib_repo = AsyncMock()
         contrib_repo.get_contribution_by_id.return_value = MagicMock(spec=Contribution)  # id exists -> update
         contrib_repo.count_contributions_for_project.return_value = 99
@@ -495,7 +495,7 @@ class TestUpsertContributionByIdQuota:
         contrib_repo.count_contributions_for_project.assert_not_called()
 
     async def test_new_insert_over_cap_rejected(self, monkeypatch):
-        monkeypatch.setattr(get_settings().user, "max_unapproved_contributions_per_project", 2)
+        monkeypatch.setattr(get_settings().consumer, "max_unapproved_contributions_per_project", 2)
         contrib_repo = AsyncMock()
         contrib_repo.get_contribution_by_id.return_value = None  # id absent -> would insert
         contrib_repo.count_contributions_for_project.return_value = 5  # over cap
@@ -507,7 +507,7 @@ class TestUpsertContributionByIdQuota:
         contrib_repo.upsert_contribution_by_id.assert_not_called()
 
     async def test_new_insert_under_cap_allowed(self, monkeypatch):
-        monkeypatch.setattr(get_settings().user, "max_unapproved_contributions_per_project", 5)
+        monkeypatch.setattr(get_settings().consumer, "max_unapproved_contributions_per_project", 5)
         contrib_repo = AsyncMock()
         contrib_repo.get_contribution_by_id.return_value = None
         contrib_repo.count_contributions_for_project.return_value = 1
@@ -520,7 +520,7 @@ class TestUpsertContributionByIdQuota:
 
     async def test_new_insert_at_exactly_cap_rejected(self, monkeypatch):
         # stored == cap: the project is full, so a brand-new document is rejected (no cap+1 slack).
-        monkeypatch.setattr(get_settings().user, "max_unapproved_contributions_per_project", 2)
+        monkeypatch.setattr(get_settings().consumer, "max_unapproved_contributions_per_project", 2)
         contrib_repo = AsyncMock()
         contrib_repo.get_contribution_by_id.return_value = None
         contrib_repo.count_contributions_for_project.return_value = 2
@@ -532,7 +532,7 @@ class TestUpsertContributionByIdQuota:
         contrib_repo.upsert_contribution_by_id.assert_not_called()
 
     async def test_new_insert_approved_project_unlimited(self, monkeypatch):
-        monkeypatch.setattr(get_settings().user, "max_unapproved_contributions_per_project", 1)
+        monkeypatch.setattr(get_settings().consumer, "max_unapproved_contributions_per_project", 1)
         contrib_repo = AsyncMock()
         contrib_repo.get_contribution_by_id.return_value = None
         contrib_repo.upsert_contribution_by_id.return_value = MagicMock(spec=Contribution)

--- a/mpcontribs-api/tests/unit/domains/test_projects_models.py
+++ b/mpcontribs-api/tests/unit/domains/test_projects_models.py
@@ -254,3 +254,58 @@ class TestProjectDecodeCursor:
     def test_malformed_cursor_raises_value_error(self):
         with pytest.raises(ValueError):
             Project.decode_cursor("!!!not-base64!!!")
+
+
+# ---------------------------------------------------------------------------
+# Column-length quota (max_columns)
+# ---------------------------------------------------------------------------
+
+
+def _columns(n: int) -> list[Column]:
+    return [Column(path=f"data.col_{i}") for i in range(n)]
+
+
+class TestColumnLengthQuota:
+    """A project may carry at most ``user.max_columns`` columns; the limit is inclusive."""
+
+    def _make_input(self, columns: list[Column]) -> dict:
+        return {
+            "_id": "cols-proj",
+            "title": "Columns Project",
+            "authors": "Alice",
+            "description": "desc",
+            "owner": "google:alice@example.com",
+            "unique_identifiers": True,
+            "stats": VALID_STATS,
+            "columns": columns,
+        }
+
+    def test_project_in_at_cap_is_allowed(self, monkeypatch):
+        from mpcontribs_api.config import get_settings
+
+        monkeypatch.setattr(get_settings().user, "max_columns", 2)
+        project = ProjectIn(**self._make_input(_columns(2)))
+        assert len(project.columns) == 2
+
+    def test_project_in_over_cap_raises(self, monkeypatch):
+        from mpcontribs_api.config import get_settings
+        from mpcontribs_api.exceptions import ValidationError as AppValidationError
+
+        monkeypatch.setattr(get_settings().user, "max_columns", 2)
+        with pytest.raises(AppValidationError):
+            ProjectIn(**self._make_input(_columns(3)))
+
+    def test_project_patch_at_cap_is_allowed(self, monkeypatch):
+        from mpcontribs_api.config import get_settings
+
+        monkeypatch.setattr(get_settings().user, "max_columns", 2)
+        patch = ProjectPatch(columns=_columns(2))
+        assert len(patch.columns) == 2
+
+    def test_project_patch_over_cap_raises(self, monkeypatch):
+        from mpcontribs_api.config import get_settings
+        from mpcontribs_api.exceptions import ValidationError as AppValidationError
+
+        monkeypatch.setattr(get_settings().user, "max_columns", 2)
+        with pytest.raises(AppValidationError):
+            ProjectPatch(columns=_columns(3))

--- a/mpcontribs-api/tests/unit/domains/test_projects_models.py
+++ b/mpcontribs-api/tests/unit/domains/test_projects_models.py
@@ -9,7 +9,9 @@ from mpcontribs_api.domains.projects.models import (
     ProjectPatch,
     Reference,
     Stats,
+    check_column_limit,
 )
+from mpcontribs_api.exceptions import ValidationError as AppValidationError
 
 # ---------------------------------------------------------------------------
 # Column
@@ -266,46 +268,35 @@ def _columns(n: int) -> list[Column]:
 
 
 class TestColumnLengthQuota:
-    """A project may carry at most ``user.max_columns`` columns; the limit is inclusive."""
+    """The column cap is enforced by ``check_column_limit`` (called from the repository with the
+    caller's effective ``max_columns``), not by the ``ProjectIn``/``ProjectPatch`` models. These
+    tests pin the pure function's contract: the cap is inclusive, over-cap writes raise, and a
+    non-list value is a no-op so legacy documents that already exceed the cap can still be read back.
+    """
 
-    def _make_input(self, columns: list[Column]) -> dict:
-        return {
-            "_id": "cols-proj",
-            "title": "Columns Project",
-            "authors": "Alice",
-            "description": "desc",
-            "owner": "google:alice@example.com",
-            "unique_identifiers": True,
-            "stats": VALID_STATS,
-            "columns": columns,
-        }
+    def test_at_cap_is_allowed(self):
+        # Inclusive: exactly max_columns entries must pass.
+        check_column_limit(_columns(2), max_columns=2)
 
-    def test_project_in_at_cap_is_allowed(self, monkeypatch):
-        from mpcontribs_api.config import get_settings
+    def test_under_cap_is_allowed(self):
+        check_column_limit(_columns(1), max_columns=2)
 
-        monkeypatch.setattr(get_settings().user, "max_columns", 2)
-        project = ProjectIn(**self._make_input(_columns(2)))
-        assert len(project.columns) == 2
-
-    def test_project_in_over_cap_raises(self, monkeypatch):
-        from mpcontribs_api.config import get_settings
-        from mpcontribs_api.exceptions import ValidationError as AppValidationError
-
-        monkeypatch.setattr(get_settings().user, "max_columns", 2)
+    def test_over_cap_raises(self):
         with pytest.raises(AppValidationError):
-            ProjectIn(**self._make_input(_columns(3)))
+            check_column_limit(_columns(3), max_columns=2)
 
-    def test_project_patch_at_cap_is_allowed(self, monkeypatch):
-        from mpcontribs_api.config import get_settings
+    def test_error_reports_offending_length(self):
+        with pytest.raises(AppValidationError) as exc_info:
+            check_column_limit(_columns(5), max_columns=2)
+        assert exc_info.value.context["column_length"] == 5
 
-        monkeypatch.setattr(get_settings().user, "max_columns", 2)
-        patch = ProjectPatch(columns=_columns(2))
-        assert len(patch.columns) == 2
+    def test_none_is_noop(self):
+        # A read path may pass a non-list (e.g. an unset field); it must never raise so legacy
+        # documents that predate the cap remain retrievable.
+        check_column_limit(None, max_columns=0)
 
-    def test_project_patch_over_cap_raises(self, monkeypatch):
-        from mpcontribs_api.config import get_settings
-        from mpcontribs_api.exceptions import ValidationError as AppValidationError
-
-        monkeypatch.setattr(get_settings().user, "max_columns", 2)
-        with pytest.raises(AppValidationError):
-            ProjectPatch(columns=_columns(3))
+    def test_model_does_not_enforce_cap(self):
+        # Regression guard: the cap moved off the model into the repository. Constructing a model
+        # with more columns than any cap must NOT raise here — enforcement happens on write.
+        patch = ProjectPatch(columns=_columns(50))
+        assert len(patch.columns) == 50

--- a/mpcontribs-api/tests/unit/domains/test_projects_models.py
+++ b/mpcontribs-api/tests/unit/domains/test_projects_models.py
@@ -9,7 +9,7 @@ from mpcontribs_api.domains.projects.models import (
     ProjectPatch,
     Reference,
     Stats,
-    check_column_limit,
+    validate_column_limit,
 )
 from mpcontribs_api.exceptions import ValidationError as AppValidationError
 
@@ -268,7 +268,7 @@ def _columns(n: int) -> list[Column]:
 
 
 class TestColumnLengthQuota:
-    """The column cap is enforced by ``check_column_limit`` (called from the repository with the
+    """The column cap is enforced by ``validate_column_limit`` (called from the repository with the
     caller's effective ``max_columns``), not by the ``ProjectIn``/``ProjectPatch`` models. These
     tests pin the pure function's contract: the cap is inclusive, over-cap writes raise, and a
     non-list value is a no-op so legacy documents that already exceed the cap can still be read back.
@@ -276,24 +276,24 @@ class TestColumnLengthQuota:
 
     def test_at_cap_is_allowed(self):
         # Inclusive: exactly max_columns entries must pass.
-        check_column_limit(_columns(2), max_columns=2)
+        validate_column_limit(_columns(2), max_columns=2)
 
     def test_under_cap_is_allowed(self):
-        check_column_limit(_columns(1), max_columns=2)
+        validate_column_limit(_columns(1), max_columns=2)
 
     def test_over_cap_raises(self):
         with pytest.raises(AppValidationError):
-            check_column_limit(_columns(3), max_columns=2)
+            validate_column_limit(_columns(3), max_columns=2)
 
     def test_error_reports_offending_length(self):
         with pytest.raises(AppValidationError) as exc_info:
-            check_column_limit(_columns(5), max_columns=2)
+            validate_column_limit(_columns(5), max_columns=2)
         assert exc_info.value.context["column_length"] == 5
 
     def test_none_is_noop(self):
         # A read path may pass a non-list (e.g. an unset field); it must never raise so legacy
         # documents that predate the cap remain retrievable.
-        check_column_limit(None, max_columns=0)
+        validate_column_limit(None, max_columns=0)
 
     def test_model_does_not_enforce_cap(self):
         # Regression guard: the cap moved off the model into the repository. Constructing a model


### PR DESCRIPTION
## Summary

Added limits to what users are able to contribute:
1. Max number of projects per user (default 3)
2. Max number of contributions on an unapproved projects (500)
3. Max number of columns on a project (160)