### PR TITLE
pin ddtrace to 4.8.2

### DIFF
--- a/mpcontribs-api/pyproject.toml
+++ b/mpcontribs-api/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
     "boltons",
     "css-html-js-minify",
     "dateparser",
-    "ddtrace==4.3.0",
+    "ddtrace==4.8.2",
     "dnspython",
     "filetype",
     "flasgger-tschaume>=0.9.7",

--- a/mpcontribs-portal/pyproject.toml
+++ b/mpcontribs-portal/pyproject.toml
@@ -27,7 +27,7 @@ authors = [
 dependencies = [
     "boltons",
     "boto3",
-    "ddtrace==4.3.0",
+    "ddtrace==4.8.2",
     "Django>=3.2,<4.0",
     "django-extensions",
     "django-settings-file",


### PR DESCRIPTION
Pin ddtrace to 4.8.2 for consistency with [emmet-api](https://github.com/materialsproject/emmet/commit/3f2daf4f897fc1551fd133ca26ce612e843ae0ae) and [web](https://github.com/materialsproject/web/commit/b53b8fb1ffbda96e098f3c8c3d39a157a90796f3) for [deplotment](https://github.com/materialsproject/devops/actions/runs/31828693466/job/94859161517)

Since mpcontribs-portal is pretty old, I’m not sure whether this upgrade will cause any issues. (I assume not)