### PR TITLE
upgrade python base image to 3.12

### DIFF
--- a/mpcontribs-api/Dockerfile
+++ b/mpcontribs-api/Dockerfile
@@ -1,4 +1,4 @@
-FROM materialsproject/devops:python-3.1113.18 AS base
+FROM materialsproject/devops:python-3.1213.2 AS base
 RUN apt-get update && apt-get install -y --no-install-recommends supervisor libopenblas-dev libpq-dev vim && apt-get clean
 WORKDIR /app
 
@@ -28,7 +28,7 @@ RUN wget -q https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-
 FROM base
 ARG BUILDARCH
 ENV BUILDARCH=x86_64
-COPY --from=builder /usr/local/lib/python3.11/site-packages /usr/local/lib/python3.11/site-packages
+COPY --from=builder /usr/local/lib/python3.12/site-packages /usr/local/lib/python3.12/site-packages
 COPY --from=builder /usr/local/bin /usr/local/bin
 COPY --from=builder /usr/lib/$BUILDARCH-linux-gnu/libsnappy* /usr/lib/$BUILDARCH-linux-gnu/
 

--- a/mpcontribs-kernel-gateway/Dockerfile
+++ b/mpcontribs-kernel-gateway/Dockerfile
@@ -1,4 +1,4 @@
-FROM materialsproject/devops:python-3.1113.18 AS base
+FROM materialsproject/devops:python-3.1213.2 AS base
 RUN apt-get update && apt-get install -y --no-install-recommends libopenblas-dev libpq-dev curl && apt-get clean
 
 FROM base AS python-deps
@@ -14,7 +14,7 @@ RUN wget -q https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-
   chmod +x wait-for-it.sh && mv wait-for-it.sh /root/.local/bin/
 
 FROM base
-COPY --from=python-deps /root/.local/lib/python3.11/site-packages /root/.local/lib/python3.11/site-packages
+COPY --from=python-deps /root/.local/lib/python3.12/site-packages /root/.local/lib/python3.12/site-packages
 COPY --from=python-deps /root/.local/bin /root/.local/bin
 
 WORKDIR /app

--- a/mpcontribs-portal/Dockerfile
+++ b/mpcontribs-portal/Dockerfile
@@ -1,4 +1,4 @@
-FROM materialsproject/devops:python-3.1113.18 AS base
+FROM materialsproject/devops:python-3.1213.2 AS base
 RUN apt-get update && apt-get install -y --no-install-recommends libopenblas-dev && apt-get clean
 FROM node:26.4.0-slim AS node
 
@@ -32,7 +32,7 @@ RUN wget -q https://raw.githubusercontent.com/vishnubob/wait-for-it/master/wait-
   chmod +x wait-for-it.sh && mv wait-for-it.sh /usr/local/bin/
 
 FROM base AS python-builds
-COPY --from=python-deps /usr/local/lib/python3.11/site-packages /usr/local/lib/python3.11/site-packages
+COPY --from=python-deps /usr/local/lib/python3.12/site-packages /usr/local/lib/python3.12/site-packages
 COPY --from=python-deps /usr/local/bin /usr/local/bin
 COPY --from=python-deps /usr/local/share /usr/local/share
 WORKDIR /app
@@ -48,7 +48,7 @@ RUN SETUPTOOLS_SCM_PRETEND_VERSION=${CONTRIBS_VERSION} pip install $PIP_FLAGS $M
 RUN python manage.py collectstatic --noinput
 
 FROM base
-COPY --from=python-builds /usr/local/lib/python3.11/site-packages /usr/local/lib/python3.11/site-packages
+COPY --from=python-builds /usr/local/lib/python3.12/site-packages /usr/local/lib/python3.12/site-packages
 COPY --from=python-builds /usr/local/bin /usr/local/bin
 COPY --from=python-builds /usr/local/share /usr/local/share
 COPY --from=python-builds /app/static /app/static


### PR DESCRIPTION
Upgrade base image to `materialsproject/devops:python-3.1213.2` (https://hub.docker.com/r/materialsproject/devops)