### PR TITLE
Logic flow consistency

### DIFF
--- a/mpcontribs-api/CLAUDE.md
+++ b/mpcontribs-api/CLAUDE.md
@@ -69,7 +69,7 @@ Components (structures/tables/attachments) have no access field of their own; th
 
 ### Repository pattern
 
-Repositories take a `User` at construction time and expose typed async methods (`get_*`, `insert_*`, `patch_*`, `upsert_*`, `delete_*`). They never leak the scope logic to routers — routers only call repository methods.
+Repositories take a `User` at construction time and expose typed async methods using CRUD nomenclature (`read_*`, `insert_*`, `update_*`, `upsert_*`, `delete_*`, each suffixed `_one`/`_many`). This same vocabulary is used consistently across all three layers — router handlers, services, and repositories — so a given operation carries the same method name end to end. They never leak the scope logic to routers — routers only call repository methods.
 
 ### Sparse field selection
 

--- a/mpcontribs-api/src/mpcontribs_api/domains/_shared/components.py
+++ b/mpcontribs-api/src/mpcontribs_api/domains/_shared/components.py
@@ -1,15 +1,13 @@
-from typing import Any
-
 from beanie.operators import In
 from fastapi_filter.contrib.beanie import Filter
 from pydantic import BaseModel
 from pymongo.asynchronous.client_session import AsyncClientSession
 
-from mpcontribs_api.authz import User
 from mpcontribs_api.config import get_settings
 from mpcontribs_api.domains._shared.models import Component, ComponentIn, DeleteResponse, DocumentOut
 from mpcontribs_api.domains._shared.repository import MongoDbRepository
 from mpcontribs_api.domains._shared.types import MD5Hash
+from mpcontribs_api.scope import Scope
 
 
 class MongoDbComponentsRepository[
@@ -19,9 +17,8 @@ class MongoDbComponentsRepository[
     TFilter: Filter,
     TPatch: BaseModel,
 ](MongoDbRepository[TDoc, TIn, TOut, TFilter, TPatch]):
-    @staticmethod
-    def _build_scope(user: User) -> dict[str, Any]:
-        return {}
+    # Components' visibility is determined by the visibility of referencing Contributions by user
+    read_scope = Scope()
 
     async def _existing_by_md5(
         self,

--- a/mpcontribs-api/src/mpcontribs_api/domains/_shared/components.py
+++ b/mpcontribs-api/src/mpcontribs_api/domains/_shared/components.py
@@ -1,12 +1,16 @@
 from beanie.operators import In
 from fastapi_filter.contrib.beanie import Filter
 from pydantic import BaseModel
+from pydantic import ValidationError as PydanticValidationError
 from pymongo.asynchronous.client_session import AsyncClientSession
+from pymongo.errors import BulkWriteError
 
 from mpcontribs_api.config import get_settings
+from mpcontribs_api.domains._shared.bulk import BulkFailure, bulk_failure_from_exception
 from mpcontribs_api.domains._shared.models import Component, ComponentIn, DeleteResponse, DocumentOut
 from mpcontribs_api.domains._shared.repository import MongoDbRepository
 from mpcontribs_api.domains._shared.types import MD5Hash
+from mpcontribs_api.exceptions import ConflictError, ValidationError
 from mpcontribs_api.scope import Scope
 
 
@@ -37,48 +41,75 @@ class MongoDbComponentsRepository[
         self,
         components: list[TIn],
         session: AsyncClientSession | None = None,
-    ) -> list[TDoc]:
-        """Bulk-insert components, deduplicated by server-computed content hash.
+    ) -> tuple[list[tuple[int, TDoc]], list[BulkFailure]]:
+        """Bulk-insert components (deduplicated by content hash), reporting per-item outcomes.
 
-        Components are content-addressed: unlike the base document-in ``insert_many``, this override
-        stays input-in because the repository must build each document to compute and dedup its
-        server-owned ``md5`` (the client never supplies it). See ``Component.from_input``.
+        Accepts TIn instead of TDoc so we can compute MD5.
 
-        Each input is built into a full document via ``Component.from_input``, which assigns a fresh
-        id and computes ``md5`` from the content (the client never supplies it). Inputs are
-        deduplicated by md5 — both against documents already stored and against each other — so the
-        return list has one entry per *unique* content, in first-seen order.
+        Returns a tuple so Contribution transactions can easily make a decision. Conversion to
+        BulkSummary is left to the ComponentService.
 
         Args:
             components (list[TIn]): components to insert
             session (AsyncClientSession): optional client session; pass when inserting inside a transaction
         """
-        # Build full docs up front so md5 is server-computed before any dedup decision.
-        docs = [self.document_model.from_input(comp) for comp in components]
-        existing_by_md5 = await self._existing_by_md5([doc.md5 for doc in docs], session=session)
+        # Build full docs up front so md5 is server-computed before any dedup decision. A build
+        # failure is per-item: record it and drop the item, letting the rest proceed.
+        failures: list[BulkFailure] = []
+        built: list[tuple[int, TDoc]] = []  # (original input index, built document)
+        md5_to_input_indices: dict[str, list[int]] = {}
+        for index, comp in enumerate(components):
+            identifier = {"name": getattr(comp, "name", None)}
+            try:
+                doc = self.document_model.from_input(comp)
+            except PydanticValidationError as exc:
+                failures.append(
+                    BulkFailure(index=index, identifier=identifier, error_code="validation_error", message=str(exc))
+                )
+                continue
+            except Exception as exc:
+                failures.append(bulk_failure_from_exception(index, identifier, exc))
+                continue
+            built.append((index, doc))
+            md5_to_input_indices.setdefault(doc.md5, []).append(index)
 
-        # First-seen unique md5 order, and the new documents that need inserting.
-        unique_md5s: list[str] = []
+        existing_by_md5 = await self._existing_by_md5(list(md5_to_input_indices.keys()), session=session)
+
+        # New documents that need inserting, one per unique md5 in first-seen order.
         new_by_md5: dict[str, TDoc] = {}
-        for doc in docs:
+        for _, doc in built:
             if doc.md5 not in existing_by_md5 and doc.md5 not in new_by_md5:
                 new_by_md5[doc.md5] = doc
-            if doc.md5 not in unique_md5s:
-                unique_md5s.append(doc.md5)
 
-        # Insert by chunks to stay within a transaction's payload budget.
+        # Insert by chunks to stay within a transaction's payload budget. With ordered=False, pymongo
+        # raises BulkWriteError carrying per-index write errors; map each back to the original inputs.
         new_docs = list(new_by_md5.values())
+        new_docs_md5s = [doc.md5 for doc in new_docs]
+        failed_md5s: set[str] = set()
         chunk_size = get_settings().mongo.component_insert_chunk_size
         for start in range(0, len(new_docs), chunk_size):
-            await self.document_model.insert_many(
-                new_docs[start : start + chunk_size],
-                ordered=False,
-                session=session,
-            )
+            chunk = new_docs[start : start + chunk_size]
+            chunk_md5s = new_docs_md5s[start : start + chunk_size]
+            try:
+                await self.document_model.insert_many(chunk, ordered=False, session=session)
+            except BulkWriteError as exc:
+                write_errors = exc.details.get("writeErrors", []) if exc.details else []
+                for err in write_errors:
+                    failed_md5 = chunk_md5s[err["index"]]
+                    failed_md5s.add(failed_md5)
+                    error_code = "conflict" if err.get("code") == 11000 else "write_error"
+                    message = err.get("errmsg", "write failed")
+                    for orig_idx in md5_to_input_indices[failed_md5]:
+                        failures.append(
+                            BulkFailure(
+                                index=orig_idx, identifier={"md5": failed_md5}, error_code=error_code, message=message
+                            )
+                        )
 
-        # One resolved document per unique md5, in first-seen order.
-        resolved = existing_by_md5 | new_by_md5
-        return [resolved[md5] for md5 in unique_md5s]
+        # Resolve each successfully built input to its stored document, dropping any whose insert failed.
+        resolved = existing_by_md5 | {md5: doc for md5, doc in new_by_md5.items() if md5 not in failed_md5s}
+        indexed_successes = [(index, resolved[doc.md5]) for index, doc in built if doc.md5 in resolved]
+        return indexed_successes, failures
 
     async def insert_one(self, component: TIn, *, session: AsyncClientSession | None = None) -> TDoc:  # pyright: ignore[reportIncompatibleMethodOverride]
         """Insert a single component, deduplicated by content hash.
@@ -88,8 +119,18 @@ class MongoDbComponentsRepository[
 
         Returns:
             TDoc: the component actually in the database
+
+        Raises:
+            ValidationError: the component could not be built from its input
+            ConflictError: the component collided on insert
         """
-        return (await self.insert_many(components=[component], session=session))[0]
+        indexed_successes, failures = await self.insert_many(components=[component], session=session)
+        if failures:
+            failure = failures[0]
+            if failure.error_code == ValidationError.error_code:
+                raise ValidationError(failure.message)
+            raise ConflictError(failure.message)
+        return indexed_successes[0][1]
 
     async def delete_many(
         self,

--- a/mpcontribs-api/src/mpcontribs_api/domains/_shared/components.py
+++ b/mpcontribs-api/src/mpcontribs_api/domains/_shared/components.py
@@ -1,16 +1,15 @@
 from beanie.operators import In
 from fastapi_filter.contrib.beanie import Filter
 from pydantic import BaseModel
-from pydantic import ValidationError as PydanticValidationError
 from pymongo.asynchronous.client_session import AsyncClientSession
 from pymongo.errors import BulkWriteError
 
 from mpcontribs_api.config import get_settings
-from mpcontribs_api.domains._shared.bulk import BulkFailure, bulk_failure_from_exception
+from mpcontribs_api.domains._shared.bulk import BulkFailure
 from mpcontribs_api.domains._shared.models import Component, ComponentIn, DeleteResponse, DocumentOut
 from mpcontribs_api.domains._shared.repository import MongoDbRepository
 from mpcontribs_api.domains._shared.types import MD5Hash
-from mpcontribs_api.exceptions import ConflictError, ValidationError
+from mpcontribs_api.exceptions import ConflictError
 from mpcontribs_api.scope import Scope
 
 
@@ -37,47 +36,32 @@ class MongoDbComponentsRepository[
         ).to_list()
         return {doc.md5: doc for doc in existing_docs}
 
-    async def insert_many(  # pyright: ignore[reportIncompatibleMethodOverride]
+    async def insert_many(
         self,
-        components: list[TIn],
+        documents: list[TDoc],
         session: AsyncClientSession | None = None,
     ) -> tuple[list[tuple[int, TDoc]], list[BulkFailure]]:
-        """Bulk-insert components (deduplicated by content hash), reporting per-item outcomes.
-
-        Accepts TIn instead of TDoc so we can compute MD5.
+        """Bulk-insert pre-built components (deduplicated by content hash), reporting per-item outcomes.
 
         Returns a tuple so Contribution transactions can easily make a decision. Conversion to
         BulkSummary is left to the ComponentService.
 
         Args:
-            components (list[TIn]): components to insert
+            documents (list[TDoc]): fully-built component documents to insert
             session (AsyncClientSession): optional client session; pass when inserting inside a transaction
         """
-        # Build full docs up front so md5 is server-computed before any dedup decision. A build
-        # failure is per-item: record it and drop the item, letting the rest proceed.
+        # Every input position is tracked by its content hash so each one can resolve to the stored
+        # document (existing or newly inserted) that shares its md5.
         failures: list[BulkFailure] = []
-        built: list[tuple[int, TDoc]] = []  # (original input index, built document)
         md5_to_input_indices: dict[str, list[int]] = {}
-        for index, comp in enumerate(components):
-            identifier = {"name": getattr(comp, "name", None)}
-            try:
-                doc = self.document_model.from_input(comp)
-            except PydanticValidationError as exc:
-                failures.append(
-                    BulkFailure(index=index, identifier=identifier, error_code="validation_error", message=str(exc))
-                )
-                continue
-            except Exception as exc:
-                failures.append(bulk_failure_from_exception(index, identifier, exc))
-                continue
-            built.append((index, doc))
+        for index, doc in enumerate(documents):
             md5_to_input_indices.setdefault(doc.md5, []).append(index)
 
         existing_by_md5 = await self._existing_by_md5(list(md5_to_input_indices.keys()), session=session)
 
         # New documents that need inserting, one per unique md5 in first-seen order.
         new_by_md5: dict[str, TDoc] = {}
-        for _, doc in built:
+        for doc in documents:
             if doc.md5 not in existing_by_md5 and doc.md5 not in new_by_md5:
                 new_by_md5[doc.md5] = doc
 
@@ -106,30 +90,26 @@ class MongoDbComponentsRepository[
                             )
                         )
 
-        # Resolve each successfully built input to its stored document, dropping any whose insert failed.
+        # Resolve each input position to its stored document, dropping any whose insert failed.
         resolved = existing_by_md5 | {md5: doc for md5, doc in new_by_md5.items() if md5 not in failed_md5s}
-        indexed_successes = [(index, resolved[doc.md5]) for index, doc in built if doc.md5 in resolved]
+        indexed_successes = [(index, resolved[doc.md5]) for index, doc in enumerate(documents) if doc.md5 in resolved]
         return indexed_successes, failures
 
-    async def insert_one(self, component: TIn, *, session: AsyncClientSession | None = None) -> TDoc:  # pyright: ignore[reportIncompatibleMethodOverride]
+    async def insert_one(self, document: TDoc, session: AsyncClientSession | None = None) -> TDoc:
         """Insert a single component, deduplicated by content hash.
 
         Args:
-            component (TIn): the component to insert
+            document (TDoc): the component to insert
 
         Returns:
-            TDoc: the component actually in the database
+            TDoc: the component actually in the database (an existing match, or the newly inserted doc)
 
         Raises:
-            ValidationError: the component could not be built from its input
             ConflictError: the component collided on insert
         """
-        indexed_successes, failures = await self.insert_many(components=[component], session=session)
+        indexed_successes, failures = await self.insert_many([document], session=session)
         if failures:
-            failure = failures[0]
-            if failure.error_code == ValidationError.error_code:
-                raise ValidationError(failure.message)
-            raise ConflictError(failure.message)
+            raise ConflictError(failures[0].message)
         return indexed_successes[0][1]
 
     async def delete_many(

--- a/mpcontribs-api/src/mpcontribs_api/domains/_shared/components.py
+++ b/mpcontribs-api/src/mpcontribs_api/domains/_shared/components.py
@@ -33,12 +33,16 @@ class MongoDbComponentsRepository[
         ).to_list()
         return {doc.md5: doc for doc in existing_docs}
 
-    async def insert_many(
+    async def insert_many(  # pyright: ignore[reportIncompatibleMethodOverride]
         self,
         components: list[TIn],
         session: AsyncClientSession | None = None,
     ) -> list[TDoc]:
         """Bulk-insert components, deduplicated by server-computed content hash.
+
+        Components are content-addressed: unlike the base document-in ``insert_many``, this override
+        stays input-in because the repository must build each document to compute and dedup its
+        server-owned ``md5`` (the client never supplies it). See ``Component.from_input``.
 
         Each input is built into a full document via ``Component.from_input``, which assigns a fresh
         id and computes ``md5`` from the content (the client never supplies it). Inputs are

--- a/mpcontribs-api/src/mpcontribs_api/domains/_shared/repository.py
+++ b/mpcontribs-api/src/mpcontribs_api/domains/_shared/repository.py
@@ -3,10 +3,10 @@ import hashlib
 import io
 import json
 import zlib
-from abc import ABC, abstractmethod
+from abc import ABC
 from collections.abc import AsyncIterable, AsyncIterator, Callable, Iterable
 from contextlib import AbstractAsyncContextManager
-from typing import Any
+from typing import Any, ClassVar
 
 from beanie import PydanticObjectId, UpdateResponse
 from beanie.operators import In, Set
@@ -22,6 +22,7 @@ from mpcontribs_api.domains._shared.models import BaseDocumentWithInput, DeleteR
 from mpcontribs_api.domains._shared.types import DownloadFormat, ShortMimeFormat
 from mpcontribs_api.exceptions import ConflictError, DownloadError, NotFoundError, ValidationError
 from mpcontribs_api.pagination import CursorParams, Page, encode_cursor
+from mpcontribs_api.scope import Scope
 
 
 class MongoDbRepository[
@@ -34,21 +35,22 @@ class MongoDbRepository[
     """Base repository encapsulating shared MongoDB access patterns.
 
     Subclasses bind the document, input, output, filter, and patch types as type parameters, set
-    the matching ``document_model`` / ``out_model`` class attributes, and implement ``_build_scope``
-    to enforce per-user authorization. Shared CRUD logic (scoping, projection, cursor pagination,
-    insertion, single-document read/patch/delete) lives here so it exists in exactly one place and
-    cannot drift between resources. Subclasses expose domain-named methods that either forward to a
-    base method (vocabulary + concrete types for routers, no logic) or implement a genuinely
-    different shape (bulk insert, compound-key upsert, download).
+    the matching ``document_model`` / ``out_model`` class attributes, and declare a ``read_scope``
+    that defines per-user visibility. Shared CRUD logic lives here. Subclasses implement domain-specific
+    logic for access when required.
 
     Attributes:
         document_model: the ``BaseDocumentWithInput`` subclass this repository operates on
         out_model: the ``SparseFieldsModel`` subclass used to build projections for reads
-        _scope (dict[str, Any]): terms injected into every query to enforce user authorization
+        read_scope: the :class:`Scope` (composition of visibility clauses) this repository applies to
+            every read; the repo declares it, the base applies it — the repo never authors the rule
+        _scope (dict[str, Any]): terms injected into every query to enforce user authorization,
+            computed once from ``read_scope`` at construction time
     """
 
     document_model: type[TDoc]
     out_model: type[TOut]
+    read_scope: ClassVar[Scope]
 
     def __init__(self, user: User) -> None:
         """Initializes an instance based on the current user.
@@ -57,13 +59,7 @@ class MongoDbRepository[
             user (User): the current user requesting resources
         """
         self._user = user
-        self._scope = self._build_scope(user)
-
-    @staticmethod
-    @abstractmethod
-    def _build_scope(user: User) -> dict[str, Any]:
-        """Provides scope based on current user's permitted groups and publicly released data."""
-        ...
+        self._scope = self.read_scope.query(user)
 
     def _convert_object_id(self, id: str) -> PydanticObjectId:
         """Converts the string representation of an ObjectId to an ObjectId"""

--- a/mpcontribs-api/src/mpcontribs_api/domains/_shared/repository.py
+++ b/mpcontribs-api/src/mpcontribs_api/domains/_shared/repository.py
@@ -195,6 +195,35 @@ class MongoDbRepository[
         """
         return await self.document_model.insert_many(documents, ordered=False, session=session)
 
+    async def upsert_one(self, document: TDoc, session: AsyncClientSession | None = None) -> TDoc:
+        """Insert ``document`` or replace the existing one with the same ``_id`` (PUT semantics).
+
+        Domains whose upsert key is a compound identity rather than ``_id`` (e.g. contributions) override this.
+
+        Args:
+            document (TDoc): the fully-built document to persist
+            session (AsyncClientSession | None): optional client session for transactions
+        """
+        try:
+            return await document.save(session=session)
+        except DuplicateKeyError as exc:
+            raise ConflictError(
+                f"Cannot upsert {self.document_model.__name__}: a conflicting document already exists",
+                identifiers=document.identifiers(),
+            ) from exc
+
+    async def upsert_many(self, documents: list[TDoc], session: AsyncClientSession | None = None) -> list[TDoc]:
+        """Upsert each document by its ``_id`` (see :meth:`upsert_one`).
+
+        Sequential by default. Domains needing per-item failure reporting or bounded concurrency
+        (e.g. contributions) orchestrate that in their service rather than overriding here.
+
+        Args:
+            documents (list[TDoc]): the fully-built documents to persist
+            session (AsyncClientSession | None): optional client session for transactions
+        """
+        return [await self.upsert_one(document, session=session) for document in documents]
+
     async def delete_many(self, filter: TFilter, session: AsyncClientSession | None = None) -> DeleteResponse:
         """Delete every scoped document matching an arbitrary ``filter``.
 

--- a/mpcontribs-api/src/mpcontribs_api/domains/_shared/repository.py
+++ b/mpcontribs-api/src/mpcontribs_api/domains/_shared/repository.py
@@ -88,7 +88,7 @@ class MongoDbRepository[
             return {**identifiers, "id": self._convert_object_id(id)}
         return identifiers
 
-    async def get_many(
+    async def read_many(
         self,
         filter: TFilter,
         fields: frozenset[str] | None = None,
@@ -144,7 +144,7 @@ class MongoDbRepository[
             )
         return {("_id" if key == "id" else key): value for key, value in identifiers.items()}
 
-    async def get_one(
+    async def read_one(
         self,
         identifiers: dict[str, Any],
         fields: frozenset[str] | None = None,
@@ -300,7 +300,7 @@ class MongoDbRepository[
             raise NotFoundError(f"{self.document_model.__name__} not found", identifiers=identifiers)
         return DeleteResponse.from_delete_result(result)
 
-    def _patch_update_fields(self, update: TPatch) -> dict[str, Any]:
+    def _update_fields(self, update: TPatch) -> dict[str, Any]:
         """Map a patch model to the MongoDB ``$set`` field dict.
 
         Defaults to the patch's set fields (``exclude_unset``), which replaces each named field
@@ -309,7 +309,7 @@ class MongoDbRepository[
         """
         return update.model_dump(exclude_unset=True)
 
-    async def _patch_matching(
+    async def _update_matching(
         self,
         match: Any,
         update: TPatch,
@@ -327,7 +327,7 @@ class MongoDbRepository[
         ``$set`` after the patch dump, so a non-empty ``extra_set`` also makes the update non-empty.
         """
         # Only retain set fields (patch)
-        update_data = self._patch_update_fields(update)
+        update_data = self._update_fields(update)
         if extra_set:
             update_data |= extra_set
         existing = await self.document_model.find_one(self._scope, match, session=session)
@@ -357,7 +357,7 @@ class MongoDbRepository[
             raise not_found
         return updated
 
-    async def patch_one(
+    async def update_one(
         self,
         identifiers: dict[str, Any],
         update: TPatch,
@@ -375,7 +375,7 @@ class MongoDbRepository[
         """
         query = self._identifier_query(identifiers)
         not_found = NotFoundError(f"{self.document_model.__name__} not found", identifiers=identifiers)
-        return await self._patch_matching(query, update, not_found, session=session, extra_set=extra_set)
+        return await self._update_matching(query, update, not_found, session=session, extra_set=extra_set)
 
     def _hash_payload(self, payload: dict[str, Any], *, separators: tuple[str, str] = (",", ":")) -> str:
         canonical = json.dumps(

--- a/mpcontribs-api/src/mpcontribs_api/domains/_shared/repository.py
+++ b/mpcontribs-api/src/mpcontribs_api/domains/_shared/repository.py
@@ -89,6 +89,7 @@ class MongoDbRepository[
         fields: frozenset[str] | None = None,
         pagination: CursorParams | None = None,
         restrict_ids: Iterable[Any] | None = None,
+        session: AsyncClientSession | None = None,
     ) -> Page[TOut]:
         """Return a scoped, filtered, cursor-paginated page of projected documents.
 
@@ -99,11 +100,12 @@ class MongoDbRepository[
             restrict_ids (Iterable | None): when provided, results are limited to these ids in
                 addition to the user scope. An empty iterable yields an empty page. Used to gate
                 reads that are authorized indirectly (e.g. components reachable via a contribution).
+            session (AsyncClientSession | None): optional client session for transactions
         """
         pagination = pagination or CursorParams()
 
         projection = self.out_model.projection(fields)
-        query = filter.filter(self.document_model.find(self._scope))
+        query = filter.filter(self.document_model.find(self._scope, session=session))
         if restrict_ids is not None:
             query = query.find(In(self.document_model.id, list(restrict_ids)))
         if pagination.cursor is not None:
@@ -140,16 +142,18 @@ class MongoDbRepository[
         self,
         identifiers: dict[str, Any],
         fields: frozenset[str] | None = None,
+        session: AsyncClientSession | None = None,
     ) -> TOut | None:
         """Return the single scoped document matching ``identifiers``, projected to ``fields``.
 
         Args:
             identifiers (dict[str, Any]): identifier field values keyed by ``identifier_fields``
             fields (frozenset[str] | None): fields to project; if None the full document is returned
+            session (AsyncClientSession | None): optional client session for transactions
         """
         query = self._identifier_query(identifiers)
         projection = self.out_model.projection(fields)
-        return await self.document_model.find_one(self._scope, query, projection_model=projection)  # pyright: ignore[reportArgumentType]
+        return await self.document_model.find_one(self._scope, query, projection_model=projection, session=session)  # pyright: ignore[reportArgumentType]
 
     async def list_ids(self, filter: TFilter, session: AsyncClientSession | None = None) -> list[Any]:
         """Return just the ids of scoped documents matching ``filter``.
@@ -166,23 +170,30 @@ class MongoDbRepository[
         docs = await query.project(projection).to_list()
         return [doc.id for doc in docs]
 
-    async def insert_one(self, in_resource: TIn) -> TDoc:
-        """Insert a new document built from its input model, rejecting an existing duplicate.
-
-        Duplicates are determined by model-declared identifiers that uniquely identify a document.
+    async def insert_one(self, document: TDoc, session: AsyncClientSession | None = None) -> TDoc:
+        """Persist a fully-built document, rejecting an existing duplicate.
 
         Args:
-            in_resource (TIn): the validated input payload to translate and store
+            document (TDoc): the stored document to insert
+            session (AsyncClientSession | None): optional client session for transactions
         """
-        document = self.document_model.from_input_model(in_resource)
         try:
-            await document.insert()
+            await document.insert(session=session)
         except DuplicateKeyError as exc:
             raise ConflictError(
                 f"Cannot insert {self.document_model.__name__}: a conflicting document already exists",
                 identifiers=document.identifiers(),
             ) from exc
         return document
+
+    async def insert_many(self, documents: list[TDoc], session: AsyncClientSession | None = None) -> Any:
+        """Bulk-insert fully-built documents in one round-trip.
+
+        Args:
+            documents (list[TDoc]): the stored documents to insert
+            session (AsyncClientSession | None): optional client session for transactions
+        """
+        return await self.document_model.insert_many(documents, ordered=False, session=session)
 
     async def delete_many(self, filter: TFilter, session: AsyncClientSession | None = None) -> DeleteResponse:
         """Delete every scoped document matching an arbitrary ``filter``.
@@ -361,6 +372,7 @@ class MongoDbRepository[
         bucket_name: str,
         key_name: str,
         restrict_ids: Iterable[Any] | None = None,
+        session: AsyncClientSession | None = None,
     ) -> AsyncIterable[bytes]:
         # Hash parameters to generate key for cache
         payload = {
@@ -375,7 +387,7 @@ class MongoDbRepository[
         # self._s3_object_exists(...)` and stream the cached object on a hit.
 
         # Build from MongoDB (and, in future, save to cache)
-        query = filter.filter(self.document_model.find(self._scope))
+        query = filter.filter(self.document_model.find(self._scope, session=session))
         if restrict_ids is not None:
             query = query.find(In(self.document_model.id, list(restrict_ids)))
         query = filter.sort(query)

--- a/mpcontribs-api/src/mpcontribs_api/domains/_shared/repository.py
+++ b/mpcontribs-api/src/mpcontribs_api/domains/_shared/repository.py
@@ -1,3 +1,4 @@
+import asyncio
 import csv
 import hashlib
 import io
@@ -8,6 +9,7 @@ from collections.abc import AsyncIterable, AsyncIterator, Callable, Iterable, Ma
 from contextlib import AbstractAsyncContextManager
 from typing import Any, ClassVar
 
+import structlog
 from beanie import PydanticObjectId, UpdateResponse
 from beanie.operators import In, Set
 from bson.errors import InvalidId
@@ -18,11 +20,15 @@ from pymongo.errors import DuplicateKeyError
 from types_aiobotocore_s3 import S3Client
 
 from mpcontribs_api.authz import User
+from mpcontribs_api.config import get_settings
+from mpcontribs_api.domains._shared.bulk import BulkFailure, BulkWriteSummary, bulk_failure_from_exception
 from mpcontribs_api.domains._shared.models import BaseDocumentWithInput, DeleteResponse, DocumentOut
 from mpcontribs_api.domains._shared.types import DownloadFormat, ShortMimeFormat
 from mpcontribs_api.exceptions import ConflictError, DownloadError, NotFoundError, ValidationError
 from mpcontribs_api.pagination import CursorParams, Page, encode_cursor
 from mpcontribs_api.scope import Scope
+
+logger = structlog.get_logger(__name__)
 
 
 class MongoDbRepository[
@@ -227,17 +233,43 @@ class MongoDbRepository[
                 identifiers=document.identifiers(),
             ) from exc
 
-    async def upsert_many(self, documents: list[TDoc], session: AsyncClientSession | None = None) -> list[TDoc]:
-        """Upsert each document by its ``_id`` (see :meth:`upsert_one`).
+    async def upsert_many(self, documents: list[TDoc]) -> BulkWriteSummary[TDoc]:
+        """Upsert each document by its ``_id`` concurrently, reporting per-item outcomes.
 
-        Sequential by default. Domains needing per-item failure reporting or bounded concurrency
-        (e.g. contributions) orchestrate that in their service rather than overriding here.
+        Each upsert is atomic. Failures are reported in 'failed', while the rest are committed.
+
+        There is no ``session`` parameter: a MongoDB session/transaction cannot be shared across
+        concurrent operations (pymongo sessions are not concurrency-safe). Callers that need an
+        all-or-nothing transactional upsert must orchestrate it themselves.
 
         Args:
             documents (list[TDoc]): the fully-built documents to persist
-            session (AsyncClientSession | None): optional client session for transactions
+
+        Returns:
+            BulkWriteSummary[TDoc]: per-item outcome, sized to ``len(documents)``
         """
-        return [await self.upsert_one(document, session=session) for document in documents]
+        if not documents:
+            return BulkWriteSummary[TDoc](total=0, succeeded=[], failed=[])
+
+        sem = asyncio.Semaphore(get_settings().mongo.max_concurrent_transactions)
+
+        async def _bounded_upsert(index: int, document: TDoc) -> TDoc | BulkFailure:
+            async with sem:
+                try:
+                    return await self.upsert_one(document)
+                except Exception as exc:
+                    logger.error(
+                        "upsert_document_failed",
+                        index=index,
+                        identifier=document.identifiers(),
+                        exc_info=True,
+                    )
+                    return bulk_failure_from_exception(index, document.identifiers(), exc)
+
+        results = await asyncio.gather(*[_bounded_upsert(i, doc) for i, doc in enumerate(documents)])
+        succeeded = [r for r in results if not isinstance(r, BulkFailure)]
+        failed = [r for r in results if isinstance(r, BulkFailure)]
+        return BulkWriteSummary[TDoc](total=len(documents), succeeded=succeeded, failed=failed)
 
     async def delete_many(self, filter: TFilter, session: AsyncClientSession | None = None) -> DeleteResponse:
         """Delete every scoped document matching an arbitrary ``filter``.

--- a/mpcontribs-api/src/mpcontribs_api/domains/_shared/repository.py
+++ b/mpcontribs-api/src/mpcontribs_api/domains/_shared/repository.py
@@ -134,6 +134,7 @@ class MongoDbRepository[
             identifiers (dict[str, Any]): identifier field values keyed by ``identifier_fields``,
                 or ``{"id": <primary key>}``
         """
+        identifiers = self.coerce_identifiers(identifiers)
         expected = self.document_model.identifier_fields()
         if identifiers.keys() != expected and identifiers.keys() != {"id"}:
             raise ValidationError(

--- a/mpcontribs-api/src/mpcontribs_api/domains/_shared/repository.py
+++ b/mpcontribs-api/src/mpcontribs_api/domains/_shared/repository.py
@@ -4,7 +4,7 @@ import io
 import json
 import zlib
 from abc import ABC
-from collections.abc import AsyncIterable, AsyncIterator, Callable, Iterable
+from collections.abc import AsyncIterable, AsyncIterator, Callable, Iterable, Mapping
 from contextlib import AbstractAsyncContextManager
 from typing import Any, ClassVar
 
@@ -168,6 +168,22 @@ class MongoDbRepository[
         query = filter.filter(self.document_model.find(self._scope, session=session))
         docs = await query.project(projection).to_list()
         return [doc.id for doc in docs]
+
+    async def count_matching(self, query: Mapping[str, Any], *, scoped: bool) -> int:
+        """Count documents matching a raw Mongo ``query``.
+
+        Raw pymongo ``count_documents`` is used (rather than Beanie's ``find(...).count()``) so any
+        query shape is expressible — dotted keys (``initiative.$id``), operators (``$ne``, ``$and``).
+
+        Args:
+            query (Mapping[str, Any]): the Mongo filter to count against
+            scoped (bool): when ``True`` the user read scope is merged in; when ``False`` the count
+                spans every document (system/integrity count)
+        """
+        match: dict[str, Any] = dict(query)
+        if scoped and self._scope:
+            match = {"$and": [self._scope, match]}
+        return await self.document_model.get_pymongo_collection().count_documents(match)
 
     async def insert_one(self, document: TDoc, session: AsyncClientSession | None = None) -> TDoc:
         """Persist a fully-built document, rejecting an existing duplicate.

--- a/mpcontribs-api/src/mpcontribs_api/domains/_shared/repository.py
+++ b/mpcontribs-api/src/mpcontribs_api/domains/_shared/repository.py
@@ -62,7 +62,7 @@ class MongoDbRepository[
 
         The repository holds no reference to the ``User`` itself — it is a query/persistence toolbox
         that makes no authorization decisions. Only the derived read scope (``_scope``) is retained;
-        all policy lives in the services. See the module docstring.
+        all policy lives in the services.
 
         Args:
             user (User): the current user, used once to compute the read scope

--- a/mpcontribs-api/src/mpcontribs_api/domains/_shared/repository.py
+++ b/mpcontribs-api/src/mpcontribs_api/domains/_shared/repository.py
@@ -53,12 +53,15 @@ class MongoDbRepository[
     read_scope: ClassVar[Scope]
 
     def __init__(self, user: User) -> None:
-        """Initializes an instance based on the current user.
+        """Initialize the repository's user scope.
+
+        The repository holds no reference to the ``User`` itself — it is a query/persistence toolbox
+        that makes no authorization decisions. Only the derived read scope (``_scope``) is retained;
+        all policy lives in the services. See the module docstring.
 
         Args:
-            user (User): the current user requesting resources
+            user (User): the current user, used once to compute the read scope
         """
-        self._user = user
         self._scope = self.read_scope.query(user)
 
     def _convert_object_id(self, id: str) -> PydanticObjectId:

--- a/mpcontribs-api/src/mpcontribs_api/domains/_shared/repository.py
+++ b/mpcontribs-api/src/mpcontribs_api/domains/_shared/repository.py
@@ -36,8 +36,7 @@ class MongoDbRepository[
 
     Subclasses bind the document, input, output, filter, and patch types as type parameters, set
     the matching ``document_model`` / ``out_model`` class attributes, and declare a ``read_scope``
-    that defines per-user visibility. Shared CRUD logic lives here. Subclasses implement domain-specific
-    logic for access when required.
+    that defines per-user visibility. Subclasses implement domain-specific logic for access when required.
 
     Attributes:
         document_model: the ``BaseDocumentWithInput`` subclass this repository operates on
@@ -227,10 +226,6 @@ class MongoDbRepository[
     async def delete_many(self, filter: TFilter, session: AsyncClientSession | None = None) -> DeleteResponse:
         """Delete every scoped document matching an arbitrary ``filter``.
 
-        This is the bulk path (e.g. "delete every ProjectGroup with owner == X"). It does not raise
-        on an empty match — a zero count is a valid, unambiguous outcome for a filter delete. Scoping
-        ensures callers cannot delete documents they are not permitted to see.
-
         Args:
             filter (TFilter): the fastapi-filter query to apply on top of the user scope
             session (AsyncClientSession | None): optional client session for transactions
@@ -305,11 +300,10 @@ class MongoDbRepository[
         # Otherwise, update the fields fully (set)
         # Brendan TODO: Set will replace an entire field
         # - if we want to append to a list (ie. add a reference) we ned Push/AddToSet
-        query = self.document_model.find_one(self._scope, match, session=session).update(
+        updated = await self.document_model.find_one(self._scope, match, session=session).update(  # pyright: ignore[reportGeneralTypeIssues] # beanie UpdateQuery is awaitable, but pyright doesn't see it
             Set(update_data),
             response_type=UpdateResponse.NEW_DOCUMENT,
         )
-        updated = await query  # pyright: ignore[reportGeneralTypeIssues] # beanie UpdateQuery is awaitable, but pyright doesn't see it
         if updated is None:
             raise not_found
         return updated

--- a/mpcontribs-api/src/mpcontribs_api/domains/_shared/service.py
+++ b/mpcontribs-api/src/mpcontribs_api/domains/_shared/service.py
@@ -75,8 +75,6 @@ class ComponentService[
 
     async def _resolve_component_id(self, identifiers: dict[str, Any]) -> PydanticObjectId | None:
         """Return the component ``_id`` after finding it via identifiers, or None if absent."""
-        if "id" in identifiers:
-            return identifiers["id"]
         existing = await self._components.get_one(identifiers, frozenset({"id"}))
         return existing.id if existing is not None else None
 
@@ -86,7 +84,6 @@ class ComponentService[
         Returns ``None``  when no in-scope contribution references the component.
         Accepts either the bare ``{"id": ...}`` form or the content-hash ``{"md5": ...}`` form.
         """
-        identifiers = self._components.coerce_identifiers(identifiers)
         oid = await self._resolve_component_id(identifiers)
         if oid is None or not await self._contributions.referenced_component_ids(self._ref_field, [oid], scoped=True):
             return None
@@ -111,7 +108,6 @@ class ComponentService[
         Raises:
             NotFoundError: when no in-scope contribution references the component
         """
-        identifiers = self._components.coerce_identifiers(identifiers)
         oid = await self._resolve_component_id(identifiers)
         if oid is None or not await self._contributions.referenced_component_ids(self._ref_field, [oid], scoped=True):
             raise NotFoundError(f"{self._components.document_model.__name__} not found", **identifiers)
@@ -181,7 +177,6 @@ class ComponentService[
         Raises:
             NotFoundError: if the component is not reachable via any in-scope contribution
         """
-        identifiers = self._components.coerce_identifiers(identifiers)
         oid = await self._resolve_component_id(identifiers)
         if oid is None or not await self._contributions.referenced_component_ids(self._ref_field, [oid], scoped=True):
             raise NotFoundError(f"{self._components.document_model.__name__} not found", **identifiers)

--- a/mpcontribs-api/src/mpcontribs_api/domains/_shared/service.py
+++ b/mpcontribs-api/src/mpcontribs_api/domains/_shared/service.py
@@ -5,10 +5,11 @@ from typing import Any
 from beanie import PydanticObjectId
 from fastapi_filter.contrib.beanie import Filter
 from pydantic import BaseModel
+from pydantic import ValidationError as PydanticValidationError
 from pymongo.asynchronous.client_session import AsyncClientSession
 from types_aiobotocore_s3 import S3Client
 
-from mpcontribs_api.domains._shared.bulk import BulkWriteSummary
+from mpcontribs_api.domains._shared.bulk import BulkFailure, BulkWriteSummary, bulk_failure_from_exception
 from mpcontribs_api.domains._shared.components import MongoDbComponentsRepository
 from mpcontribs_api.domains._shared.models import Component, ComponentDeleteResponse, ComponentIn, DocumentOut
 from mpcontribs_api.domains._shared.types import DownloadFormat, ShortMimeFormat
@@ -95,8 +96,31 @@ class ComponentService[
         session: AsyncClientSession | None = None,
     ) -> BulkWriteSummary[TDoc]:
         """Bulk-insert components (deduplicated by content hash), reporting per-item outcomes."""
-        indexed_successes, failures = await self._components.insert_many(components=components, session=session)
-        succeeded = [doc for _, doc in sorted(indexed_successes, key=lambda pair: pair[0])]
+        build_failures: list[BulkFailure] = []
+        origins: list[int] = []  # original input index for each successfully built document
+        docs: list[TDoc] = []
+        for index, comp in enumerate(components):
+            identifier = {"name": getattr(comp, "name", None)}
+            try:
+                docs.append(self._components.document_model.from_input(comp))
+            except PydanticValidationError as exc:
+                build_failures.append(
+                    BulkFailure(index=index, identifier=identifier, error_code="validation_error", message=str(exc))
+                )
+                continue
+            except Exception as exc:
+                build_failures.append(bulk_failure_from_exception(index, identifier, exc))
+                continue
+            origins.append(index)
+
+        indexed_successes, insert_failures = await self._components.insert_many(docs, session=session)
+        # Repository indices are positions in ``docs``; map them back to the original input positions.
+        successes = [(origins[position], doc) for position, doc in indexed_successes]
+        failures = build_failures + [
+            failure.model_copy(update={"index": origins[failure.index]}) for failure in insert_failures
+        ]
+
+        succeeded = [doc for _, doc in sorted(successes, key=lambda pair: pair[0])]
         failed = sorted(failures, key=lambda failure: failure.index)
         return BulkWriteSummary[TDoc](total=len(components), succeeded=succeeded, failed=failed)
 

--- a/mpcontribs-api/src/mpcontribs_api/domains/_shared/service.py
+++ b/mpcontribs-api/src/mpcontribs_api/domains/_shared/service.py
@@ -8,6 +8,7 @@ from pydantic import BaseModel
 from pymongo.asynchronous.client_session import AsyncClientSession
 from types_aiobotocore_s3 import S3Client
 
+from mpcontribs_api.domains._shared.bulk import BulkWriteSummary
 from mpcontribs_api.domains._shared.components import MongoDbComponentsRepository
 from mpcontribs_api.domains._shared.models import Component, ComponentDeleteResponse, ComponentIn, DocumentOut
 from mpcontribs_api.domains._shared.types import DownloadFormat, ShortMimeFormat
@@ -95,9 +96,12 @@ class ComponentService[
         self,
         components: list[TIn],
         session: AsyncClientSession | None = None,
-    ) -> list[TDoc]:
-        """Bulk-insert components, deduplicated by content hash. See repository ``insert_many``."""
-        return await self._components.insert_many(components=components, session=session)
+    ) -> BulkWriteSummary[TDoc]:
+        """Bulk-insert components (deduplicated by content hash), reporting per-item outcomes."""
+        indexed_successes, failures = await self._components.insert_many(components=components, session=session)
+        succeeded = [doc for _, doc in sorted(indexed_successes, key=lambda pair: pair[0])]
+        failed = sorted(failures, key=lambda failure: failure.index)
+        return BulkWriteSummary[TDoc](total=len(components), succeeded=succeeded, failed=failed)
 
     async def patch_one(self, identifiers: dict[str, Any], update: TPatch) -> TDoc:
         """Partially update a component matching ``identifiers``, gated by contribution reachability.

--- a/mpcontribs-api/src/mpcontribs_api/domains/_shared/service.py
+++ b/mpcontribs-api/src/mpcontribs_api/domains/_shared/service.py
@@ -57,7 +57,7 @@ class ComponentService[
         self._ref_field = ref_field
         self._bucket_name = bucket_name or ref_field
 
-    async def get_many(
+    async def read_many(
         self,
         filter: TFilter,
         pagination: CursorParams,
@@ -70,16 +70,16 @@ class ComponentService[
         allowed to see
         """
         allowed = await self._contributions.referenced_component_ids(self._ref_field, scoped=True)
-        return await self._components.get_many(
+        return await self._components.read_many(
             pagination=pagination, filter=filter, fields=fields, restrict_ids=allowed
         )
 
     async def _resolve_component_id(self, identifiers: dict[str, Any]) -> PydanticObjectId | None:
         """Return the component ``_id`` after finding it via identifiers, or None if absent."""
-        existing = await self._components.get_one(identifiers, frozenset({"id"}))
+        existing = await self._components.read_one(identifiers, frozenset({"id"}))
         return existing.id if existing is not None else None
 
-    async def get_one(self, identifiers: dict[str, Any], fields: frozenset[str] | None) -> TDoc | TOut | None:
+    async def read_one(self, identifiers: dict[str, Any], fields: frozenset[str] | None) -> TDoc | TOut | None:
         """Find a single component matching ``identifiers``, gated by contribution reachability.
 
         Returns ``None``  when no in-scope contribution references the component.
@@ -88,7 +88,7 @@ class ComponentService[
         oid = await self._resolve_component_id(identifiers)
         if oid is None or not await self._contributions.referenced_component_ids(self._ref_field, [oid], scoped=True):
             return None
-        return await self._components.get_one(identifiers, fields)
+        return await self._components.read_one(identifiers, fields)
 
     async def insert_many(
         self,
@@ -124,7 +124,7 @@ class ComponentService[
         failed = sorted(failures, key=lambda failure: failure.index)
         return BulkWriteSummary[TDoc](total=len(components), succeeded=succeeded, failed=failed)
 
-    async def patch_one(self, identifiers: dict[str, Any], update: TPatch) -> TDoc:
+    async def update_one(self, identifiers: dict[str, Any], update: TPatch) -> TDoc:
         """Partially update a component matching ``identifiers``, gated by contribution reachability.
 
         Accepts either the bare ``{"id": ...}`` form or the content-hash ``{"md5": ...}`` form.
@@ -135,7 +135,7 @@ class ComponentService[
         oid = await self._resolve_component_id(identifiers)
         if oid is None or not await self._contributions.referenced_component_ids(self._ref_field, [oid], scoped=True):
             raise NotFoundError(f"{self._components.document_model.__name__} not found", **identifiers)
-        return await self._components.patch_one(identifiers, update)
+        return await self._components.update_one(identifiers, update)
 
     async def download(
         self,

--- a/mpcontribs-api/src/mpcontribs_api/domains/attachments/router.py
+++ b/mpcontribs-api/src/mpcontribs_api/domains/attachments/router.py
@@ -20,25 +20,25 @@ router = APIRouter()
 
 
 @router.get("")
-async def get_attachments(
+async def read_many(
     service: AttachmentServiceDep,
     pagination: Annotated[CursorParams, Depends()],
     filter: AttachmentFilter = FilterDepends(AttachmentFilter),
     fields: FieldSelector = None,
 ):
     selected = AttachmentOut.parse_fields(fields)
-    return await service.get_many(filter=filter, fields=selected, pagination=pagination)
+    return await service.read_many(filter=filter, fields=selected, pagination=pagination)
 
 
 @router.get("/{id}")
-async def get_one(
+async def read_one(
     service: AttachmentServiceDep,
     id: str,
     fields: FieldSelector = None,
 ):
     """Return a single attachment addressed by its ``_id``."""
     selected = AttachmentOut.parse_fields(fields)
-    return await service.get_one(identifiers={"id": id}, fields=selected)
+    return await service.read_one(identifiers={"id": id}, fields=selected)
 
 
 @router.get("/download/{short_mime}")
@@ -69,7 +69,7 @@ async def download_attachment(
 
 
 @router.delete("", response_model=ComponentDeleteResponse, dependencies=[Depends(require_user)])
-async def delete_attachments(service: AttachmentServiceDep, filter: AttachmentFilter = FilterDepends(AttachmentFilter)):
+async def delete_many(service: AttachmentServiceDep, filter: AttachmentFilter = FilterDepends(AttachmentFilter)):
     return await service.delete_many(filter=filter)
 
 
@@ -80,10 +80,10 @@ async def delete_one(service: AttachmentServiceDep, id: str):
 
 
 @router.patch("/{id}", dependencies=[Depends(require_user)])
-async def patch_one(
+async def update_one(
     service: AttachmentServiceDep,
     id: str,
     update: AttachmentPatch,
 ):
     """Patch a single attachment addressed by its ``_id`` or its content ``md5``."""
-    return await service.patch_one(identifiers={"id": id}, update=update)
+    return await service.update_one(identifiers={"id": id}, update=update)

--- a/mpcontribs-api/src/mpcontribs_api/domains/consumers/dependencies.py
+++ b/mpcontribs-api/src/mpcontribs_api/domains/consumers/dependencies.py
@@ -2,7 +2,7 @@ from typing import Annotated
 
 from fastapi import Depends
 
-from mpcontribs_api.dependencies import MongoClientDep, UserDep
+from mpcontribs_api.dependencies import UserDep
 from mpcontribs_api.domains.consumers.models import ConsumerSettings
 from mpcontribs_api.domains.consumers.repository import MongoDbConsumerRepository
 from mpcontribs_api.domains.consumers.service import ConsumerService
@@ -25,11 +25,8 @@ async def get_effective_limits(user: UserDep) -> ConsumerSettings:
 ConsumerLimitsDep = Annotated[ConsumerSettings, Depends(get_effective_limits)]
 
 
-def get_consumer_service(
-    user: UserDep,
-    client: MongoClientDep,
-) -> ConsumerService:
-    return ConsumerService(client=client, user=user, consumer=MongoDbConsumerRepository(user))
+def get_consumer_service(user: UserDep) -> ConsumerService:
+    return ConsumerService(consumer=MongoDbConsumerRepository(user))
 
 
 ConsumerServiceDep = Annotated[ConsumerService, Depends(get_consumer_service)]

--- a/mpcontribs-api/src/mpcontribs_api/domains/consumers/dependencies.py
+++ b/mpcontribs-api/src/mpcontribs_api/domains/consumers/dependencies.py
@@ -2,16 +2,10 @@ from typing import Annotated
 
 from fastapi import Depends
 
-from mpcontribs_api.dependencies import UserDep
+from mpcontribs_api.dependencies import MongoClientDep, UserDep
 from mpcontribs_api.domains.consumers.models import ConsumerSettings
 from mpcontribs_api.domains.consumers.repository import MongoDbConsumerRepository
-
-
-def get_scoped_consumers(user: UserDep) -> MongoDbConsumerRepository:
-    return MongoDbConsumerRepository(user)
-
-
-ConsumerDep = Annotated[MongoDbConsumerRepository, Depends(get_scoped_consumers)]
+from mpcontribs_api.domains.consumers.service import ConsumerService
 
 
 async def get_effective_limits(user: UserDep) -> ConsumerSettings:
@@ -29,3 +23,13 @@ async def get_effective_limits(user: UserDep) -> ConsumerSettings:
 
 
 ConsumerLimitsDep = Annotated[ConsumerSettings, Depends(get_effective_limits)]
+
+
+def get_consumer_service(
+    user: UserDep,
+    client: MongoClientDep,
+) -> ConsumerService:
+    return ConsumerService(client=client, user=user, consumer=MongoDbConsumerRepository(user))
+
+
+ConsumerServiceDep = Annotated[ConsumerService, Depends(get_consumer_service)]

--- a/mpcontribs-api/src/mpcontribs_api/domains/consumers/dependencies.py
+++ b/mpcontribs-api/src/mpcontribs_api/domains/consumers/dependencies.py
@@ -3,26 +3,8 @@ from typing import Annotated
 from fastapi import Depends
 
 from mpcontribs_api.dependencies import UserDep
-from mpcontribs_api.domains.consumers.models import ConsumerSettings
 from mpcontribs_api.domains.consumers.repository import MongoDbConsumerRepository
 from mpcontribs_api.domains.consumers.service import ConsumerService
-
-
-async def get_effective_limits(user: UserDep) -> ConsumerSettings:
-    """Resolve the settings in effect for the current caller.
-
-    Returns the ``settings`` of the caller's stored ``Consumer`` override if one exists, otherwise a
-    default ``ConsumerSettings`` (which fills from the env-backed global defaults). Callers with no
-    ``consumer_id`` (anonymous or dev) skip the lookup.
-    """
-    if user.consumer_id is None:
-        return ConsumerSettings()
-
-    override = await MongoDbConsumerRepository(user).get_one({"consumer_id": user.consumer_id})
-    return override.settings if override and override.settings else ConsumerSettings()
-
-
-ConsumerLimitsDep = Annotated[ConsumerSettings, Depends(get_effective_limits)]
 
 
 def get_consumer_service(user: UserDep) -> ConsumerService:

--- a/mpcontribs-api/src/mpcontribs_api/domains/consumers/repository.py
+++ b/mpcontribs-api/src/mpcontribs_api/domains/consumers/repository.py
@@ -24,7 +24,7 @@ class MongoDbConsumerRepository(MongoDbRepository[Consumer, ConsumerIn, Consumer
     # Admin-only resource (routes enforce ``require_admin``); no clauses → no visibility filter.
     read_scope = Scope()
 
-    def _patch_update_fields(self, update: ConsumerPatch) -> dict[str, Any]:
+    def _update_fields(self, update: ConsumerPatch) -> dict[str, Any]:
         """Flatten the patch to dotted ``settings.<field>`` keys.
 
         The limits live under a nested ``settings`` sub-document; dotting the update makes a partial

--- a/mpcontribs-api/src/mpcontribs_api/domains/consumers/repository.py
+++ b/mpcontribs-api/src/mpcontribs_api/domains/consumers/repository.py
@@ -1,6 +1,5 @@
 from typing import Any
 
-from mpcontribs_api.authz import User
 from mpcontribs_api.domains._shared.repository import MongoDbRepository
 from mpcontribs_api.domains.consumers.models import (
     Consumer,
@@ -9,25 +8,21 @@ from mpcontribs_api.domains.consumers.models import (
     ConsumerOut,
     ConsumerPatch,
 )
+from mpcontribs_api.scope import Scope
 
 
 class MongoDbConsumerRepository(MongoDbRepository[Consumer, ConsumerIn, ConsumerOut, ConsumerFilter, ConsumerPatch]):
     """Repository for admin-managed consumer overrides.
 
     Consumer overrides are an admin-only resource: every route that reaches this repository is
-    gated by ``require_admin``, so no per-user read scope is needed and ``_build_scope`` returns an
-    empty filter (admins see all overrides). Reads and deletes use the base repository directly
-    (keyed on ``consumer_id`` via ``Consumer.identifier_fields``); only the nested-``settings`` patch
-    shape is resource-specific.
+    gated by ``require_admin``, so no per-user read scope is needed and ``read_scope`` is
+    unrestricted (admins see all overrides). Only the nested-``settings`` patch shape is resource-specific.
     """
 
     document_model = Consumer
     out_model = ConsumerOut
-
-    @staticmethod
-    def _build_scope(user: User) -> dict[str, Any]:
-        # Admin-only resource (routes enforce ``require_admin``); no visibility filter required.
-        return {}
+    # Admin-only resource (routes enforce ``require_admin``); no clauses → no visibility filter.
+    read_scope = Scope()
 
     def _patch_update_fields(self, update: ConsumerPatch) -> dict[str, Any]:
         """Flatten the patch to dotted ``settings.<field>`` keys.

--- a/mpcontribs-api/src/mpcontribs_api/domains/consumers/router.py
+++ b/mpcontribs-api/src/mpcontribs_api/domains/consumers/router.py
@@ -21,7 +21,7 @@ router = APIRouter(dependencies=[Depends(require_admin)])
 
 
 @router.get("")
-async def get_many(
+async def read_many(
     service: ConsumerServiceDep,
     pagination: Annotated[CursorParams, Depends()],
     filter: ConsumerFilter = FilterDepends(ConsumerFilter),
@@ -29,18 +29,18 @@ async def get_many(
 ):
     """List consumer overrides (admin only)."""
     selected = ConsumerOut.parse_fields(fields)
-    return await service.get_many(filter=filter, pagination=pagination, fields=selected)
+    return await service.read_many(filter=filter, pagination=pagination, fields=selected)
 
 
 @router.get("/{id}")
-async def get_one(
+async def read_one(
     id: str,
     service: ConsumerServiceDep,
     fields: FieldSelector = None,
 ):
     """Get a single consumer override by document id (admin only)."""
     selected = ConsumerOut.parse_fields(fields)
-    return await service.get_one(id, fields=selected)
+    return await service.read_one(id, fields=selected)
 
 
 @router.post("", response_model=ConsumerOut, status_code=status.HTTP_201_CREATED)
@@ -53,13 +53,13 @@ async def insert_one(
 
 
 @router.patch("/{id}", response_model=ConsumerOut)
-async def patch_one(
+async def update_one(
     service: ConsumerServiceDep,
     id: str,
     update: ConsumerPatch,
 ):
     """Partially update a consumer override by document id (admin only)."""
-    return await service.patch_one(id, update)
+    return await service.update_one(id, update)
 
 
 @router.delete("/{id}", status_code=status.HTTP_204_NO_CONTENT)

--- a/mpcontribs-api/src/mpcontribs_api/domains/consumers/router.py
+++ b/mpcontribs-api/src/mpcontribs_api/domains/consumers/router.py
@@ -5,7 +5,7 @@ from fastapi_filter import FilterDepends
 
 from mpcontribs_api.dependencies import require_admin
 from mpcontribs_api.domains._shared.types import FieldSelector
-from mpcontribs_api.domains.consumers.dependencies import ConsumerDep
+from mpcontribs_api.domains.consumers.dependencies import ConsumerServiceDep
 from mpcontribs_api.domains.consumers.models import (
     ConsumerFilter,
     ConsumerIn,
@@ -21,56 +21,52 @@ router = APIRouter(dependencies=[Depends(require_admin)])
 
 
 @router.get("")
-async def get_consumers(
-    repo: ConsumerDep,
+async def get_many(
+    service: ConsumerServiceDep,
     pagination: Annotated[CursorParams, Depends()],
     filter: ConsumerFilter = FilterDepends(ConsumerFilter),
     fields: FieldSelector = None,
 ):
     """List consumer overrides (admin only)."""
-    if fields is None:
-        fields = list(ConsumerOut.default_fields())
     selected = ConsumerOut.parse_fields(fields)
-    return await repo.get_many(filter=filter, pagination=pagination, fields=selected)
+    return await service.get_many(filter=filter, pagination=pagination, fields=selected)
 
 
 @router.get("/{id}")
-async def get_consumer_by_id(
+async def get_one(
     id: str,
-    repo: ConsumerDep,
+    service: ConsumerServiceDep,
     fields: FieldSelector = None,
 ):
     """Get a single consumer override by document id (admin only)."""
-    if fields is None:
-        fields = list(ConsumerOut.default_fields())
     selected = ConsumerOut.parse_fields(fields)
-    return await repo.get_one(repo.coerce_identifiers({"id": id}), selected)
+    return await service.get_one(id, fields=selected)
 
 
 @router.post("", response_model=ConsumerOut, status_code=status.HTTP_201_CREATED)
-async def create_consumer(
-    repo: ConsumerDep,
+async def insert_one(
+    service: ConsumerServiceDep,
     consumer: ConsumerIn,
 ):
     """Create a new consumer override, rejecting a duplicate ``consumer_id`` with 409 (admin only)."""
-    return await repo.insert_one(consumer)
+    return await service.insert_one(consumer)
 
 
 @router.patch("/{id}", response_model=ConsumerOut)
-async def patch_consumer_by_id(
-    repo: ConsumerDep,
+async def patch_one(
+    service: ConsumerServiceDep,
     id: str,
     update: ConsumerPatch,
 ):
     """Partially update a consumer override by document id (admin only)."""
-    return await repo.patch_one(repo.coerce_identifiers({"id": id}), update)
+    return await service.patch_one(id, update)
 
 
 @router.delete("/{id}", status_code=status.HTTP_204_NO_CONTENT)
-async def delete_consumer_by_id(
-    repo: ConsumerDep,
+async def delete_one(
+    service: ConsumerServiceDep,
     id: str,
 ):
     """Delete a consumer override by document id (admin only)."""
-    await repo.delete_one(repo.coerce_identifiers({"id": id}))
+    await service.delete_one(id)
     return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/mpcontribs-api/src/mpcontribs_api/domains/consumers/service.py
+++ b/mpcontribs-api/src/mpcontribs_api/domains/consumers/service.py
@@ -23,23 +23,23 @@ class ConsumerService:
         """
         if consumer_id is None:
             return ConsumerSettings()
-        override = await self._consumer.get_one({"consumer_id": consumer_id}, fields=None)
+        override = await self._consumer.read_one({"consumer_id": consumer_id}, fields=None)
         return override.settings if override and override.settings else ConsumerSettings()
 
-    async def get_many(
+    async def read_many(
         self, filter: ConsumerFilter, pagination: CursorParams, fields: frozenset[str] | None
     ) -> Page[ConsumerOut]:
-        return await self._consumer.get_many(filter=filter, pagination=pagination, fields=fields)
+        return await self._consumer.read_many(filter=filter, pagination=pagination, fields=fields)
 
-    async def get_one(self, id: str, fields: frozenset[str] | None) -> ConsumerOut | None:
-        return await self._consumer.get_one(identifiers={"id": id}, fields=fields)
+    async def read_one(self, id: str, fields: frozenset[str] | None) -> ConsumerOut | None:
+        return await self._consumer.read_one(identifiers={"id": id}, fields=fields)
 
     async def insert_one(self, consumer: ConsumerIn) -> Consumer:
         document = self._consumer.document_model.from_input_model(consumer)
         return await self._consumer.insert_one(document)
 
-    async def patch_one(self, id: str, update: ConsumerPatch) -> Consumer:
-        return await self._consumer.patch_one(identifiers={"id": id}, update=update)
+    async def update_one(self, id: str, update: ConsumerPatch) -> Consumer:
+        return await self._consumer.update_one(identifiers={"id": id}, update=update)
 
     async def delete_one(self, id: str) -> None:
         await self._consumer.delete_one(identifiers={"id": id})

--- a/mpcontribs-api/src/mpcontribs_api/domains/consumers/service.py
+++ b/mpcontribs-api/src/mpcontribs_api/domains/consumers/service.py
@@ -1,4 +1,11 @@
-from mpcontribs_api.domains.consumers.models import Consumer, ConsumerFilter, ConsumerIn, ConsumerOut, ConsumerPatch
+from mpcontribs_api.domains.consumers.models import (
+    Consumer,
+    ConsumerFilter,
+    ConsumerIn,
+    ConsumerOut,
+    ConsumerPatch,
+    ConsumerSettings,
+)
 from mpcontribs_api.domains.consumers.repository import MongoDbConsumerRepository
 from mpcontribs_api.pagination import CursorParams, Page
 
@@ -6,6 +13,18 @@ from mpcontribs_api.pagination import CursorParams, Page
 class ConsumerService:
     def __init__(self, consumer: MongoDbConsumerRepository):
         self._consumer = consumer
+
+    async def effective_limits(self, consumer_id: str | None) -> ConsumerSettings:
+        """Resolve the settings in effect for a caller's Kong ``consumer_id``.
+
+        Returns the stored override's ``settings`` if one exists, otherwise a default
+        ``ConsumerSettings`` (which fills from the env-backed global defaults). A caller with no
+        ``consumer_id`` (anonymous/dev) skips the lookup entirely.
+        """
+        if consumer_id is None:
+            return ConsumerSettings()
+        override = await self._consumer.get_one({"consumer_id": consumer_id}, fields=None)
+        return override.settings if override and override.settings else ConsumerSettings()
 
     async def get_many(
         self, filter: ConsumerFilter, pagination: CursorParams, fields: frozenset[str] | None

--- a/mpcontribs-api/src/mpcontribs_api/domains/consumers/service.py
+++ b/mpcontribs-api/src/mpcontribs_api/domains/consumers/service.py
@@ -1,15 +1,10 @@
-from pymongo import AsyncMongoClient
-
-from mpcontribs_api.authz import User
 from mpcontribs_api.domains.consumers.models import Consumer, ConsumerFilter, ConsumerIn, ConsumerOut, ConsumerPatch
 from mpcontribs_api.domains.consumers.repository import MongoDbConsumerRepository
 from mpcontribs_api.pagination import CursorParams, Page
 
 
 class ConsumerService:
-    def __init__(self, client: AsyncMongoClient, user: User, consumer: MongoDbConsumerRepository):
-        self._client = client
-        self._user = user
+    def __init__(self, consumer: MongoDbConsumerRepository):
         self._consumer = consumer
 
     async def get_many(

--- a/mpcontribs-api/src/mpcontribs_api/domains/consumers/service.py
+++ b/mpcontribs-api/src/mpcontribs_api/domains/consumers/service.py
@@ -13,18 +13,14 @@ class ConsumerService:
         return await self._consumer.get_many(filter=filter, pagination=pagination, fields=fields)
 
     async def get_one(self, id: str, fields: frozenset[str] | None) -> ConsumerOut | None:
-        return await self._consumer.get_one(
-            identifiers=self._consumer.coerce_identifiers(identifiers={"id": id}), fields=fields
-        )
+        return await self._consumer.get_one(identifiers={"id": id}, fields=fields)
 
     async def insert_one(self, consumer: ConsumerIn) -> Consumer:
         document = self._consumer.document_model.from_input_model(consumer)
         return await self._consumer.insert_one(document)
 
     async def patch_one(self, id: str, update: ConsumerPatch) -> Consumer:
-        return await self._consumer.patch_one(
-            identifiers=self._consumer.coerce_identifiers(identifiers={"id": id}), update=update
-        )
+        return await self._consumer.patch_one(identifiers={"id": id}, update=update)
 
     async def delete_one(self, id: str) -> None:
-        await self._consumer.delete_one(identifiers=self._consumer.coerce_identifiers(identifiers={"id": id}))
+        await self._consumer.delete_one(identifiers={"id": id})

--- a/mpcontribs-api/src/mpcontribs_api/domains/consumers/service.py
+++ b/mpcontribs-api/src/mpcontribs_api/domains/consumers/service.py
@@ -23,7 +23,8 @@ class ConsumerService:
         )
 
     async def insert_one(self, consumer: ConsumerIn) -> Consumer:
-        return await self._consumer.insert_one(in_resource=consumer)
+        document = self._consumer.document_model.from_input_model(consumer)
+        return await self._consumer.insert_one(document)
 
     async def patch_one(self, id: str, update: ConsumerPatch) -> Consumer:
         return await self._consumer.patch_one(

--- a/mpcontribs-api/src/mpcontribs_api/domains/consumers/service.py
+++ b/mpcontribs-api/src/mpcontribs_api/domains/consumers/service.py
@@ -1,0 +1,34 @@
+from pymongo import AsyncMongoClient
+
+from mpcontribs_api.authz import User
+from mpcontribs_api.domains.consumers.models import Consumer, ConsumerFilter, ConsumerIn, ConsumerOut, ConsumerPatch
+from mpcontribs_api.domains.consumers.repository import MongoDbConsumerRepository
+from mpcontribs_api.pagination import CursorParams, Page
+
+
+class ConsumerService:
+    def __init__(self, client: AsyncMongoClient, user: User, consumer: MongoDbConsumerRepository):
+        self._client = client
+        self._user = user
+        self._consumer = consumer
+
+    async def get_many(
+        self, filter: ConsumerFilter, pagination: CursorParams, fields: frozenset[str] | None
+    ) -> Page[ConsumerOut]:
+        return await self._consumer.get_many(filter=filter, pagination=pagination, fields=fields)
+
+    async def get_one(self, id: str, fields: frozenset[str] | None) -> ConsumerOut | None:
+        return await self._consumer.get_one(
+            identifiers=self._consumer.coerce_identifiers(identifiers={"id": id}), fields=fields
+        )
+
+    async def insert_one(self, consumer: ConsumerIn) -> Consumer:
+        return await self._consumer.insert_one(in_resource=consumer)
+
+    async def patch_one(self, id: str, update: ConsumerPatch) -> Consumer:
+        return await self._consumer.patch_one(
+            identifiers=self._consumer.coerce_identifiers(identifiers={"id": id}), update=update
+        )
+
+    async def delete_one(self, id: str) -> None:
+        await self._consumer.delete_one(identifiers=self._consumer.coerce_identifiers(identifiers={"id": id}))

--- a/mpcontribs-api/src/mpcontribs_api/domains/contributions/dependencies.py
+++ b/mpcontribs-api/src/mpcontribs_api/domains/contributions/dependencies.py
@@ -4,7 +4,7 @@ from fastapi import Depends
 
 from mpcontribs_api.dependencies import MongoClientDep, UserDep
 from mpcontribs_api.domains.attachments.repository import MongoDbAttachmentRepository
-from mpcontribs_api.domains.consumers.dependencies import ConsumerLimitsDep
+from mpcontribs_api.domains.consumers.dependencies import ConsumerServiceDep
 from mpcontribs_api.domains.contributions.repository import (
     MongoDbContributionRepository,
 )
@@ -14,10 +14,10 @@ from mpcontribs_api.domains.structures.repository import MongoDbStructureReposit
 from mpcontribs_api.domains.tables.repository import MongoDbTableRepository
 
 
-def get_contribution_service(
+async def get_contribution_service(
     user: UserDep,
     client: MongoClientDep,
-    limits: ConsumerLimitsDep,
+    consumers: ConsumerServiceDep,
 ) -> ContributionService:
     return ContributionService(
         client=client,
@@ -27,7 +27,7 @@ def get_contribution_service(
         structures=MongoDbStructureRepository(user),
         attachments=MongoDbAttachmentRepository(user),
         tables=MongoDbTableRepository(user),
-        limits=limits,
+        limits=await consumers.effective_limits(user.consumer_id),
     )
 
 

--- a/mpcontribs-api/src/mpcontribs_api/domains/contributions/dependencies.py
+++ b/mpcontribs-api/src/mpcontribs_api/domains/contributions/dependencies.py
@@ -22,7 +22,7 @@ def get_contribution_service(
     return ContributionService(
         client=client,
         user=user,
-        projects=MongoDbProjectRepository(user, limits),
+        projects=MongoDbProjectRepository(user),
         contributions=MongoDbContributionRepository(user),
         structures=MongoDbStructureRepository(user),
         attachments=MongoDbAttachmentRepository(user),

--- a/mpcontribs-api/src/mpcontribs_api/domains/contributions/dependencies.py
+++ b/mpcontribs-api/src/mpcontribs_api/domains/contributions/dependencies.py
@@ -14,13 +14,6 @@ from mpcontribs_api.domains.structures.repository import MongoDbStructureReposit
 from mpcontribs_api.domains.tables.repository import MongoDbTableRepository
 
 
-def get_scoped_contributions(user: UserDep) -> MongoDbContributionRepository:
-    return MongoDbContributionRepository(user)
-
-
-ContributionDep = Annotated[MongoDbContributionRepository, Depends(get_scoped_contributions)]
-
-
 def get_contribution_service(
     user: UserDep,
     client: MongoClientDep,

--- a/mpcontribs-api/src/mpcontribs_api/domains/contributions/repository.py
+++ b/mpcontribs-api/src/mpcontribs_api/domains/contributions/repository.py
@@ -1,16 +1,12 @@
-from collections.abc import AsyncIterable
-from contextlib import AbstractAsyncContextManager
 from typing import Any, cast
 
 from beanie import PydanticObjectId, UpdateResponse
 from beanie.operators import Set
 from pymongo.asynchronous.client_session import AsyncClientSession
 from pymongo.errors import DuplicateKeyError
-from types_aiobotocore_s3 import S3Client
 
 from mpcontribs_api.domains._shared.bulk import BulkUpdateSummary
 from mpcontribs_api.domains._shared.repository import MongoDbRepository
-from mpcontribs_api.domains._shared.types import DownloadFormat, ShortMimeFormat
 from mpcontribs_api.domains._shared.units import QuantityLeaf
 from mpcontribs_api.domains.contributions.models import (
     Contribution,
@@ -328,25 +324,3 @@ class MongoDbContributionRepository(
                 f"contribution '{id}' cannot be upserted: the resulting identity already exists",
                 id=id,
             ) from err
-
-    async def download_contributions(
-        self,
-        format: DownloadFormat,
-        short_mime: ShortMimeFormat,
-        ignore_cache: bool,
-        filter: ContributionFilter,
-        fields: frozenset[str] | None,
-        key_name: str,
-        s3: AbstractAsyncContextManager[S3Client],
-        bucket_name: str = "contributions",
-    ) -> AsyncIterable[bytes]:
-        return self.download(
-            format=format,
-            short_mime=short_mime,
-            ignore_cache=ignore_cache,
-            filter=filter,
-            fields=fields,
-            bucket_name=bucket_name,
-            key_name=key_name,
-            s3=s3,
-        )

--- a/mpcontribs-api/src/mpcontribs_api/domains/contributions/repository.py
+++ b/mpcontribs-api/src/mpcontribs_api/domains/contributions/repository.py
@@ -29,6 +29,7 @@ from mpcontribs_api.domains.contributions.stats import (
     merge_contribution_columns,
 )
 from mpcontribs_api.exceptions import ConflictError, NotFoundError, PermissionError
+from mpcontribs_api.scope import Public, RoleIn, Scope
 
 # Sentinel for "leave unique_value untouched" on patch (distinct from a real None value).
 _UNSET: Any = object()
@@ -67,20 +68,13 @@ class MongoDbContributionRepository(
 
     document_model = Contribution
     out_model = ContributionOut
+    # Contributions have no owner of their own; visible when public or belonging to a project the
+    # caller may write to (keyed on ``project``). Admins bypass scope (handled by ``Scope``).
+    read_scope = Scope(Public(), RoleIn("project", "writable_projects"))
 
     def __init__(self, user: User) -> None:
         super().__init__(user)
         self._user = user
-
-    @staticmethod
-    def _build_scope(user: User) -> dict[str, Any]:
-        """Provides scope based on current user's permitted groups and publicly released data."""
-        if user.is_admin:
-            return {}
-        ors: list[dict[str, Any]] = [{"is_public": True}]
-        if user.writable_projects:
-            ors.append({"project": {"$in": sorted(user.writable_projects)}})
-        return {"$or": ors}
 
     async def count_contributions_for_project(self, project_name: str) -> int:
         """Count contributions already stored for a project.

--- a/mpcontribs-api/src/mpcontribs_api/domains/contributions/repository.py
+++ b/mpcontribs-api/src/mpcontribs_api/domains/contributions/repository.py
@@ -269,7 +269,7 @@ class MongoDbContributionRepository(
         agg.columns = finalize_columns(acc)
         return agg
 
-    async def upsert_one(
+    async def upsert_one(  # pyright: ignore[reportIncompatibleMethodOverride]
         self,
         identifiers: dict[str, Any],
         contribution: ContributionIn,

--- a/mpcontribs-api/src/mpcontribs_api/domains/contributions/repository.py
+++ b/mpcontribs-api/src/mpcontribs_api/domains/contributions/repository.py
@@ -269,6 +269,7 @@ class MongoDbContributionRepository(
         Relies on the unique index over the identity fields as the concurrency tiebreaker.
         On insert a fresh document is written with ``is_public=False``.
         """
+        identifiers = self.coerce_identifiers(identifiers)
         if identifiers.keys() == {"id"}:
             return await self._upsert_by_id(
                 identifiers["id"], contribution, None if unique_value is _UNSET else unique_value

--- a/mpcontribs-api/src/mpcontribs_api/domains/contributions/repository.py
+++ b/mpcontribs-api/src/mpcontribs_api/domains/contributions/repository.py
@@ -8,7 +8,6 @@ from pymongo.asynchronous.client_session import AsyncClientSession
 from pymongo.errors import DuplicateKeyError
 from types_aiobotocore_s3 import S3Client
 
-from mpcontribs_api.authz import User
 from mpcontribs_api.domains._shared.bulk import BulkUpdateSummary
 from mpcontribs_api.domains._shared.repository import MongoDbRepository
 from mpcontribs_api.domains._shared.types import DownloadFormat, ShortMimeFormat
@@ -28,7 +27,7 @@ from mpcontribs_api.domains.contributions.stats import (
     finalize_columns,
     merge_contribution_columns,
 )
-from mpcontribs_api.exceptions import ConflictError, NotFoundError, PermissionError
+from mpcontribs_api.exceptions import ConflictError, NotFoundError
 from mpcontribs_api.scope import Public, RoleIn, Scope
 
 # Sentinel for "leave unique_value untouched" on patch (distinct from a real None value).
@@ -71,10 +70,6 @@ class MongoDbContributionRepository(
     # Contributions have no owner of their own; visible when public or belonging to a project the
     # caller may write to (keyed on ``project``). Admins bypass scope (handled by ``Scope``).
     read_scope = Scope(Public(), RoleIn("project", "writable_projects"))
-
-    def __init__(self, user: User) -> None:
-        super().__init__(user)
-        self._user = user
 
     async def count_contributions_for_project(self, project_name: str) -> int:
         """Count contributions already stored for a project.
@@ -319,11 +314,6 @@ class MongoDbContributionRepository(
                 identifiers["id"], contribution, None if unique_value is _UNSET else unique_value
             )
 
-        project = str(identifiers["project"])
-        # Make sure the user is allowed to upsert a contribution under the provided project
-        if not self._user.can_write(project):
-            raise PermissionError(f"not authorized to write to project '{project}'")
-
         doc = self.document_model.from_input_model(contribution)
         doc.unique_value = identifiers["unique_value"]
         doc.condition_key = identifiers["condition_key"]
@@ -351,9 +341,6 @@ class MongoDbContributionRepository(
         unique_value: Scalar | None = None,
     ) -> Contribution:
         """Upsert a single Contribution keyed on its Mongo ``_id`` (see :meth:`upsert_one`)."""
-        if not self._user.can_write(contribution.project):
-            raise PermissionError(f"not authorized to write to project '{contribution.project}'")
-
         oid = self._convert_object_id(id)
         doc = self.document_model.from_input_model(contribution)
         # from_input_model mints a fresh id; upsert-by-id must key on the caller-supplied id so the

--- a/mpcontribs-api/src/mpcontribs_api/domains/contributions/repository.py
+++ b/mpcontribs-api/src/mpcontribs_api/domains/contributions/repository.py
@@ -61,7 +61,7 @@ class MongoDbContributionRepository(
     # caller may write to (keyed on ``project``). Admins bypass scope (handled by ``Scope``).
     read_scope = Scope(Public(), RoleIn("project", "writable_projects"))
 
-    async def patch_one(  # pyright: ignore[reportIncompatibleMethodOverride]
+    async def update_one(  # pyright: ignore[reportIncompatibleMethodOverride]
         self,
         identifiers: dict[str, Any],
         update: ContributionPatch,
@@ -87,7 +87,7 @@ class MongoDbContributionRepository(
         not_found = NotFoundError(f"{self.document_model.__name__} not found", identifiers=identifiers)
         try:
             if unique_value is _UNSET:
-                return await self._patch_matching(match, update, not_found, session=session)
+                return await self._update_matching(match, update, not_found, session=session)
             update_data = _build_update_set(
                 update.model_dump(exclude_unset=True), existing_data, replace_data=replace_data
             )
@@ -105,7 +105,7 @@ class MongoDbContributionRepository(
                 identifiers=identifiers,
             ) from err
 
-    async def patch_many(
+    async def update_many(
         self,
         filter: ContributionFilter,
         fields: dict[str, Any],

--- a/mpcontribs-api/src/mpcontribs_api/domains/contributions/repository.py
+++ b/mpcontribs-api/src/mpcontribs_api/domains/contributions/repository.py
@@ -65,14 +65,6 @@ class MongoDbContributionRepository(
     # caller may write to (keyed on ``project``). Admins bypass scope (handled by ``Scope``).
     read_scope = Scope(Public(), RoleIn("project", "writable_projects"))
 
-    async def count_contributions_for_project(self, project_name: str) -> int:
-        """Count contributions already stored for a project.
-
-        Unscoped on purpose: the unapproved-contribution quota is a property of the project as a
-        whole, not of what the current user can see. The cap comparison lives in the service.
-        """
-        return await self.document_model.find(self.document_model.project == project_name).count()
-
     async def patch_one(  # pyright: ignore[reportIncompatibleMethodOverride]
         self,
         identifiers: dict[str, Any],

--- a/mpcontribs-api/src/mpcontribs_api/domains/contributions/repository.py
+++ b/mpcontribs-api/src/mpcontribs_api/domains/contributions/repository.py
@@ -57,13 +57,7 @@ def _build_update_set(update_data: dict[str, Any], existing_data: Any, *, replac
 class MongoDbContributionRepository(
     MongoDbRepository[Contribution, ContributionIn, ContributionOut, ContributionFilter, ContributionPatch]
 ):
-    """A repository layer for access to MongoDB.
-
-    Shared CRUD logic lives on :class:`MongoDbRepository`; the methods here are domain-named
-    forwarders that give routers a consistent vocabulary and concrete types, plus the operations
-    whose shape is contribution-specific (filtered delete, id-keyed upsert, download).
-    Multi-collection orchestration (component inserts) lives in ``ContributionService``.
-    """
+    """A repository layer for access to MongoDB."""
 
     document_model = Contribution
     out_model = ContributionOut
@@ -154,7 +148,7 @@ class MongoDbContributionRepository(
             matched=result.matched_count, modified=result.modified_count, projects=sorted(projects)
         )
 
-    async def list_ids(  # pyright: ignore[reportIncompatibleMethodOverride]
+    async def list_ids(
         self,
         filter: ContributionFilter,
         session: AsyncClientSession | None = None,
@@ -175,28 +169,6 @@ class MongoDbContributionRepository(
         query = filter.filter(self.document_model.find(*criteria)).get_filter_query()
         collection = self.document_model.get_pymongo_collection()
         return [doc["_id"] async for doc in collection.find(query, {"_id": 1})]
-
-    async def insert_many(  # pyright: ignore[reportIncompatibleMethodOverride]
-        self,
-        docs: list[Contribution],
-        session: AsyncClientSession | None = None,
-    ):
-        """Bulk-insert pre-built Contribution documents.
-
-        Used by the ``ContributionService`` no-component fast path. On partial failure pymongo
-        raises ``BulkWriteError`` whose ``details["writeErrors"]`` carries per-index error info
-        that the service maps back into a ``BulkWriteSummary``.
-        """
-        return await self.document_model.insert_many(docs, ordered=False, session=session)
-
-    async def insert_one(  # pyright: ignore[reportIncompatibleMethodOverride]
-        self,
-        doc: Contribution,
-        session: AsyncClientSession | None = None,
-    ) -> Contribution:
-        """Insert a single pre-built Contribution document, optionally in a transaction."""
-        await doc.insert(session=session)
-        return doc
 
     async def existing_identities(self, identities: list[ContributionIdentity]) -> set[ContributionIdentity]:
         """Return the subset of identities that already exist, scoped to the user.
@@ -297,7 +269,7 @@ class MongoDbContributionRepository(
         agg.columns = finalize_columns(acc)
         return agg
 
-    async def upsert_one(  # pyright: ignore[reportIncompatibleMethodOverride]
+    async def upsert_one(
         self,
         identifiers: dict[str, Any],
         contribution: ContributionIn,

--- a/mpcontribs-api/src/mpcontribs_api/domains/contributions/router.py
+++ b/mpcontribs-api/src/mpcontribs_api/domains/contributions/router.py
@@ -51,18 +51,18 @@ def _enforce_bulk_limit(contributions: list[ContributionIn]) -> None:
 
 
 @router.get("")
-async def get_many(
+async def read_many(
     service: ContributionServiceDep,
     pagination: Annotated[CursorParams, Depends()],
     filter: ContributionFilter = FilterDepends(ContributionFilter),
     fields: FieldSelector = None,
 ):
     selected = ContributionOut.parse_fields(fields)
-    return await service.get_many(pagination=pagination, filter=filter, fields=selected)
+    return await service.read_many(pagination=pagination, filter=filter, fields=selected)
 
 
 @router.delete("", response_model=DeleteResponse, dependencies=[Depends(require_user)])
-async def delete_contributions(
+async def delete_many(
     service: ContributionServiceDep,
     filter: ContributionFilter = FilterDepends(ContributionFilter),
 ) -> BulkDeleteSummary:
@@ -70,7 +70,7 @@ async def delete_contributions(
 
 
 @router.patch("", dependencies=[Depends(require_user)])
-async def patch_contributions(
+async def update_many(
     service: ContributionServiceDep,
     body: ContributionPatch,
     filter: ContributionFilter = FilterDepends(ContributionFilter),
@@ -84,12 +84,12 @@ async def patch_contributions(
     ``data`` deep-merges into each row's stored ``data`` by default
     Pass ``?replace_data=true`` to overwrite the whole ``data`` dict instead.
     """
-    return await service.patch_many(filter=filter, update=body, replace_data=replace_data)
+    return await service.update_many(filter=filter, update=body, replace_data=replace_data)
 
 
 # TODO: Might want to take contributions in from request body and run model_validate_json on it (much faster)
 @router.post("", response_model=BulkWriteSummary[Contribution], dependencies=[Depends(require_user)])
-async def insert_contributions(
+async def insert_many(
     service: ContributionServiceDep,
     contributions: list[ContributionIn],
 ):
@@ -98,7 +98,7 @@ async def insert_contributions(
 
 
 @router.put("", response_model=BulkWriteSummary[Contribution], dependencies=[Depends(require_user)])
-async def upsert_contributions(
+async def upsert_many(
     service: ContributionServiceDep,
     contributions: list[ContributionIn],
 ):
@@ -142,13 +142,13 @@ async def delete_one(
 
 
 @router.get("/{id}")
-async def get_one(
+async def read_one(
     service: ContributionServiceDep,
     id: str,
     fields: FieldSelector = None,
 ):
     selected = ContributionOut.parse_fields(fields)
-    return await service.get_one({"id": id}, fields=selected)
+    return await service.read_one({"id": id}, fields=selected)
 
 
 @router.put("/{id}", dependencies=[Depends(require_user)])
@@ -159,8 +159,8 @@ async def upsert_one(service: ContributionServiceDep, id: str, contribution: Con
 
 
 @router.patch("/{id}", dependencies=[Depends(require_user)])
-async def patch_one(service: ContributionServiceDep, id: str, update: ContributionPatch, replace_data: bool = False):
+async def update_one(service: ContributionServiceDep, id: str, update: ContributionPatch, replace_data: bool = False):
     # The by-id patch re-resolves ``unique_value`` and validates the identifier hierarchy against the
-    # merged state (see ``ContributionService.patch_one``); ``?replace_data=true``
+    # merged state (see ``ContributionService.update_one``); ``?replace_data=true``
     # overwrites the whole ``data`` dict instead of deep-merging.
-    return await service.patch_one({"id": id}, update=update, replace_data=replace_data)
+    return await service.update_one({"id": id}, update=update, replace_data=replace_data)

--- a/mpcontribs-api/src/mpcontribs_api/domains/contributions/router.py
+++ b/mpcontribs-api/src/mpcontribs_api/domains/contributions/router.py
@@ -6,7 +6,7 @@ from fastapi_filter import FilterDepends
 
 from mpcontribs_api.config import get_settings
 from mpcontribs_api.dependencies import S3Dep, require_user
-from mpcontribs_api.domains._shared.bulk import BulkUpdateSummary, BulkWriteSummary
+from mpcontribs_api.domains._shared.bulk import BulkDeleteSummary, BulkUpdateSummary, BulkWriteSummary
 from mpcontribs_api.domains._shared.models import DeleteResponse
 from mpcontribs_api.domains._shared.types import (
     DownloadFormat,
@@ -14,7 +14,7 @@ from mpcontribs_api.domains._shared.types import (
     ShortMimeFormat,
     download_filename,
 )
-from mpcontribs_api.domains.contributions.dependencies import ContributionDep, ContributionServiceDep
+from mpcontribs_api.domains.contributions.dependencies import ContributionServiceDep
 from mpcontribs_api.domains.contributions.models import (
     Contribution,
     ContributionFilter,
@@ -51,22 +51,22 @@ def _enforce_bulk_limit(contributions: list[ContributionIn]) -> None:
 
 
 @router.get("")
-async def get_contributions(
-    repo: ContributionDep,
+async def get_many(
+    service: ContributionServiceDep,
     pagination: Annotated[CursorParams, Depends()],
     filter: ContributionFilter = FilterDepends(ContributionFilter),
     fields: FieldSelector = None,
 ):
     selected = ContributionOut.parse_fields(fields)
-    return await repo.get_many(pagination=pagination, filter=filter, fields=selected)
+    return await service.get_many(pagination=pagination, filter=filter, fields=selected)
 
 
 @router.delete("", response_model=DeleteResponse, dependencies=[Depends(require_user)])
 async def delete_contributions(
-    repo: ContributionDep,
+    service: ContributionServiceDep,
     filter: ContributionFilter = FilterDepends(ContributionFilter),
-) -> DeleteResponse:
-    return await repo.delete_many(filter=filter)
+) -> BulkDeleteSummary:
+    return await service.delete_many(filter=filter)
 
 
 @router.patch("", dependencies=[Depends(require_user)])
@@ -108,7 +108,7 @@ async def upsert_contributions(
 
 @router.get("/download/{short_mime}")
 async def download_contributions(
-    repo: ContributionDep,
+    service: ContributionServiceDep,
     s3: S3Dep,
     short_mime: ShortMimeFormat = ShortMimeFormat.GZ,
     format: DownloadFormat = DownloadFormat.JSONL,
@@ -117,14 +117,13 @@ async def download_contributions(
     fields: FieldSelector = None,
 ):
     selected = ContributionOut.parse_fields(fields)
-    body = await repo.download_contributions(
+    body = await service.download(
         format=format,
         short_mime=short_mime,
         ignore_cache=ignore_cache,
         filter=filter,
         fields=selected,
         s3=s3,
-        key_name="",  # TODO: Temp
     )
     filename = download_filename("contributions", format, short_mime)
     return StreamingResponse(

--- a/mpcontribs-api/src/mpcontribs_api/domains/contributions/service.py
+++ b/mpcontribs-api/src/mpcontribs_api/domains/contributions/service.py
@@ -106,7 +106,7 @@ class ContributionService:
             "tables": self._tables,
         }
 
-    async def get_one(
+    async def read_one(
         self, identifiers: dict[str, Any], fields: frozenset[str] | None
     ) -> Contribution | ContributionOut | None:
         """Return the single scoped contribution matching ``identifiers``.
@@ -114,12 +114,12 @@ class ContributionService:
         Accepts either the bare ``{"id": ...}`` form or the semantic
         ``{"project", "identifier", "version"}`` set, resolved by the base ``_identifier_query``.
         """
-        return await self._contributions.get_one(identifiers, fields)
+        return await self._contributions.read_one(identifiers, fields)
 
-    async def get_many(
+    async def read_many(
         self, pagination: CursorParams, filter: ContributionFilter, fields: frozenset[str] | None
     ) -> Page[ContributionOut]:
-        return await self._contributions.get_many(pagination=pagination, filter=filter, fields=fields)
+        return await self._contributions.read_many(pagination=pagination, filter=filter, fields=fields)
 
     async def download(
         self,
@@ -153,7 +153,7 @@ class ContributionService:
         if set(identifiers) == {"id"}:
             filter = ContributionFilter(id=identifiers["id"])
         else:
-            existing = await self._contributions.get_one(identifiers, frozenset({"id"}))
+            existing = await self._contributions.read_one(identifiers, frozenset({"id"}))
             if existing is None:
                 return BulkDeleteSummary(num_deleted=0, num_children_deleted=0)
             filter = ContributionFilter(id=existing.id)
@@ -166,7 +166,7 @@ class ContributionService:
         be read in the current scope (existence/permission is enforced on insert, not here). The
         caller turns the count into a remaining allowance against the cap.
         """
-        project = await self._projects.get_one({"id": project_id}, frozenset({"is_approved"}))
+        project = await self._projects.read_one({"id": project_id}, frozenset({"is_approved"}))
         if not project or project.is_approved:
             return None
         # Soft limit: this count feeds a non-atomic check-then-write, so concurrent writes to the
@@ -698,7 +698,7 @@ class ContributionService:
         await self.update_project({doc.project for doc in succeeded})
         return BulkWriteSummary[Contribution](total=len(contributions), succeeded=succeeded, failed=failed)
 
-    async def patch_many(
+    async def update_many(
         self,
         filter: ContributionFilter,
         update: ContributionPatch,
@@ -714,7 +714,7 @@ class ContributionService:
         - **Fast path** — the patch touches no identity input. A single ``$set`` is applied to every
           matched row in one ``update_many``.
         - **Per-row path** — the patch changes an Identifer field (or ``data``). Each matched row is
-          patched individually via ``patch_one`` and any per-row conflict is reported
+          patched individually via ``update_one`` and any per-row conflict is reported
           in ``failed``.
 
         A ``data`` patch deep-merges into each row's stored ``data`` by default (unmentioned leaves
@@ -741,7 +741,7 @@ class ContributionService:
         touches_identity = bool(ContributionIdentity.model_fields() & fields.keys()) or "data" in fields
         if not touches_identity:
             # No identity/unique_value recompute needed, so a uniform $set is safe.
-            summary = await self._contributions.patch_many(filter, fields)
+            summary = await self._contributions.update_many(filter, fields)
             await self.update_project(project_ids=summary.projects)
             return summary
 
@@ -767,7 +767,7 @@ class ContributionService:
         async def _patch_one(index: int, oid: PydanticObjectId) -> Contribution | BulkFailure:
             async with sem:
                 try:
-                    return await self.patch_one({"id": str(oid)}, update, replace_data=replace_data)
+                    return await self.update_one({"id": str(oid)}, update, replace_data=replace_data)
                 except Exception as exc:
                     logger.info("bulk_patch_item_failed", id=str(oid))
                     return bulk_failure_from_exception(index, {"id": str(oid)}, exc)
@@ -801,7 +801,7 @@ class ContributionService:
         """
         if not self._user.can_write(contribution.project):
             raise PermissionError(f"not authorized to write to project '{contribution.project}'")
-        existing = await self._contributions.get_one(identifiers, None)
+        existing = await self._contributions.read_one(identifiers, None)
         if existing is None:
             stored = await self._unapproved_stored_count(contribution.project)
             cap = self._limits.max_unapproved_contributions_per_project
@@ -814,7 +814,7 @@ class ContributionService:
         unique_value = await self._resolve_unique_value(contribution.project, contribution.data)
         return await self._contributions.upsert_one(identifiers, contribution, unique_value)
 
-    async def patch_one(
+    async def update_one(
         self, identifiers: dict[str, Any], update: ContributionPatch, *, replace_data: bool = False
     ) -> Contribution:
         """Partially update the single scoped contribution matching ``identifiers``.
@@ -832,7 +832,7 @@ class ContributionService:
         ``unique_value`` is resolved against the same post-write view the repository will persist.
         """
         if not self._user.is_admin:
-            target = await self._contributions.get_one(identifiers, frozenset({"id", "project"}))
+            target = await self._contributions.read_one(identifiers, frozenset({"id", "project"}))
             if target is None:
                 raise NotFoundError("contribution not found", identifiers=identifiers)
             if target.project not in self._user.writable_projects:
@@ -841,13 +841,13 @@ class ContributionService:
         touches_unique = "data" in set_fields or "project" in set_fields
         touches_identity = bool(ContributionIdentity.HIERARCHY_FIELDS & set_fields.keys())
         if not touches_unique and not touches_identity:
-            return await self._contributions.patch_one(identifiers, update)
+            return await self._contributions.update_one(identifiers, update)
 
         if replace_data and set_fields.get("data") is not None:
             # A whole-dict overwrite must satisfy the strict insert-path rules (no leaf fragments).
             validate_contribution_data(set_fields["data"])
 
-        existing = await self._contributions.get_one(identifiers, None)
+        existing = await self._contributions.read_one(identifiers, None)
         if existing is None or existing.project is None:
             raise NotFoundError("contribution not found", identifiers=identifiers)
 
@@ -859,7 +859,7 @@ class ContributionService:
                 existing_formula=existing.formula,
             )
         if not touches_unique:
-            return await self._contributions.patch_one(identifiers, update)
+            return await self._contributions.update_one(identifiers, update)
 
         project = set_fields.get("project") or existing.project
         # Resolve unique_value against the data the write will actually leave behind: the merged view
@@ -871,7 +871,7 @@ class ContributionService:
         else:
             data = QuantityLeaf.merge_data(existing.data, set_fields["data"])
         unique_value = await self._resolve_unique_value(project, data)
-        return await self._contributions.patch_one(
+        return await self._contributions.update_one(
             identifiers,
             update,
             unique_value=unique_value,
@@ -928,7 +928,7 @@ class ContributionService:
         # Loop through cursor rather than materialize arbitrary number of Contributions
         while True:
             # Since we are deleting everything matching filter, we can continuously get the 1st page
-            page = await self._contributions.get_many(
+            page = await self._contributions.read_many(
                 pagination=CursorParams(cursor=None, limit=100),
                 filter=filter,
             )

--- a/mpcontribs-api/src/mpcontribs_api/domains/contributions/service.py
+++ b/mpcontribs-api/src/mpcontribs_api/domains/contributions/service.py
@@ -170,7 +170,8 @@ class ContributionService:
             return None
         # Soft limit: this count feeds a non-atomic check-then-write, so concurrent writes to the
         # same project can overshoot the cap by a bounded amount. Acceptable for an anti-abuse quota.
-        return await self._contributions.count_contributions_for_project(project_id)
+        # Unscoped: the quota is a property of the project as a whole, not of what the caller can see.
+        return await self._contributions.count_matching({"project": project_id}, scoped=False)
 
     async def insert_many(
         self,

--- a/mpcontribs-api/src/mpcontribs_api/domains/contributions/service.py
+++ b/mpcontribs-api/src/mpcontribs_api/domains/contributions/service.py
@@ -615,8 +615,20 @@ class ContributionService:
     async def _do_insert_group(self, group: list[PreparedWrite], session: AsyncClientSession) -> list[Contribution]:
         """Perform the insert of Contributions and their components within a single session."""
         template = group[0].contribution
-        structures = await self._structures.insert_many(template.structures or [], session=session)
-        tables = await self._tables.insert_many(template.tables or [], session=session)
+        structure_successes, structure_failures = await self._structures.insert_many(
+            template.structures or [], session=session
+        )
+        table_successes, table_failures = await self._tables.insert_many(template.tables or [], session=session)
+        # A contribution and its components commit or roll back together, so any per-component failure
+        # aborts the whole transaction. Re-raise it here; ``_insert_with_components`` maps the raised
+        # error onto this contribution's ``BulkFailure``.
+        component_failures = structure_failures + table_failures
+        if component_failures:
+            first = component_failures[0]
+            message = f"Component insert failed: {first.message}"
+            raise ConflictError(message) if first.error_code == ConflictError.error_code else ValidationError(message)
+        structures = [doc for _, doc in structure_successes]
+        tables = [doc for _, doc in table_successes]
         struct_links = cast(list[Link[Structure]] | None, structures or None)
         table_links = cast(list[Link[Table]] | None, tables or None)
         inserted: list[Contribution] = []

--- a/mpcontribs-api/src/mpcontribs_api/domains/contributions/service.py
+++ b/mpcontribs-api/src/mpcontribs_api/domains/contributions/service.py
@@ -550,7 +550,7 @@ class ContributionService:
             return [], []
         docs = []
         for item in items:
-            doc = Contribution.from_input_model(item.contribution)
+            doc = self._contributions.document_model.from_input_model(item.contribution)
             doc.unique_value = item.unique_value
             doc.condition_key = item.condition_key
             docs.append(doc)
@@ -646,7 +646,7 @@ class ContributionService:
         table_links = cast(list[Link[Table]] | None, tables or None)
         inserted: list[Contribution] = []
         for item in group:
-            doc = Contribution.from_input_model(item.contribution)
+            doc = self._contributions.document_model.from_input_model(item.contribution)
             doc.unique_value = item.unique_value
             doc.condition_key = item.condition_key
             doc.structures = struct_links

--- a/mpcontribs-api/src/mpcontribs_api/domains/contributions/service.py
+++ b/mpcontribs-api/src/mpcontribs_api/domains/contributions/service.py
@@ -473,33 +473,6 @@ class ContributionService:
         identities = [item.contribution.identity(item.unique_value, item.condition_key) for item in items]
         return await self._contributions.existing_identities(identities)
 
-    @staticmethod
-    def _log_quota_exceeded(
-        project_id: str,
-        cap: int,
-        stored: int,
-        accepted: int,
-        rejected: list[PreparedWrite],
-    ) -> None:
-        """Emit a structured audit event for an unapproved-project quota breach.
-
-        Request/user correlation (``consumer_id``, ``request_id``, ``trace_id``) is merged from the
-        per-request contextvars, so only the domain-specific dimensions are added here. The rejected
-        identifier list is capped to keep a pathological batch from bloating a single log line.
-        """
-        rejected_identifiers = [item.contribution.material_id for item in rejected[:_QUOTA_LOG_IDENTIFIER_CAP]]
-        logger.warning(
-            "contribution.unapproved_quota_exceeded",
-            project=project_id,
-            max_allowed=cap,
-            stored=stored,
-            attempted=accepted + len(rejected),
-            accepted=accepted,
-            rejected=len(rejected),
-            rejected_identifiers=rejected_identifiers,
-            rejected_identifiers_truncated=len(rejected) > _QUOTA_LOG_IDENTIFIER_CAP,
-        )
-
     async def _split_contributions(
         self, contributions: list[ContributionIn], *, is_upsert: bool
     ) -> tuple[list[BulkFailure], list[PreparedWrite]]:

--- a/mpcontribs-api/src/mpcontribs_api/domains/contributions/service.py
+++ b/mpcontribs-api/src/mpcontribs_api/domains/contributions/service.py
@@ -1,6 +1,7 @@
 import asyncio
 from collections import defaultdict
-from collections.abc import Iterable
+from collections.abc import AsyncIterable, Iterable
+from contextlib import AbstractAsyncContextManager
 from dataclasses import dataclass
 from typing import Any, cast
 
@@ -9,6 +10,7 @@ from beanie import Link, PydanticObjectId
 from pymongo import AsyncMongoClient
 from pymongo.asynchronous.client_session import AsyncClientSession
 from pymongo.errors import BulkWriteError
+from types_aiobotocore_s3 import S3Client
 
 from mpcontribs_api.authz import User
 from mpcontribs_api.config import MongoSettings, get_settings
@@ -20,6 +22,7 @@ from mpcontribs_api.domains._shared.bulk import (
     bulk_failure_from_exception,
 )
 from mpcontribs_api.domains._shared.repository import MongoDbRepository
+from mpcontribs_api.domains._shared.types import DownloadFormat, ShortMimeFormat
 from mpcontribs_api.domains._shared.units import QuantityLeaf
 from mpcontribs_api.domains.attachments.models import AttachmentFilter
 from mpcontribs_api.domains.attachments.repository import MongoDbAttachmentRepository
@@ -44,7 +47,7 @@ from mpcontribs_api.domains.structures.repository import MongoDbStructureReposit
 from mpcontribs_api.domains.tables.models import Table, TableFilter
 from mpcontribs_api.domains.tables.repository import MongoDbTableRepository
 from mpcontribs_api.exceptions import AppError, ConflictError, NotFoundError, PermissionError, ValidationError
-from mpcontribs_api.pagination import CursorParams
+from mpcontribs_api.pagination import CursorParams, Page
 
 logger = structlog.get_logger(__name__)
 
@@ -111,6 +114,31 @@ class ContributionService:
         ``{"project", "identifier", "version"}`` set, resolved by the base ``_identifier_query``.
         """
         return await self._contributions.get_one(self._contributions.coerce_identifiers(identifiers), fields)
+
+    async def get_many(
+        self, pagination: CursorParams, filter: ContributionFilter, fields: frozenset[str] | None
+    ) -> Page[ContributionOut]:
+        return await self._contributions.get_many(pagination=pagination, filter=filter, fields=fields)
+
+    async def download(
+        self,
+        format: DownloadFormat,
+        short_mime: ShortMimeFormat,
+        ignore_cache: bool,
+        filter: ContributionFilter,
+        fields: frozenset[str] | None,
+        s3: AbstractAsyncContextManager[S3Client],
+    ) -> AsyncIterable[bytes]:
+        """Stream a gzip-compressed export of matching contributions. See repository ``download``."""
+        return await self._contributions.download_contributions(
+            format=format,
+            short_mime=short_mime,
+            ignore_cache=ignore_cache,
+            filter=filter,
+            fields=fields,
+            s3=s3,
+            key_name="",  # TODO: Temp
+        )
 
     async def delete_one(self, identifiers: dict[str, Any]) -> BulkDeleteSummary:
         """Delete a single contribution and its child components, matching ``identifiers``.

--- a/mpcontribs-api/src/mpcontribs_api/domains/contributions/service.py
+++ b/mpcontribs-api/src/mpcontribs_api/domains/contributions/service.py
@@ -830,6 +830,12 @@ class ContributionService:
         ``unique_value`` is resolved against the same post-write view the repository will persist.
         """
         identifiers = self._contributions.coerce_identifiers(identifiers)
+        if not self._user.is_admin:
+            target = await self._contributions.get_one(identifiers, frozenset({"id", "project"}))
+            if target is None:
+                raise NotFoundError("contribution not found", identifiers=identifiers)
+            if target.project not in self._user.writable_projects:
+                raise PermissionError(f"not authorized to write to project '{target.project}'")
         set_fields = update.model_dump(exclude_unset=True)
         touches_unique = "data" in set_fields or "project" in set_fields
         touches_identity = bool(ContributionIdentity.HIERARCHY_FIELDS & set_fields.keys())
@@ -912,6 +918,8 @@ class ContributionService:
         Returns:
             BulkDeleteSummary: a summary of how many documents and child documents were deleted
         """
+        if not self._user.is_admin:
+            filter = filter.model_copy(update={"project__in": sorted(self._user.writable_projects)})
         num_deleted_components = 0
         num_deleted_contributions = 0
         # Projects touched by this delete, so their rollup stats can be recomputed once at the end.

--- a/mpcontribs-api/src/mpcontribs_api/domains/contributions/service.py
+++ b/mpcontribs-api/src/mpcontribs_api/domains/contributions/service.py
@@ -130,7 +130,7 @@ class ContributionService:
         s3: AbstractAsyncContextManager[S3Client],
     ) -> AsyncIterable[bytes]:
         """Stream a gzip-compressed export of matching contributions. See repository ``download``."""
-        return await self._contributions.download_contributions(
+        return self._contributions.download(
             format=format,
             short_mime=short_mime,
             ignore_cache=ignore_cache,
@@ -138,6 +138,7 @@ class ContributionService:
             fields=fields,
             s3=s3,
             key_name="",  # TODO: Temp
+            bucket_name="contributions",
         )
 
     async def delete_one(self, identifiers: dict[str, Any]) -> BulkDeleteSummary:

--- a/mpcontribs-api/src/mpcontribs_api/domains/contributions/service.py
+++ b/mpcontribs-api/src/mpcontribs_api/domains/contributions/service.py
@@ -113,7 +113,7 @@ class ContributionService:
         Accepts either the bare ``{"id": ...}`` form or the semantic
         ``{"project", "identifier", "version"}`` set, resolved by the base ``_identifier_query``.
         """
-        return await self._contributions.get_one(self._contributions.coerce_identifiers(identifiers), fields)
+        return await self._contributions.get_one(identifiers, fields)
 
     async def get_many(
         self, pagination: CursorParams, filter: ContributionFilter, fields: frozenset[str] | None
@@ -149,7 +149,6 @@ class ContributionService:
         :meth:`delete_many` so children are never orphaned; a missing target is a zero-count
         result (mirroring the bulk delete path, which does not 404).
         """
-        identifiers = self._contributions.coerce_identifiers(identifiers)
         if set(identifiers) == {"id"}:
             filter = ContributionFilter(id=identifiers["id"])
         else:
@@ -798,7 +797,6 @@ class ContributionService:
         """
         if not self._user.can_write(contribution.project):
             raise PermissionError(f"not authorized to write to project '{contribution.project}'")
-        identifiers = self._contributions.coerce_identifiers(identifiers)
         existing = await self._contributions.get_one(identifiers, None)
         if existing is None:
             stored = await self._unapproved_stored_count(contribution.project)
@@ -829,7 +827,6 @@ class ContributionService:
         re-validated strictly (the permissive patch validator allows leaf fragments a full doc may not).
         ``unique_value`` is resolved against the same post-write view the repository will persist.
         """
-        identifiers = self._contributions.coerce_identifiers(identifiers)
         if not self._user.is_admin:
             target = await self._contributions.get_one(identifiers, frozenset({"id", "project"}))
             if target is None:

--- a/mpcontribs-api/src/mpcontribs_api/domains/contributions/service.py
+++ b/mpcontribs-api/src/mpcontribs_api/domains/contributions/service.py
@@ -7,6 +7,7 @@ from typing import Any, cast
 
 import structlog
 from beanie import Link, PydanticObjectId
+from pydantic import ValidationError as PydanticValidationError
 from pymongo import AsyncMongoClient
 from pymongo.asynchronous.client_session import AsyncClientSession
 from pymongo.errors import BulkWriteError
@@ -614,10 +615,13 @@ class ContributionService:
     async def _do_insert_group(self, group: list[PreparedWrite], session: AsyncClientSession) -> list[Contribution]:
         """Perform the insert of Contributions and their components within a single session."""
         template = group[0].contribution
-        structure_successes, structure_failures = await self._structures.insert_many(
-            template.structures or [], session=session
-        )
-        table_successes, table_failures = await self._tables.insert_many(template.tables or [], session=session)
+        try:
+            structure_docs = [Structure.from_input(s) for s in (template.structures or [])]
+            table_docs = [Table.from_input(t) for t in (template.tables or [])]
+        except PydanticValidationError as exc:
+            raise ValidationError(str(exc)) from exc
+        structure_successes, structure_failures = await self._structures.insert_many(structure_docs, session=session)
+        table_successes, table_failures = await self._tables.insert_many(table_docs, session=session)
         # A contribution and its components commit or roll back together, so any per-component failure
         # aborts the whole transaction. Re-raise it here; ``_insert_with_components`` maps the raised
         # error onto this contribution's ``BulkFailure``.

--- a/mpcontribs-api/src/mpcontribs_api/domains/initiatives/dependencies.py
+++ b/mpcontribs-api/src/mpcontribs_api/domains/initiatives/dependencies.py
@@ -4,10 +4,11 @@ from fastapi import Depends
 
 from mpcontribs_api.dependencies import UserDep
 from mpcontribs_api.domains.initiatives.repository import InitiativeRepository
+from mpcontribs_api.domains.initiatives.service import InitiativeService
 
 
-def get_initiative_repository(user: UserDep) -> InitiativeRepository:
-    return InitiativeRepository(user)
+def get_initiative_service(user: UserDep) -> InitiativeService:
+    return InitiativeService(initiatives=InitiativeRepository(user))
 
 
-InitiativeDep = Annotated[InitiativeRepository, Depends(get_initiative_repository)]
+InitiativeServiceDep = Annotated[InitiativeService, Depends(get_initiative_service)]

--- a/mpcontribs-api/src/mpcontribs_api/domains/initiatives/dependencies.py
+++ b/mpcontribs-api/src/mpcontribs_api/domains/initiatives/dependencies.py
@@ -3,7 +3,7 @@ from typing import Annotated
 from fastapi import Depends
 
 from mpcontribs_api.dependencies import UserDep
-from mpcontribs_api.domains.initiatives.repository import InitiativeRepository
+from mpcontribs_api.domains.initiatives.repository import MongoDbInitiativeRepository
 from mpcontribs_api.domains.initiatives.service import InitiativeService
 from mpcontribs_api.domains.projects.repository import MongoDbProjectRepository
 
@@ -11,7 +11,7 @@ from mpcontribs_api.domains.projects.repository import MongoDbProjectRepository
 def get_initiative_service(user: UserDep) -> InitiativeService:
     return InitiativeService(
         user=user,
-        initiatives=InitiativeRepository(user),
+        initiatives=MongoDbInitiativeRepository(user),
         projects=MongoDbProjectRepository(user),
     )
 

--- a/mpcontribs-api/src/mpcontribs_api/domains/initiatives/dependencies.py
+++ b/mpcontribs-api/src/mpcontribs_api/domains/initiatives/dependencies.py
@@ -5,10 +5,15 @@ from fastapi import Depends
 from mpcontribs_api.dependencies import UserDep
 from mpcontribs_api.domains.initiatives.repository import InitiativeRepository
 from mpcontribs_api.domains.initiatives.service import InitiativeService
+from mpcontribs_api.domains.projects.repository import MongoDbProjectRepository
 
 
 def get_initiative_service(user: UserDep) -> InitiativeService:
-    return InitiativeService(initiatives=InitiativeRepository(user))
+    return InitiativeService(
+        user=user,
+        initiatives=InitiativeRepository(user),
+        projects=MongoDbProjectRepository(user),
+    )
 
 
 InitiativeServiceDep = Annotated[InitiativeService, Depends(get_initiative_service)]

--- a/mpcontribs-api/src/mpcontribs_api/domains/initiatives/repository.py
+++ b/mpcontribs-api/src/mpcontribs_api/domains/initiatives/repository.py
@@ -1,5 +1,3 @@
-from pymongo.errors import DuplicateKeyError
-
 from mpcontribs_api.domains._shared.repository import MongoDbRepository
 from mpcontribs_api.domains.initiatives.models import (
     Initiative,
@@ -8,7 +6,6 @@ from mpcontribs_api.domains.initiatives.models import (
     InitiativeOut,
     InitiativePatch,
 )
-from mpcontribs_api.exceptions import ConflictError
 from mpcontribs_api.scope import Owned, Public, RoleIn, Scope
 
 
@@ -22,15 +19,6 @@ class InitiativeRepository(
     # Visible when public+approved, owned by the caller, or collaborated on via an
     # ``initiative:<slug>`` role (keyed on ``slug``). Admins bypass scope (handled by ``Scope``).
     read_scope = Scope(Public(approved=True), Owned(), RoleIn("slug", "initiative_roles"))
-
-    async def insert_one(self, data: InitiativeIn, owner: str) -> Initiative:  # pyright: ignore[reportIncompatibleMethodOverride]
-        """Insert a new initiative owned by ``owner``, rejecting a duplicate ``slug``."""
-        initiative = self.document_model.from_input_model(data=data, owner=owner)
-        try:
-            await initiative.insert()
-        except DuplicateKeyError as exc:  # unique slug index
-            raise ConflictError("an initiative with this slug already exists", slug=data.slug) from exc
-        return initiative
 
     async def count_unapproved_for_owner(self, owner: str) -> int:
         """Count ``owner``'s unapproved initiatives, ignoring user scope."""

--- a/mpcontribs-api/src/mpcontribs_api/domains/initiatives/repository.py
+++ b/mpcontribs-api/src/mpcontribs_api/domains/initiatives/repository.py
@@ -1,11 +1,5 @@
-from typing import Any
-
-from pymongo.asynchronous.client_session import AsyncClientSession
 from pymongo.errors import DuplicateKeyError
 
-from mpcontribs_api.authz import User
-from mpcontribs_api.config import get_settings
-from mpcontribs_api.domains._shared.models import DeleteResponse
 from mpcontribs_api.domains._shared.repository import MongoDbRepository
 from mpcontribs_api.domains.initiatives.models import (
     Initiative,
@@ -14,100 +8,33 @@ from mpcontribs_api.domains.initiatives.models import (
     InitiativeOut,
     InitiativePatch,
 )
-from mpcontribs_api.exceptions import ConflictError, NotFoundError, PermissionError, ValidationError
+from mpcontribs_api.exceptions import ConflictError
 from mpcontribs_api.scope import Owned, Public, RoleIn, Scope
 
 
 class InitiativeRepository(
     MongoDbRepository[Initiative, InitiativeIn, InitiativeOut, InitiativeFilter, InitiativePatch]
 ):
+    """Query/persistence toolbox for initiatives."""
+
     document_model = Initiative
     out_model = InitiativeOut
     # Visible when public+approved, owned by the caller, or collaborated on via an
     # ``initiative:<slug>`` role (keyed on ``slug``). Admins bypass scope (handled by ``Scope``).
     read_scope = Scope(Public(approved=True), Owned(), RoleIn("slug", "initiative_roles"))
 
-    def __init__(self, user: User) -> None:
-        super().__init__(user)
-        self._limits = get_settings().domain.initiatives
-
-    async def insert_one(self, data: InitiativeIn) -> Initiative:  # pyright: ignore[reportIncompatibleMethodOverride]
-        """Create an initiative owned by the caller, enforcing the per-owner unapproved quota.
-
-        ``owner`` is forced to the caller and the initiative starts unapproved and private. A
-        non-admin who already owns ``max_unapproved_per_owner`` unapproved initiatives is rejected
-        with 409. A duplicate ``slug`` (globally unique) is also a 409.
-        """
-        if self._user.username is None:
-            raise PermissionError(required_role="authenticated")
-
-        if not self._user.is_admin:
-            unapproved = await self.document_model.find(
-                self.document_model.owner == self._user.username,
-                self.document_model.is_approved == False,  # noqa: E712 — Beanie needs the value, not `is`
-            ).count()
-            if unapproved >= self._limits.max_unapproved_per_owner:
-                raise ConflictError(
-                    "owner already has the maximum number of unapproved initiatives",
-                    limit=self._limits.max_unapproved_per_owner,
-                )
-
-        initiative = self.document_model.from_input_model(data=data, owner=self._user.username)
+    async def insert_one(self, data: InitiativeIn, owner: str) -> Initiative:  # pyright: ignore[reportIncompatibleMethodOverride]
+        """Insert a new initiative owned by ``owner``, rejecting a duplicate ``slug``."""
+        initiative = self.document_model.from_input_model(data=data, owner=owner)
         try:
             await initiative.insert()
         except DuplicateKeyError as exc:  # unique slug index
             raise ConflictError("an initiative with this slug already exists", slug=data.slug) from exc
         return initiative
 
-    async def patch_one(  # pyright: ignore[reportIncompatibleMethodOverride]
-        self, identifiers: dict[str, Any], update: InitiativePatch, session: AsyncClientSession | None = None
-    ) -> Initiative:
-        """Patch a scoped initiative by ``slug``, enforcing manage rights and approval rules.
-
-        - The caller must be able to *manage* the initiative (owner/collaborator/admin)
-        - Only an admin may change ``is_approved``.
-        - The resulting state must satisfy ``is_public ⇒ is_approved`` (re-checked here because a
-          partial ``$set`` does not run the document validator).
-
-        ``identifiers`` is the ``{"slug": ...}`` form; the auth checks run against the resolved
-        document, and the write itself is delegated to the base :meth:`MongoDbRepository.patch_one`.
-        """
-        slug = identifiers["slug"]
-        existing = await self.document_model.find_one(self._scope, self.document_model.slug == slug)
-        if existing is None:
-            raise NotFoundError("Initiative not found", slug=slug)
-        if not (
-            self._user.can_manage(id=existing.slug, resource="initiative") or self._user.username == existing.owner
-        ):
-            raise PermissionError(required_role="initiative-owner-collaborator-or-admin")
-
-        data = update.model_dump(exclude_unset=True)
-        if "is_approved" in data and not self._user.is_admin:
-            raise PermissionError("only admins can set `is_approved`", required_role="admin")
-
-        resulting_approved = data.get("is_approved", existing.is_approved)
-        resulting_public = data.get("is_public", existing.is_public)
-        if resulting_public and not resulting_approved:
-            raise ValidationError("an initiative cannot be public until it is approved", slug=slug)
-
-        return await super().patch_one(identifiers, update, session=session)
-
-    async def delete_one(
-        self, identifiers: dict[str, Any], session: AsyncClientSession | None = None
-    ) -> DeleteResponse:
-        """Delete a scoped initiative by ``slug``. Restricted to the owner or an admin.
-
-        Collaborators may contribute projects but may not dissolve the effort. Deleting an
-        initiative does not touch member projects; their ``initiative`` link simply dangles until
-        re-pointed (reads resolve a missing link to null).
-
-        ``identifiers`` is the ``{"slug": ...}`` form; the write is delegated to the base
-        :meth:`MongoDbRepository.delete_one`.
-        """
-        slug = identifiers["slug"]
-        existing = await self.document_model.find_one(self._scope, self.document_model.slug == slug)
-        if existing is None:
-            raise NotFoundError("Initiative not found", slug=slug)
-        if not (self._user.is_admin or existing.owner == self._user.username):
-            raise PermissionError(required_role="owner-or-admin")
-        return await super().delete_one(identifiers, session=session)
+    async def count_unapproved_for_owner(self, owner: str) -> int:
+        """Count ``owner``'s unapproved initiatives, ignoring user scope."""
+        return await self.document_model.find(
+            self.document_model.owner == owner,
+            self.document_model.is_approved == False,  # noqa: E712 — Beanie needs the value, not `is`
+        ).count()

--- a/mpcontribs-api/src/mpcontribs_api/domains/initiatives/repository.py
+++ b/mpcontribs-api/src/mpcontribs_api/domains/initiatives/repository.py
@@ -19,10 +19,3 @@ class MongoDbInitiativeRepository(
     # Visible when public+approved, owned by the caller, or collaborated on via an
     # ``initiative:<slug>`` role (keyed on ``slug``). Admins bypass scope (handled by ``Scope``).
     read_scope = Scope(Public(approved=True), Owned(), RoleIn("slug", "initiative_roles"))
-
-    async def count_unapproved_for_owner(self, owner: str) -> int:
-        """Count ``owner``'s unapproved initiatives, ignoring user scope."""
-        return await self.document_model.find(
-            self.document_model.owner == owner,
-            self.document_model.is_approved == False,  # noqa: E712 — Beanie needs the value, not `is`
-        ).count()

--- a/mpcontribs-api/src/mpcontribs_api/domains/initiatives/repository.py
+++ b/mpcontribs-api/src/mpcontribs_api/domains/initiatives/repository.py
@@ -9,7 +9,7 @@ from mpcontribs_api.domains.initiatives.models import (
 from mpcontribs_api.scope import Owned, Public, RoleIn, Scope
 
 
-class InitiativeRepository(
+class MongoDbInitiativeRepository(
     MongoDbRepository[Initiative, InitiativeIn, InitiativeOut, InitiativeFilter, InitiativePatch]
 ):
     """Query/persistence toolbox for initiatives."""

--- a/mpcontribs-api/src/mpcontribs_api/domains/initiatives/repository.py
+++ b/mpcontribs-api/src/mpcontribs_api/domains/initiatives/repository.py
@@ -15,6 +15,7 @@ from mpcontribs_api.domains.initiatives.models import (
     InitiativePatch,
 )
 from mpcontribs_api.exceptions import ConflictError, NotFoundError, PermissionError, ValidationError
+from mpcontribs_api.scope import Owned, Public, RoleIn, Scope
 
 
 class InitiativeRepository(
@@ -22,23 +23,13 @@ class InitiativeRepository(
 ):
     document_model = Initiative
     out_model = InitiativeOut
+    # Visible when public+approved, owned by the caller, or collaborated on via an
+    # ``initiative:<slug>`` role (keyed on ``slug``). Admins bypass scope (handled by ``Scope``).
+    read_scope = Scope(Public(approved=True), Owned(), RoleIn("slug", "initiative_roles"))
 
     def __init__(self, user: User) -> None:
         super().__init__(user)
         self._limits = get_settings().domain.initiatives
-
-    @staticmethod
-    def _build_scope(user: User) -> dict[str, Any]:
-        """Scope reads to what the caller may see: public+approved, owned, or collaborated-on."""
-        if user.is_admin:
-            return {}
-        ors: list[dict[str, Any]] = [{"is_public": True, "is_approved": True}]
-        if not user.is_anonymous:
-            ors.append({"owner": user.username})
-            slugs = user.initiative_roles
-            if slugs:
-                ors.append({"slug": {"$in": sorted(slugs)}})
-        return {"$or": ors}
 
     async def insert_one(self, data: InitiativeIn) -> Initiative:  # pyright: ignore[reportIncompatibleMethodOverride]
         """Create an initiative owned by the caller, enforcing the per-owner unapproved quota.

--- a/mpcontribs-api/src/mpcontribs_api/domains/initiatives/router.py
+++ b/mpcontribs-api/src/mpcontribs_api/domains/initiatives/router.py
@@ -18,7 +18,7 @@ router = APIRouter()
 
 
 @router.get("")
-async def get_many(
+async def read_many(
     service: InitiativeServiceDep,
     pagination: Annotated[CursorParams, Depends()],
     filter: InitiativeFilter = FilterDepends(InitiativeFilter),
@@ -26,18 +26,18 @@ async def get_many(
 ):
     """Return paginated initiatives matching a filter, scoped to the caller."""
     selected = InitiativeOut.parse_fields(fields)
-    return await service.get_many(pagination=pagination, filter=filter, fields=selected)
+    return await service.read_many(pagination=pagination, filter=filter, fields=selected)
 
 
 @router.get("/{slug}")
-async def get_one(
+async def read_one(
     service: InitiativeServiceDep,
     slug: str,
     fields: FieldSelector = None,
 ):
     """Return the single initiative identified by ``slug``, scoped to the caller."""
     selected = InitiativeOut.parse_fields(fields)
-    return await service.get_one({"slug": slug}, fields=selected)
+    return await service.read_one({"slug": slug}, fields=selected)
 
 
 @router.post(
@@ -56,7 +56,7 @@ async def insert_one(
 
 
 @router.patch("/{slug}", response_model=InitiativeOut, dependencies=[Depends(require_user)])
-async def patch_one(
+async def update_one(
     service: InitiativeServiceDep,
     slug: str,
     update: InitiativePatch,
@@ -66,7 +66,7 @@ async def patch_one(
     Requires manage rights (owner/collaborator/admin). ``is_approved`` is admin-only, and an
     initiative cannot be made public until it is approved.
     """
-    return await service.patch_one({"slug": slug}, update=update)
+    return await service.update_one({"slug": slug}, update=update)
 
 
 @router.delete("/{slug}", status_code=status.HTTP_204_NO_CONTENT, dependencies=[Depends(require_user)])

--- a/mpcontribs-api/src/mpcontribs_api/domains/initiatives/router.py
+++ b/mpcontribs-api/src/mpcontribs_api/domains/initiatives/router.py
@@ -5,7 +5,7 @@ from fastapi_filter import FilterDepends
 
 from mpcontribs_api.dependencies import require_user
 from mpcontribs_api.domains._shared.types import FieldSelector
-from mpcontribs_api.domains.initiatives.dependencies import InitiativeDep
+from mpcontribs_api.domains.initiatives.dependencies import InitiativeServiceDep
 from mpcontribs_api.domains.initiatives.models import (
     InitiativeFilter,
     InitiativeIn,
@@ -19,32 +19,32 @@ router = APIRouter()
 
 @router.get("")
 async def get_initiatives(
-    repo: InitiativeDep,
+    service: InitiativeServiceDep,
     pagination: Annotated[CursorParams, Depends()],
     filter: InitiativeFilter = FilterDepends(InitiativeFilter),
-    fields: FieldSelector = InitiativeOut.default_fields(),
+    fields: FieldSelector = None,
 ):
     """Return paginated initiatives matching a filter, scoped to the caller."""
     selected = InitiativeOut.parse_fields(fields)
-    return await repo.get_many(pagination=pagination, filter=filter, fields=selected)
+    return await service.get_many(pagination=pagination, filter=filter, fields=selected)
 
 
 @router.get("/{slug}")
 async def get_one(
-    repo: InitiativeDep,
+    service: InitiativeServiceDep,
     slug: str,
-    fields: FieldSelector = InitiativeOut.default_fields(),
+    fields: FieldSelector = None,
 ):
     """Return the single initiative identified by ``slug``, scoped to the caller."""
     selected = InitiativeOut.parse_fields(fields)
-    return await repo.get_one({"slug": slug}, fields=selected)
+    return await service.get_one({"slug": slug}, fields=selected)
 
 
 @router.post(
     "", response_model=InitiativeOut, status_code=status.HTTP_201_CREATED, dependencies=[Depends(require_user)]
 )
 async def insert_initiative(
-    repo: InitiativeDep,
+    service: InitiativeServiceDep,
     initiative: InitiativeIn,
 ):
     """Create a new initiative owned by the caller.
@@ -52,12 +52,12 @@ async def insert_initiative(
     Starts unapproved and private. Rejected with 409 if the caller already owns the maximum number
     of unapproved initiatives, or if the slug is already taken.
     """
-    return await repo.insert_one(data=initiative)
+    return await service.insert_one(data=initiative)
 
 
 @router.patch("/{slug}", response_model=InitiativeOut, dependencies=[Depends(require_user)])
 async def patch_one(
-    repo: InitiativeDep,
+    service: InitiativeServiceDep,
     slug: str,
     update: InitiativePatch,
 ):
@@ -66,14 +66,14 @@ async def patch_one(
     Requires manage rights (owner/collaborator/admin). ``is_approved`` is admin-only, and an
     initiative cannot be made public until it is approved.
     """
-    return await repo.patch_one({"slug": slug}, update=update)
+    return await service.patch_one({"slug": slug}, update=update)
 
 
 @router.delete("/{slug}", status_code=status.HTTP_204_NO_CONTENT, dependencies=[Depends(require_user)])
 async def delete_one(
-    repo: InitiativeDep,
+    service: InitiativeServiceDep,
     slug: str,
 ):
     """Delete the initiative identified by ``slug``. Restricted to its owner or an admin."""
-    await repo.delete_one({"slug": slug})
+    await service.delete_one({"slug": slug})
     return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/mpcontribs-api/src/mpcontribs_api/domains/initiatives/router.py
+++ b/mpcontribs-api/src/mpcontribs_api/domains/initiatives/router.py
@@ -18,7 +18,7 @@ router = APIRouter()
 
 
 @router.get("")
-async def get_initiatives(
+async def get_many(
     service: InitiativeServiceDep,
     pagination: Annotated[CursorParams, Depends()],
     filter: InitiativeFilter = FilterDepends(InitiativeFilter),
@@ -43,7 +43,7 @@ async def get_one(
 @router.post(
     "", response_model=InitiativeOut, status_code=status.HTTP_201_CREATED, dependencies=[Depends(require_user)]
 )
-async def insert_initiative(
+async def insert_one(
     service: InitiativeServiceDep,
     initiative: InitiativeIn,
 ):

--- a/mpcontribs-api/src/mpcontribs_api/domains/initiatives/service.py
+++ b/mpcontribs-api/src/mpcontribs_api/domains/initiatives/service.py
@@ -40,17 +40,17 @@ class InitiativeService:
         self._projects = projects
         self._limits = get_settings().domain.initiatives
 
-    async def get_many(
+    async def read_many(
         self, pagination: CursorParams, filter: InitiativeFilter, fields: frozenset[str] | None
     ) -> Page[InitiativeOut]:
         """Return a page of scoped initiatives matching ``filter``."""
-        return await self._initiatives.get_many(pagination=pagination, filter=filter, fields=fields)
+        return await self._initiatives.read_many(pagination=pagination, filter=filter, fields=fields)
 
-    async def get_one(
+    async def read_one(
         self, identifiers: dict[str, Any], fields: frozenset[str] | None
     ) -> Initiative | InitiativeOut | None:
         """Return the single scoped initiative matching ``identifiers`` (``{"slug": ...}``)."""
-        return await self._initiatives.get_one(identifiers, fields)
+        return await self._initiatives.read_one(identifiers, fields)
 
     async def insert_one(self, data: InitiativeIn) -> Initiative:
         """Create an initiative owned by the caller, enforcing the per-owner unapproved quota.
@@ -80,7 +80,7 @@ class InitiativeService:
         initiative = self._initiatives.document_model.from_input_model(data, owner=self._user.username)
         return await self._initiatives.insert_one(initiative)
 
-    async def patch_one(self, identifiers: dict[str, Any], update: InitiativePatch) -> Initiative:
+    async def update_one(self, identifiers: dict[str, Any], update: InitiativePatch) -> Initiative:
         """Patch a scoped initiative by ``slug``, enforcing manage rights and approval rules.
 
         - The caller must be able to *manage* the initiative (owner/collaborator/admin).
@@ -89,7 +89,7 @@ class InitiativeService:
           partial ``$set`` does not run the document validator).
         """
         slug = identifiers["slug"]
-        existing = await self._initiatives.get_one(identifiers)
+        existing = await self._initiatives.read_one(identifiers)
         if existing is None:
             raise NotFoundError("Initiative not found", slug=slug)
         if not (self._user.can_manage(id=slug, resource="initiative") or self._user.username == existing.owner):
@@ -104,7 +104,7 @@ class InitiativeService:
         if resulting_public and not resulting_approved:
             raise ValidationError("an initiative cannot be public until it is approved", slug=slug)
 
-        return await self._initiatives.patch_one(identifiers, update)
+        return await self._initiatives.update_one(identifiers, update)
 
     async def delete_one(self, identifiers: dict[str, Any]) -> DeleteResponse:
         """Delete a scoped initiative by ``slug``. Restricted to the owner or an admin.
@@ -113,7 +113,7 @@ class InitiativeService:
         see the initiative gets a 404; one who can see it but does not own it gets a 403. After the
         initiative is removed, the ``initiative`` link is unset on every member project.
         """
-        existing = await self._initiatives.get_one(identifiers)
+        existing = await self._initiatives.read_one(identifiers)
         if existing is None:
             raise NotFoundError("Initiative not found", **identifiers)
         if not (self._user.is_admin or existing.owner == self._user.username):

--- a/mpcontribs-api/src/mpcontribs_api/domains/initiatives/service.py
+++ b/mpcontribs-api/src/mpcontribs_api/domains/initiatives/service.py
@@ -64,7 +64,11 @@ class InitiativeService:
             raise PermissionError(required_role="authenticated")
 
         if not self._user.is_admin:
-            unapproved = await self._initiatives.count_unapproved_for_owner(self._user.username)
+            # Unscoped: the per-owner unapproved cap counts every one of the owner's unapproved
+            # initiatives, regardless of what the current caller can see.
+            unapproved = await self._initiatives.count_matching(
+                {"owner": self._user.username, "is_approved": False}, scoped=False
+            )
             if unapproved >= self._limits.max_unapproved_per_owner:
                 raise ConflictError(
                     "owner already has the maximum number of unapproved initiatives",

--- a/mpcontribs-api/src/mpcontribs_api/domains/initiatives/service.py
+++ b/mpcontribs-api/src/mpcontribs_api/domains/initiatives/service.py
@@ -1,5 +1,7 @@
 from typing import Any
 
+from mpcontribs_api.authz import User
+from mpcontribs_api.config import get_settings
 from mpcontribs_api.domains._shared.models import DeleteResponse
 from mpcontribs_api.domains.initiatives.models import (
     Initiative,
@@ -9,18 +11,32 @@ from mpcontribs_api.domains.initiatives.models import (
     InitiativePatch,
 )
 from mpcontribs_api.domains.initiatives.repository import InitiativeRepository
+from mpcontribs_api.domains.projects.repository import MongoDbProjectRepository
+from mpcontribs_api.exceptions import ConflictError, NotFoundError, PermissionError, ValidationError
 from mpcontribs_api.pagination import CursorParams, Page
 
 
 class InitiativeService:
-    """Service layer for initiatives.
+    """Owns initiative write policy; the repository is a scoped query/persistence toolbox.
 
-    Initiatives have no cross-domain coordination, so the service is a thin pass-through that owns
-    ``_fields`` parsing and keeps the router off the repository.
+    Every authorization decision, invariant, and quota for initiatives lives here:
+
+    - **Authentication** on insert.
+    - **Per-owner unapproved quota** — a non-admin may not exceed ``max_unapproved_per_owner``.
+    - **Manage rights** on patch — the caller must own the initiative or hold its ``initiative:<slug>``
+      role (or be an admin).
+    - **Admin-only approval** — only an admin may set ``is_approved``.
+    - **Owner-or-admin delete** — collaborators may contribute projects but not dissolve the effort;
+      a caller who cannot see the initiative gets a 404, one who can see but does not own it gets a 403.
+    - **The ``public ⇒ approved`` invariant**, re-checked on patch because a partial ``$set`` bypasses
+      the document validator.
     """
 
-    def __init__(self, initiatives: InitiativeRepository) -> None:
+    def __init__(self, user: User, initiatives: InitiativeRepository, projects: MongoDbProjectRepository) -> None:
+        self._user = user
         self._initiatives = initiatives
+        self._projects = projects
+        self._limits = get_settings().domain.initiatives
 
     async def get_many(
         self, pagination: CursorParams, filter: InitiativeFilter, fields: frozenset[str] | None
@@ -35,13 +51,65 @@ class InitiativeService:
         return await self._initiatives.get_one(identifiers, fields)
 
     async def insert_one(self, data: InitiativeIn) -> Initiative:
-        """Create an initiative owned by the caller. See repository ``insert_one``."""
-        return await self._initiatives.insert_one(data=data)
+        """Create an initiative owned by the caller, enforcing the per-owner unapproved quota.
+
+        ``owner`` is forced to the caller and the initiative starts unapproved and private. A
+        non-admin who already owns ``max_unapproved_per_owner`` unapproved initiatives is rejected
+        with 409; a duplicate ``slug`` is also a 409 (raised by the repository).
+        """
+        # The route enforces authentication, so an anonymous caller should never reach here.
+        if self._user.username is None:
+            raise PermissionError(required_role="authenticated")
+
+        if not self._user.is_admin:
+            unapproved = await self._initiatives.count_unapproved_for_owner(self._user.username)
+            if unapproved >= self._limits.max_unapproved_per_owner:
+                raise ConflictError(
+                    "owner already has the maximum number of unapproved initiatives",
+                    limit=self._limits.max_unapproved_per_owner,
+                )
+
+        return await self._initiatives.insert_one(data=data, owner=self._user.username)
 
     async def patch_one(self, identifiers: dict[str, Any], update: InitiativePatch) -> Initiative:
-        """Patch the scoped initiative matching ``identifiers`` (``{"slug": ...}``). See repository."""
-        return await self._initiatives.patch_one(identifiers, update=update)
+        """Patch a scoped initiative by ``slug``, enforcing manage rights and approval rules.
+
+        - The caller must be able to *manage* the initiative (owner/collaborator/admin).
+        - Only an admin may change ``is_approved``.
+        - The resulting state must satisfy ``is_public ⇒ is_approved`` (re-checked here because a
+          partial ``$set`` does not run the document validator).
+        """
+        slug = identifiers["slug"]
+        existing = await self._initiatives.get_one(identifiers)
+        if existing is None:
+            raise NotFoundError("Initiative not found", slug=slug)
+        if not (self._user.can_manage(id=slug, resource="initiative") or self._user.username == existing.owner):
+            raise PermissionError(required_role="initiative-owner-collaborator-or-admin")
+
+        data = update.model_dump(exclude_unset=True)
+        if "is_approved" in data and not self._user.is_admin:
+            raise PermissionError("only admins can set `is_approved`", required_role="admin")
+
+        resulting_approved = data.get("is_approved", existing.is_approved)
+        resulting_public = data.get("is_public", existing.is_public)
+        if resulting_public and not resulting_approved:
+            raise ValidationError("an initiative cannot be public until it is approved", slug=slug)
+
+        return await self._initiatives.patch_one(identifiers, update)
 
     async def delete_one(self, identifiers: dict[str, Any]) -> DeleteResponse:
-        """Delete the scoped initiative matching ``identifiers`` (``{"slug": ...}``). See repository."""
-        return await self._initiatives.delete_one(identifiers)
+        """Delete a scoped initiative by ``slug``. Restricted to the owner or an admin.
+
+        Collaborators may contribute projects but may not delete. A caller who cannot
+        see the initiative gets a 404; one who can see it but does not own it gets a 403. After the
+        initiative is removed, the ``initiative`` link is unset on every member project.
+        """
+        existing = await self._initiatives.get_one(identifiers)
+        if existing is None:
+            raise NotFoundError("Initiative not found", **identifiers)
+        if not (self._user.is_admin or existing.owner == self._user.username):
+            raise PermissionError(required_role="owner-or-admin")
+        response = await self._initiatives.delete_one(identifiers)
+        if existing.id is not None:
+            await self._projects.clear_initiative_refs(existing.id)
+        return response

--- a/mpcontribs-api/src/mpcontribs_api/domains/initiatives/service.py
+++ b/mpcontribs-api/src/mpcontribs_api/domains/initiatives/service.py
@@ -69,7 +69,10 @@ class InitiativeService:
                     limit=self._limits.max_unapproved_per_owner,
                 )
 
-        return await self._initiatives.insert_one(data=data, owner=self._user.username)
+        # The repository translates the unique-slug DuplicateKeyError into a ConflictError whose
+        # context carries the slug (Initiative.identifier_fields() == {"slug"}).
+        initiative = self._initiatives.document_model.from_input_model(data, owner=self._user.username)
+        return await self._initiatives.insert_one(initiative)
 
     async def patch_one(self, identifiers: dict[str, Any], update: InitiativePatch) -> Initiative:
         """Patch a scoped initiative by ``slug``, enforcing manage rights and approval rules.

--- a/mpcontribs-api/src/mpcontribs_api/domains/initiatives/service.py
+++ b/mpcontribs-api/src/mpcontribs_api/domains/initiatives/service.py
@@ -1,0 +1,47 @@
+from typing import Any
+
+from mpcontribs_api.domains._shared.models import DeleteResponse
+from mpcontribs_api.domains.initiatives.models import (
+    Initiative,
+    InitiativeFilter,
+    InitiativeIn,
+    InitiativeOut,
+    InitiativePatch,
+)
+from mpcontribs_api.domains.initiatives.repository import InitiativeRepository
+from mpcontribs_api.pagination import CursorParams, Page
+
+
+class InitiativeService:
+    """Service layer for initiatives.
+
+    Initiatives have no cross-domain coordination, so the service is a thin pass-through that owns
+    ``_fields`` parsing and keeps the router off the repository.
+    """
+
+    def __init__(self, initiatives: InitiativeRepository) -> None:
+        self._initiatives = initiatives
+
+    async def get_many(
+        self, pagination: CursorParams, filter: InitiativeFilter, fields: frozenset[str] | None
+    ) -> Page[InitiativeOut]:
+        """Return a page of scoped initiatives matching ``filter``."""
+        return await self._initiatives.get_many(pagination=pagination, filter=filter, fields=fields)
+
+    async def get_one(
+        self, identifiers: dict[str, Any], fields: frozenset[str] | None
+    ) -> Initiative | InitiativeOut | None:
+        """Return the single scoped initiative matching ``identifiers`` (``{"slug": ...}``)."""
+        return await self._initiatives.get_one(identifiers, fields)
+
+    async def insert_one(self, data: InitiativeIn) -> Initiative:
+        """Create an initiative owned by the caller. See repository ``insert_one``."""
+        return await self._initiatives.insert_one(data=data)
+
+    async def patch_one(self, identifiers: dict[str, Any], update: InitiativePatch) -> Initiative:
+        """Patch the scoped initiative matching ``identifiers`` (``{"slug": ...}``). See repository."""
+        return await self._initiatives.patch_one(identifiers, update=update)
+
+    async def delete_one(self, identifiers: dict[str, Any]) -> DeleteResponse:
+        """Delete the scoped initiative matching ``identifiers`` (``{"slug": ...}``). See repository."""
+        return await self._initiatives.delete_one(identifiers)

--- a/mpcontribs-api/src/mpcontribs_api/domains/initiatives/service.py
+++ b/mpcontribs-api/src/mpcontribs_api/domains/initiatives/service.py
@@ -10,7 +10,7 @@ from mpcontribs_api.domains.initiatives.models import (
     InitiativeOut,
     InitiativePatch,
 )
-from mpcontribs_api.domains.initiatives.repository import InitiativeRepository
+from mpcontribs_api.domains.initiatives.repository import MongoDbInitiativeRepository
 from mpcontribs_api.domains.projects.repository import MongoDbProjectRepository
 from mpcontribs_api.exceptions import ConflictError, NotFoundError, PermissionError, ValidationError
 from mpcontribs_api.pagination import CursorParams, Page
@@ -32,7 +32,9 @@ class InitiativeService:
       the document validator.
     """
 
-    def __init__(self, user: User, initiatives: InitiativeRepository, projects: MongoDbProjectRepository) -> None:
+    def __init__(
+        self, user: User, initiatives: MongoDbInitiativeRepository, projects: MongoDbProjectRepository
+    ) -> None:
         self._user = user
         self._initiatives = initiatives
         self._projects = projects

--- a/mpcontribs-api/src/mpcontribs_api/domains/project_groups/dependencies.py
+++ b/mpcontribs-api/src/mpcontribs_api/domains/project_groups/dependencies.py
@@ -8,13 +8,6 @@ from mpcontribs_api.domains.project_groups.service import ProjectGroupService
 from mpcontribs_api.domains.projects.repository import MongoDbProjectRepository
 
 
-def get_project_group_repository(user: UserDep) -> ProjectGroupRepository:
-    return ProjectGroupRepository(user)
-
-
-ProjectGroupDep = Annotated[ProjectGroupRepository, Depends(get_project_group_repository)]
-
-
 def get_project_group_service(user: UserDep) -> ProjectGroupService:
     return ProjectGroupService(
         groups=ProjectGroupRepository(user),

--- a/mpcontribs-api/src/mpcontribs_api/domains/project_groups/dependencies.py
+++ b/mpcontribs-api/src/mpcontribs_api/domains/project_groups/dependencies.py
@@ -10,6 +10,7 @@ from mpcontribs_api.domains.projects.repository import MongoDbProjectRepository
 
 def get_project_group_service(user: UserDep) -> ProjectGroupService:
     return ProjectGroupService(
+        user=user,
         groups=ProjectGroupRepository(user),
         projects=MongoDbProjectRepository(user),
     )

--- a/mpcontribs-api/src/mpcontribs_api/domains/project_groups/dependencies.py
+++ b/mpcontribs-api/src/mpcontribs_api/domains/project_groups/dependencies.py
@@ -3,7 +3,7 @@ from typing import Annotated
 from fastapi import Depends
 
 from mpcontribs_api.dependencies import UserDep
-from mpcontribs_api.domains.project_groups.repository import ProjectGroupRepository
+from mpcontribs_api.domains.project_groups.repository import MongoDbProjectGroupRepository
 from mpcontribs_api.domains.project_groups.service import ProjectGroupService
 from mpcontribs_api.domains.projects.repository import MongoDbProjectRepository
 
@@ -11,7 +11,7 @@ from mpcontribs_api.domains.projects.repository import MongoDbProjectRepository
 def get_project_group_service(user: UserDep) -> ProjectGroupService:
     return ProjectGroupService(
         user=user,
-        groups=ProjectGroupRepository(user),
+        groups=MongoDbProjectGroupRepository(user),
         projects=MongoDbProjectRepository(user),
     )
 

--- a/mpcontribs-api/src/mpcontribs_api/domains/project_groups/models.py
+++ b/mpcontribs-api/src/mpcontribs_api/domains/project_groups/models.py
@@ -88,12 +88,12 @@ class ProjectGroupOut(DocumentOut[PydanticObjectId]):
     description: str | None = None
 
     @staticmethod
-    def default_fields() -> list[str]:
-        return [
+    def default_fields() -> tuple[str, ...]:
+        return (
             "name",
             "description",
             "projects",
-        ]
+        )
 
 
 class ProjectGroupPatch(SparseFieldsModel):

--- a/mpcontribs-api/src/mpcontribs_api/domains/project_groups/repository.py
+++ b/mpcontribs-api/src/mpcontribs_api/domains/project_groups/repository.py
@@ -3,10 +3,8 @@ from typing import Any
 from beanie import PydanticObjectId, UpdateResponse
 from beanie.operators import AddToSet, Pull
 from bson import DBRef
-from bson.errors import InvalidId
 from pymongo.asynchronous.client_session import AsyncClientSession
 
-from mpcontribs_api.authz import User
 from mpcontribs_api.domains._shared.models import DeleteResponse
 from mpcontribs_api.domains._shared.repository import MongoDbRepository
 from mpcontribs_api.domains._shared.types import ShortStr
@@ -18,6 +16,7 @@ from mpcontribs_api.domains.project_groups.models import (
     ProjectGroupPatch,
 )
 from mpcontribs_api.exceptions import NotFoundError, PermissionError
+from mpcontribs_api.scope import Owned, Public, RoleIn, Scope
 
 
 class ProjectGroupRepository(
@@ -25,30 +24,16 @@ class ProjectGroupRepository(
 ):
     document_model = ProjectGroup
     out_model = ProjectGroupOut
-
-    @staticmethod
-    def _build_scope(user: User) -> dict[str, Any]:
-        """Scope reads to what the caller may see: public groups, ones they own, or ones granted."""
-        if user.is_admin:
-            return {}
-        ors: list[dict[str, Any]] = [{"is_public": True}]
-        if not user.is_anonymous:
-            ors.append({"owner": user.username})
-            granted: list[PydanticObjectId] = []
-            for raw in user.project_group_roles:
-                try:
-                    granted.append(PydanticObjectId(raw))
-                except InvalidId:
-                    continue
-            if granted:
-                ors.append({"_id": {"$in": sorted(granted)}})
-        return {"$or": ors}
+    # Visible when public, owned by the caller, or granted via a ``project-group:<oid>`` role (keyed
+    # on ``_id``). Project groups have no approval flag. Roles arrive as raw hex strings, so the id
+    # clause coerces each to ``PydanticObjectId`` (malformed values are dropped by ``RoleIn``). Admins
+    # bypass scope (handled by ``Scope``).
+    read_scope = Scope(Public(), Owned(), RoleIn("_id", "project_group_roles", coerce=PydanticObjectId))
 
     async def delete_one(
         self, identifiers: dict[str, Any], session: AsyncClientSession | None = None
     ) -> DeleteResponse:
-        """Delete the single project group matching ``identifiers`` (``{name, owner}`` or ``{id}``).
-
+        """Delete the single project group matching ``identifiers`` (``{name, owner}`` or ``{id}``).O
         Absence (in scope) takes precedence over the ownership gate: a non-admin may only delete
         their own group, so deleting another owner's visible (public) group is forbidden rather
         than silently a no-op. The ``name`` + ``owner`` unique index makes the match unambiguous.

--- a/mpcontribs-api/src/mpcontribs_api/domains/project_groups/repository.py
+++ b/mpcontribs-api/src/mpcontribs_api/domains/project_groups/repository.py
@@ -15,7 +15,7 @@ from mpcontribs_api.domains.project_groups.models import (
 from mpcontribs_api.scope import Owned, Public, RoleIn, Scope
 
 
-class ProjectGroupRepository(
+class MongoDbProjectGroupRepository(
     MongoDbRepository[ProjectGroup, ProjectGroupIn, ProjectGroupOut, ProjectGroupFilter, ProjectGroupPatch]
 ):
     """Query/persistence toolbox for project groups."""

--- a/mpcontribs-api/src/mpcontribs_api/domains/project_groups/repository.py
+++ b/mpcontribs-api/src/mpcontribs_api/domains/project_groups/repository.py
@@ -1,11 +1,8 @@
-from typing import Any
-
 from beanie import PydanticObjectId, UpdateResponse
 from beanie.operators import AddToSet, Pull
 from bson import DBRef
 from pymongo.asynchronous.client_session import AsyncClientSession
 
-from mpcontribs_api.domains._shared.models import DeleteResponse
 from mpcontribs_api.domains._shared.repository import MongoDbRepository
 from mpcontribs_api.domains._shared.types import ShortStr
 from mpcontribs_api.domains.project_groups.models import (
@@ -15,13 +12,14 @@ from mpcontribs_api.domains.project_groups.models import (
     ProjectGroupOut,
     ProjectGroupPatch,
 )
-from mpcontribs_api.exceptions import NotFoundError, PermissionError
 from mpcontribs_api.scope import Owned, Public, RoleIn, Scope
 
 
 class ProjectGroupRepository(
     MongoDbRepository[ProjectGroup, ProjectGroupIn, ProjectGroupOut, ProjectGroupFilter, ProjectGroupPatch]
 ):
+    """Query/persistence toolbox for project groups."""
+
     document_model = ProjectGroup
     out_model = ProjectGroupOut
     # Visible when public, owned by the caller, or granted via a ``project-group:<oid>`` role (keyed
@@ -29,36 +27,6 @@ class ProjectGroupRepository(
     # clause coerces each to ``PydanticObjectId`` (malformed values are dropped by ``RoleIn``). Admins
     # bypass scope (handled by ``Scope``).
     read_scope = Scope(Public(), Owned(), RoleIn("_id", "project_group_roles", coerce=PydanticObjectId))
-
-    async def delete_one(
-        self, identifiers: dict[str, Any], session: AsyncClientSession | None = None
-    ) -> DeleteResponse:
-        """Delete the single project group matching ``identifiers`` (``{name, owner}`` or ``{id}``).O
-        Absence (in scope) takes precedence over the ownership gate: a non-admin may only delete
-        their own group, so deleting another owner's visible (public) group is forbidden rather
-        than silently a no-op. The ``name`` + ``owner`` unique index makes the match unambiguous.
-        The auth check runs against the resolved document; the write is delegated to the base
-        :meth:`MongoDbRepository.delete_one`.
-        """
-        doc = await self.document_model.find_one(self._scope, self._identifier_query(identifiers), session=session)  # pyright: ignore[reportArgumentType]
-        if doc is None:
-            raise NotFoundError(f"{self.document_model.__name__} not found", **identifiers)
-        if not (self._user.is_admin or doc.owner == self._user.username):
-            raise PermissionError(required_role="owner-or-admin")
-        return await super().delete_one(identifiers, session=session)
-
-    async def delete_many(  # pyright: ignore[reportIncompatibleMethodOverride]
-        self, filter: ProjectGroupFilter, session: AsyncClientSession | None = None
-    ) -> DeleteResponse:
-        """Bulk-delete project groups matching ``filter``, restricted to the caller's own.
-
-        A non-admin's bulk delete is scoped to their own groups (overriding any ``owner`` in the
-        filter) so it can never remove public groups belonging to others. The write is delegated to
-        the base :meth:`MongoDbRepository.delete_many`.
-        """
-        if not self._user.is_admin:
-            filter.owner = self._user.username
-        return await super().delete_many(filter, session=session)
 
     async def add_project_refs(
         self,

--- a/mpcontribs-api/src/mpcontribs_api/domains/project_groups/router.py
+++ b/mpcontribs-api/src/mpcontribs_api/domains/project_groups/router.py
@@ -7,7 +7,7 @@ from mpcontribs_api.dependencies import require_user
 from mpcontribs_api.domains._shared.bulk import BulkWriteSummary
 from mpcontribs_api.domains._shared.models import DeleteResponse
 from mpcontribs_api.domains._shared.types import FieldSelector, PrefixedEmail, SearchStr
-from mpcontribs_api.domains.project_groups.dependencies import ProjectGroupDep, ProjectGroupServiceDep
+from mpcontribs_api.domains.project_groups.dependencies import ProjectGroupServiceDep
 from mpcontribs_api.domains.project_groups.models import (
     ProjectGroupFilter,
     ProjectGroupIn,
@@ -22,21 +22,21 @@ router = APIRouter()
 
 @router.get("")
 async def get_project_groups(
-    repo: ProjectGroupDep,
+    service: ProjectGroupServiceDep,
     pagination: Annotated[CursorParams, Depends()],
     filter: ProjectGroupFilter = FilterDepends(ProjectGroupFilter),
-    fields: FieldSelector = ProjectGroupOut.default_fields(),
+    fields: FieldSelector = None,
 ):
     """Return paginated project groups matching a filter.
 
     Args:
-        repo (ProjectGroupDep): the project group repo we depend on
+        service (ProjectGroupServiceDep): the project group service we depend on
         pagination (CursorParams): arguments for cursor-based pagination
         filter (ProjectGroupFilter): optional filters to select ProjectGroups
         fields (FieldSelector): the fields to return to a user
     """
     selected = ProjectGroupOut.parse_fields(fields)
-    return await repo.get_many(pagination=pagination, filter=filter, fields=selected)
+    return await service.get_many(pagination=pagination, filter=filter, fields=selected)
 
 
 @router.get("/item")
@@ -44,7 +44,7 @@ async def get_one(
     service: ProjectGroupServiceDep,
     name: SearchStr,
     owner: PrefixedEmail,
-    fields: FieldSelector = ProjectGroupOut.default_fields(),
+    fields: FieldSelector = None,
 ):
     """Return the single project group identified by ``name`` + ``owner``.
 
@@ -116,16 +116,16 @@ async def delete_one(
 
 @router.delete("", response_model=DeleteResponse, dependencies=[Depends(require_user)])
 async def delete_project_groups(
-    repo: ProjectGroupDep,
+    service: ProjectGroupServiceDep,
     filter: ProjectGroupFilter = FilterDepends(ProjectGroupFilter),
 ):
     """Bulk-delete every project group matching ``filter`` (e.g. all with a given owner).
 
     Args:
-        repo (ProjectGroupDep): the project group repo we depend on
+        service (ProjectGroupServiceDep): the project group service we depend on
         filter (ProjectGroupFilter): the query selecting which project groups to delete
     """
-    return await repo.delete_many(filter=filter)
+    return await service.delete_many(filter=filter)
 
 
 @router.post("/item/projects", response_model=BulkWriteSummary[str], dependencies=[Depends(require_user)])

--- a/mpcontribs-api/src/mpcontribs_api/domains/project_groups/router.py
+++ b/mpcontribs-api/src/mpcontribs_api/domains/project_groups/router.py
@@ -21,7 +21,7 @@ router = APIRouter()
 
 
 @router.get("")
-async def get_project_groups(
+async def read_many(
     service: ProjectGroupServiceDep,
     pagination: Annotated[CursorParams, Depends()],
     filter: ProjectGroupFilter = FilterDepends(ProjectGroupFilter),
@@ -36,11 +36,11 @@ async def get_project_groups(
         fields (FieldSelector): the fields to return to a user
     """
     selected = ProjectGroupOut.parse_fields(fields)
-    return await service.get_many(pagination=pagination, filter=filter, fields=selected)
+    return await service.read_many(pagination=pagination, filter=filter, fields=selected)
 
 
 @router.get("/item")
-async def get_one(
+async def read_one(
     service: ProjectGroupServiceDep,
     name: SearchStr,
     owner: PrefixedEmail,
@@ -55,13 +55,13 @@ async def get_one(
         fields (FieldSelector): the fields to return to a user
     """
     selected = ProjectGroupOut.parse_fields(fields)
-    return await service.get_one({"name": name, "owner": owner}, fields=selected)
+    return await service.read_one({"name": name, "owner": owner}, fields=selected)
 
 
 @router.post(
     "", response_model=ProjectGroupOut, status_code=status.HTTP_201_CREATED, dependencies=[Depends(require_user)]
 )
-async def insert_project_group(
+async def insert_one(
     service: ProjectGroupServiceDep,
     project_group: ProjectGroupIn,
 ):
@@ -78,7 +78,7 @@ async def insert_project_group(
 
 
 @router.patch("/item", response_model=ProjectGroupOut, dependencies=[Depends(require_user)])
-async def patch_one(
+async def update_one(
     service: ProjectGroupServiceDep,
     name: SearchStr,
     owner: PrefixedEmail,
@@ -92,7 +92,7 @@ async def patch_one(
         owner (PrefixedEmail): the project group's owner
         update (ProjectGroupPatch): the partial update to apply - unset fields are dropped
     """
-    return await service.patch_one({"name": name, "owner": owner}, update=update)
+    return await service.update_one({"name": name, "owner": owner}, update=update)
 
 
 @router.delete("/item", status_code=status.HTTP_204_NO_CONTENT, dependencies=[Depends(require_user)])
@@ -115,7 +115,7 @@ async def delete_one(
 
 
 @router.delete("", response_model=DeleteResponse, dependencies=[Depends(require_user)])
-async def delete_project_groups(
+async def delete_many(
     service: ProjectGroupServiceDep,
     filter: ProjectGroupFilter = FilterDepends(ProjectGroupFilter),
 ):

--- a/mpcontribs-api/src/mpcontribs_api/domains/project_groups/service.py
+++ b/mpcontribs-api/src/mpcontribs_api/domains/project_groups/service.py
@@ -7,6 +7,7 @@ from mpcontribs_api.domains._shared.models import DeleteResponse
 from mpcontribs_api.domains._shared.types import ShortStr
 from mpcontribs_api.domains.project_groups.models import (
     ProjectGroup,
+    ProjectGroupFilter,
     ProjectGroupIn,
     ProjectGroupOut,
     ProjectGroupPatch,
@@ -14,6 +15,7 @@ from mpcontribs_api.domains.project_groups.models import (
 from mpcontribs_api.domains.project_groups.repository import ProjectGroupRepository
 from mpcontribs_api.domains.projects.repository import MongoDbProjectRepository
 from mpcontribs_api.exceptions import NotFoundError
+from mpcontribs_api.pagination import CursorParams, Page
 
 # Fields the membership operations need off a resolved group: its id (target of the update) and its
 # current members (so deletion can tell members from non-members).
@@ -48,9 +50,19 @@ class ProjectGroupService:
             raise NotFoundError("One or more projects not found or not visible", ids=missing)
         return await self._groups.insert_one(in_resource=project_group)
 
+    async def get_many(
+        self, filter: ProjectGroupFilter, pagination: CursorParams, fields: frozenset[str] | None
+    ) -> Page[ProjectGroupOut]:
+        """Return a page of scoped project groups matching ``filter``."""
+        return await self._groups.get_many(pagination=pagination, filter=filter, fields=fields)
+
     async def get_one(self, identifiers: dict[str, Any], fields: frozenset[str] | None) -> ProjectGroupOut | None:
         """Return the single group matching ``identifiers`` (``{"name", "owner"}`` or ``{"id"}``)."""
         return await self._groups.get_one(identifiers, fields)
+
+    async def delete_many(self, filter: ProjectGroupFilter) -> DeleteResponse:
+        """Bulk-delete every scoped project group matching ``filter``."""
+        return await self._groups.delete_many(filter=filter)
 
     async def patch_one(self, identifiers: dict[str, Any], update: ProjectGroupPatch) -> ProjectGroup:
         """Patch the single group matching ``identifiers`` (``{"name", "owner"}`` or ``{"id"}``)."""

--- a/mpcontribs-api/src/mpcontribs_api/domains/project_groups/service.py
+++ b/mpcontribs-api/src/mpcontribs_api/domains/project_groups/service.py
@@ -49,10 +49,6 @@ class ProjectGroupService:
         self._groups = groups
         self._projects = projects
 
-    async def _project_exists(self, project_id: ShortStr) -> bool:
-        """Whether a project with ``project_id`` exists and is visible to the caller."""
-        return await self._projects.get_one({"id": project_id}, fields=frozenset({"id"})) is not None
-
     async def insert_one(self, project_group: ProjectGroupIn) -> ProjectGroup:
         """Insert a new group after verifying every referenced project exists and is visible.
 
@@ -60,7 +56,8 @@ class ProjectGroupService:
         """
         if not self._user.is_admin:
             project_group = project_group.model_copy(update={"owner": self._user.username})
-        missing = [pid for pid in project_group.projects if not await self._project_exists(pid)]
+        existing = await self._projects.existing_ids(list(project_group.projects), scoped=True)
+        missing = [pid for pid in project_group.projects if pid not in existing]
         if missing:
             raise NotFoundError("One or more projects not found or not visible", ids=missing)
         document = self._groups.document_model.from_input_model(project_group)
@@ -129,10 +126,11 @@ class ProjectGroupService:
         A project that does not exist or is not visible to the caller is reported as a failed item;
         the rest are added in a single atomic ``$addToSet`` (idempotent for existing members).
         """
+        existing = await self._projects.existing_ids(project_ids, scoped=True)
         failed: list[BulkFailure] = []
         valid: list[ShortStr] = []
         for index, pid in enumerate(project_ids):
-            if not await self._project_exists(pid):
+            if pid not in existing:
                 failed.append(
                     BulkFailure(
                         index=index,

--- a/mpcontribs-api/src/mpcontribs_api/domains/project_groups/service.py
+++ b/mpcontribs-api/src/mpcontribs_api/domains/project_groups/service.py
@@ -2,6 +2,7 @@ from typing import Any
 
 from beanie import Link
 
+from mpcontribs_api.authz import User
 from mpcontribs_api.domains._shared.bulk import BulkFailure, BulkWriteSummary
 from mpcontribs_api.domains._shared.models import DeleteResponse
 from mpcontribs_api.domains._shared.types import ShortStr
@@ -14,7 +15,7 @@ from mpcontribs_api.domains.project_groups.models import (
 )
 from mpcontribs_api.domains.project_groups.repository import ProjectGroupRepository
 from mpcontribs_api.domains.projects.repository import MongoDbProjectRepository
-from mpcontribs_api.exceptions import NotFoundError
+from mpcontribs_api.exceptions import NotFoundError, PermissionError
 from mpcontribs_api.pagination import CursorParams, Page
 
 # Fields the membership operations need off a resolved group: its id (target of the update) and its
@@ -23,13 +24,27 @@ _GROUP_FIELDS = frozenset({"id", "projects"})
 
 
 class ProjectGroupService:
-    """Coordinates project-group membership changes across the groups and projects collections"""
+    """Owns project-group write policy.
+
+    Authorization lives here, not in the repository:
+
+    - **Owner forcing** on create — a non-admin's new group is owned by the caller (admins may set an
+      owner explicitly).
+    - **Owner-or-admin delete** — a non-admin may delete only their own group, even one they can see;
+      a caller who cannot see the group gets a 404, one who can see but does not own it gets a 403.
+    - **Owner-scoped bulk delete** — a non-admin's ``delete_many`` is restricted to their own groups,
+      overriding any ``owner`` in the filter, so it can never remove others' public groups.
+
+    Membership changes validate each project against the projects collection before writing.
+    """
 
     def __init__(
         self,
+        user: User,
         groups: ProjectGroupRepository,
         projects: MongoDbProjectRepository,
     ) -> None:
+        self._user = user
         self._groups = groups
         self._projects = projects
 
@@ -42,9 +57,8 @@ class ProjectGroupService:
 
         Non-admins are set as owner automatically, while admins can specify owners.
         """
-        user = self._groups._user
-        if not user.is_admin:
-            project_group = project_group.model_copy(update={"owner": user.username})
+        if not self._user.is_admin:
+            project_group = project_group.model_copy(update={"owner": self._user.username})
         missing = [pid for pid in project_group.projects if not await self._project_exists(pid)]
         if missing:
             raise NotFoundError("One or more projects not found or not visible", ids=missing)
@@ -61,7 +75,13 @@ class ProjectGroupService:
         return await self._groups.get_one(identifiers, fields)
 
     async def delete_many(self, filter: ProjectGroupFilter) -> DeleteResponse:
-        """Bulk-delete every scoped project group matching ``filter``."""
+        """Bulk-delete scoped project groups matching ``filter``, restricted to the caller's own.
+
+        A non-admin's bulk delete is scoped to their own groups (overriding any ``owner`` in the
+        filter) so it can never remove public groups belonging to others.
+        """
+        if not self._user.is_admin:
+            filter.owner = self._user.username
         return await self._groups.delete_many(filter=filter)
 
     async def patch_one(self, identifiers: dict[str, Any], update: ProjectGroupPatch) -> ProjectGroup:
@@ -69,7 +89,17 @@ class ProjectGroupService:
         return await self._groups.patch_one(identifiers, update)
 
     async def delete_one(self, identifiers: dict[str, Any]) -> DeleteResponse:
-        """Delete the single group matching ``identifiers`` (``{"name", "owner"}`` or ``{"id"}``)."""
+        """Delete the single group matching ``identifiers`` (``{"name", "owner"}`` or ``{"id"}``).
+
+        Restricted to the owner or an admin. Absence (in scope) takes precedence over the ownership
+        gate: a caller who cannot see the group gets a 404, one who can see it (e.g. a public group)
+        but does not own it gets a 403 rather than a silent no-op.
+        """
+        group = await self._groups.get_one(identifiers, fields=frozenset({"id", "owner"}))
+        if group is None:
+            raise NotFoundError("ProjectGroup not found", **identifiers)
+        if not (self._user.is_admin or group.owner == self._user.username):
+            raise PermissionError(required_role="owner-or-admin")
         return await self._groups.delete_one(identifiers)
 
     async def _resolve_one(self, identifiers: dict[str, Any]) -> ProjectGroupOut:

--- a/mpcontribs-api/src/mpcontribs_api/domains/project_groups/service.py
+++ b/mpcontribs-api/src/mpcontribs_api/domains/project_groups/service.py
@@ -18,9 +18,10 @@ from mpcontribs_api.domains.projects.repository import MongoDbProjectRepository
 from mpcontribs_api.exceptions import NotFoundError, PermissionError
 from mpcontribs_api.pagination import CursorParams, Page
 
-# Fields the membership operations need off a resolved group: its id (target of the update) and its
-# current members (so deletion can tell members from non-members).
-_GROUP_FIELDS = frozenset({"id", "projects"})
+# Fields the membership operations need off a resolved group: its id (target of the update), its
+# owner (to authorize the mutation), and its current members (so deletion can tell members from
+# non-members).
+_GROUP_FIELDS = frozenset({"id", "owner", "projects"})
 
 
 class ProjectGroupService:
@@ -109,7 +110,7 @@ class ProjectGroupService:
         return await self._groups.delete_one(identifiers)
 
     async def _resolve_one(self, identifiers: dict[str, Any]) -> ProjectGroupOut:
-        """Resolve a visible group matching ``identifiers``, or raise ``NotFoundError``.
+        """Resolve a group the caller may *mutate* matching ``identifiers``, or raise.
 
         ``identifiers`` is either the primary-key form ``{"id": <ObjectId str>}`` or the semantic
         ``{"name": ..., "owner": ...}``. Propagates ``ConflictError`` from the repository if
@@ -119,6 +120,8 @@ class ProjectGroupService:
         group = await self._groups.get_one(query, fields=_GROUP_FIELDS)
         if group is None:
             raise NotFoundError("ProjectGroup not found", **identifiers)
+        if not (self._user.is_admin or group.owner == self._user.username):
+            raise PermissionError(required_role="owner-or-admin")
         return group  # pyright: ignore[reportReturnType]  # projected reads return the out model
 
     async def _add(self, group: ProjectGroupOut, project_ids: list[ShortStr]) -> BulkWriteSummary[str]:

--- a/mpcontribs-api/src/mpcontribs_api/domains/project_groups/service.py
+++ b/mpcontribs-api/src/mpcontribs_api/domains/project_groups/service.py
@@ -62,7 +62,8 @@ class ProjectGroupService:
         missing = [pid for pid in project_group.projects if not await self._project_exists(pid)]
         if missing:
             raise NotFoundError("One or more projects not found or not visible", ids=missing)
-        return await self._groups.insert_one(in_resource=project_group)
+        document = self._groups.document_model.from_input_model(project_group)
+        return await self._groups.insert_one(document)
 
     async def get_many(
         self, filter: ProjectGroupFilter, pagination: CursorParams, fields: frozenset[str] | None

--- a/mpcontribs-api/src/mpcontribs_api/domains/project_groups/service.py
+++ b/mpcontribs-api/src/mpcontribs_api/domains/project_groups/service.py
@@ -116,8 +116,7 @@ class ProjectGroupService:
         ``{"name": ..., "owner": ...}``. Propagates ``ConflictError`` from the repository if
         ``(name, owner)`` identifiers are ambiguous.
         """
-        query = self._groups.coerce_identifiers(identifiers)
-        group = await self._groups.get_one(query, fields=_GROUP_FIELDS)
+        group = await self._groups.get_one(identifiers, fields=_GROUP_FIELDS)
         if group is None:
             raise NotFoundError("ProjectGroup not found", **identifiers)
         if not (self._user.is_admin or group.owner == self._user.username):

--- a/mpcontribs-api/src/mpcontribs_api/domains/project_groups/service.py
+++ b/mpcontribs-api/src/mpcontribs_api/domains/project_groups/service.py
@@ -87,6 +87,11 @@ class ProjectGroupService:
 
     async def patch_one(self, identifiers: dict[str, Any], update: ProjectGroupPatch) -> ProjectGroup:
         """Patch the single group matching ``identifiers`` (``{"name", "owner"}`` or ``{"id"}``)."""
+        group = await self._groups.get_one(identifiers, fields=frozenset({"id", "owner"}))
+        if group is None:
+            raise NotFoundError("ProjectGroup not found", **identifiers)
+        if not (self._user.is_admin or group.owner == self._user.username):
+            raise PermissionError(required_role="owner-or-admin")
         return await self._groups.patch_one(identifiers, update)
 
     async def delete_one(self, identifiers: dict[str, Any]) -> DeleteResponse:

--- a/mpcontribs-api/src/mpcontribs_api/domains/project_groups/service.py
+++ b/mpcontribs-api/src/mpcontribs_api/domains/project_groups/service.py
@@ -13,7 +13,7 @@ from mpcontribs_api.domains.project_groups.models import (
     ProjectGroupOut,
     ProjectGroupPatch,
 )
-from mpcontribs_api.domains.project_groups.repository import ProjectGroupRepository
+from mpcontribs_api.domains.project_groups.repository import MongoDbProjectGroupRepository
 from mpcontribs_api.domains.projects.repository import MongoDbProjectRepository
 from mpcontribs_api.exceptions import NotFoundError, PermissionError
 from mpcontribs_api.pagination import CursorParams, Page
@@ -41,7 +41,7 @@ class ProjectGroupService:
     def __init__(
         self,
         user: User,
-        groups: ProjectGroupRepository,
+        groups: MongoDbProjectGroupRepository,
         projects: MongoDbProjectRepository,
     ) -> None:
         self._user = user

--- a/mpcontribs-api/src/mpcontribs_api/domains/project_groups/service.py
+++ b/mpcontribs-api/src/mpcontribs_api/domains/project_groups/service.py
@@ -63,15 +63,15 @@ class ProjectGroupService:
         document = self._groups.document_model.from_input_model(project_group)
         return await self._groups.insert_one(document)
 
-    async def get_many(
+    async def read_many(
         self, filter: ProjectGroupFilter, pagination: CursorParams, fields: frozenset[str] | None
     ) -> Page[ProjectGroupOut]:
         """Return a page of scoped project groups matching ``filter``."""
-        return await self._groups.get_many(pagination=pagination, filter=filter, fields=fields)
+        return await self._groups.read_many(pagination=pagination, filter=filter, fields=fields)
 
-    async def get_one(self, identifiers: dict[str, Any], fields: frozenset[str] | None) -> ProjectGroupOut | None:
+    async def read_one(self, identifiers: dict[str, Any], fields: frozenset[str] | None) -> ProjectGroupOut | None:
         """Return the single group matching ``identifiers`` (``{"name", "owner"}`` or ``{"id"}``)."""
-        return await self._groups.get_one(identifiers, fields)
+        return await self._groups.read_one(identifiers, fields)
 
     async def delete_many(self, filter: ProjectGroupFilter) -> DeleteResponse:
         """Bulk-delete scoped project groups matching ``filter``, restricted to the caller's own.
@@ -83,14 +83,14 @@ class ProjectGroupService:
             filter.owner = self._user.username
         return await self._groups.delete_many(filter=filter)
 
-    async def patch_one(self, identifiers: dict[str, Any], update: ProjectGroupPatch) -> ProjectGroup:
+    async def update_one(self, identifiers: dict[str, Any], update: ProjectGroupPatch) -> ProjectGroup:
         """Patch the single group matching ``identifiers`` (``{"name", "owner"}`` or ``{"id"}``)."""
-        group = await self._groups.get_one(identifiers, fields=frozenset({"id", "owner"}))
+        group = await self._groups.read_one(identifiers, fields=frozenset({"id", "owner"}))
         if group is None:
             raise NotFoundError("ProjectGroup not found", **identifiers)
         if not (self._user.is_admin or group.owner == self._user.username):
             raise PermissionError(required_role="owner-or-admin")
-        return await self._groups.patch_one(identifiers, update)
+        return await self._groups.update_one(identifiers, update)
 
     async def delete_one(self, identifiers: dict[str, Any]) -> DeleteResponse:
         """Delete the single group matching ``identifiers`` (``{"name", "owner"}`` or ``{"id"}``).
@@ -99,7 +99,7 @@ class ProjectGroupService:
         gate: a caller who cannot see the group gets a 404, one who can see it (e.g. a public group)
         but does not own it gets a 403 rather than a silent no-op.
         """
-        group = await self._groups.get_one(identifiers, fields=frozenset({"id", "owner"}))
+        group = await self._groups.read_one(identifiers, fields=frozenset({"id", "owner"}))
         if group is None:
             raise NotFoundError("ProjectGroup not found", **identifiers)
         if not (self._user.is_admin or group.owner == self._user.username):
@@ -113,7 +113,7 @@ class ProjectGroupService:
         ``{"name": ..., "owner": ...}``. Propagates ``ConflictError`` from the repository if
         ``(name, owner)`` identifiers are ambiguous.
         """
-        group = await self._groups.get_one(identifiers, fields=_GROUP_FIELDS)
+        group = await self._groups.read_one(identifiers, fields=_GROUP_FIELDS)
         if group is None:
             raise NotFoundError("ProjectGroup not found", **identifiers)
         if not (self._user.is_admin or group.owner == self._user.username):

--- a/mpcontribs-api/src/mpcontribs_api/domains/projects/dependencies.py
+++ b/mpcontribs-api/src/mpcontribs_api/domains/projects/dependencies.py
@@ -3,7 +3,7 @@ from typing import Annotated
 from fastapi import Depends
 
 from mpcontribs_api.dependencies import UserDep
-from mpcontribs_api.domains.initiatives.repository import InitiativeRepository
+from mpcontribs_api.domains.initiatives.repository import MongoDbInitiativeRepository
 from mpcontribs_api.domains.projects.repository import (
     MongoDbProjectRepository,
 )
@@ -14,7 +14,7 @@ def get_project_service(user: UserDep) -> ProjectService:
     return ProjectService(
         user=user,
         projects=MongoDbProjectRepository(user),
-        initiatives=InitiativeRepository(user),
+        initiatives=MongoDbInitiativeRepository(user),
     )
 
 

--- a/mpcontribs-api/src/mpcontribs_api/domains/projects/dependencies.py
+++ b/mpcontribs-api/src/mpcontribs_api/domains/projects/dependencies.py
@@ -12,6 +12,7 @@ from mpcontribs_api.domains.projects.service import ProjectService
 
 def get_project_service(user: UserDep) -> ProjectService:
     return ProjectService(
+        user=user,
         projects=MongoDbProjectRepository(user),
         initiatives=InitiativeRepository(user),
     )

--- a/mpcontribs-api/src/mpcontribs_api/domains/projects/dependencies.py
+++ b/mpcontribs-api/src/mpcontribs_api/domains/projects/dependencies.py
@@ -3,19 +3,11 @@ from typing import Annotated
 from fastapi import Depends
 
 from mpcontribs_api.dependencies import UserDep
-from mpcontribs_api.domains.consumers.dependencies import ConsumerLimitsDep
 from mpcontribs_api.domains.initiatives.repository import InitiativeRepository
 from mpcontribs_api.domains.projects.repository import (
     MongoDbProjectRepository,
 )
 from mpcontribs_api.domains.projects.service import ProjectService
-
-
-def get_scoped_projects(user: UserDep, limits: ConsumerLimitsDep) -> MongoDbProjectRepository:
-    return MongoDbProjectRepository(user, limits)
-
-
-ProjectDep = Annotated[MongoDbProjectRepository, Depends(get_scoped_projects)]
 
 
 def get_project_service(user: UserDep) -> ProjectService:

--- a/mpcontribs-api/src/mpcontribs_api/domains/projects/repository.py
+++ b/mpcontribs-api/src/mpcontribs_api/domains/projects/repository.py
@@ -2,7 +2,6 @@ from typing import Any
 
 from beanie import PydanticObjectId
 from pymongo import UpdateOne
-from pymongo.asynchronous.client_session import AsyncClientSession
 
 from mpcontribs_api.domains._shared.repository import MongoDbRepository
 from mpcontribs_api.domains.projects.models import (
@@ -19,11 +18,6 @@ from mpcontribs_api.scope import Owned, Public, RoleIn, Scope
 
 class MongoDbProjectRepository(MongoDbRepository[Project, ProjectIn, ProjectOut, ProjectFilter, ProjectPatch]):
     """A repository layer for access to MongoDB.
-
-    This is the layer that directly interacts with database operations. Shared CRUD logic lives on
-    :class:`MongoDbRepository`; the methods here are domain-named forwarders that give routers a
-    consistent vocabulary and concrete types, plus the operations whose shape is genuinely
-    project-specific (id-keyed upsert).
 
     Attributes:
         _scope (dict[str, Any]): additional terms to inject into mongo queries to enforce user
@@ -48,14 +42,6 @@ class MongoDbProjectRepository(MongoDbRepository[Project, ProjectIn, ProjectOut,
         without the scope filter. The service authorizes the write against the returned document.
         """
         return await self.document_model.find_one(self.document_model.id == id)
-
-    async def save(self, document: Project, session: AsyncClientSession | None = None) -> Project:
-        """Persist a fully-built project document (insert or full replace), keyed on its ``id``.
-
-        Mechanical write: the service has already applied every policy decision (ownership, approval,
-        server-field preservation, quota) to ``document``; this just writes it.
-        """
-        return await document.save(session=session)
 
     async def unique_columns_by_id(self, ids: list[str]) -> dict[str, str | None]:
         """Return ``{project_id: unique_column}`` for the given project ids, scoped to the user.

--- a/mpcontribs-api/src/mpcontribs_api/domains/projects/repository.py
+++ b/mpcontribs-api/src/mpcontribs_api/domains/projects/repository.py
@@ -42,7 +42,7 @@ class MongoDbProjectRepository(MongoDbRepository[Project, ProjectIn, ProjectOut,
 
         Projects carry a meaningful ``ShortStr`` id that is not part of the input body, so it is added here.
         """
-        document = Project.from_input_model(project, id=id)
+        document = self.document_model.from_input_model(project, id=id)
         existing = await self.document_model.find_one(self.document_model.id == id)
         if existing:
             raise ConflictError(f"Cannot insert document.\n Document with ID {id} exists")
@@ -141,3 +141,16 @@ class MongoDbProjectRepository(MongoDbRepository[Project, ProjectIn, ProjectOut,
         if exclude_project_id is not None:
             query["_id"] = {"$ne": exclude_project_id}
         return await collection.count_documents(query)
+
+    async def clear_initiative_refs(self, initiative_id: PydanticObjectId) -> int:
+        """Unset the ``initiative`` link on every project pointing at ``initiative_id``.
+
+        Args:
+            initiative_id (PydanticObjectId): the deleted initiative whose back-references to clear
+        """
+        collection = self.document_model.get_pymongo_collection()
+        result = await collection.update_many(
+            {"initiative.$id": initiative_id},
+            {"$set": {"initiative": None}},
+        )
+        return result.modified_count

--- a/mpcontribs-api/src/mpcontribs_api/domains/projects/repository.py
+++ b/mpcontribs-api/src/mpcontribs_api/domains/projects/repository.py
@@ -14,7 +14,6 @@ from mpcontribs_api.domains.projects.models import (
     ProjectPatch,
     Stats,
 )
-from mpcontribs_api.exceptions import ConflictError
 from mpcontribs_api.scope import Owned, Public, RoleIn, Scope
 
 
@@ -36,18 +35,6 @@ class MongoDbProjectRepository(MongoDbRepository[Project, ProjectIn, ProjectOut,
     # Visible when public+approved, owned by the caller, or granted as a bare project role (its
     # ``_id``). Admins bypass scope (handled by ``Scope``).
     read_scope = Scope(Public(approved=True), Owned(), RoleIn("_id", "project_roles"))
-
-    async def insert_one(self, id: str, project: ProjectIn) -> Project:  # pyright: ignore[reportIncompatibleMethodOverride]
-        """Insert a new project under a caller-supplied ``id``, rejecting a duplicate id.
-
-        Projects carry a meaningful ``ShortStr`` id that is not part of the input body, so it is added here.
-        """
-        document = self.document_model.from_input_model(project, id=id)
-        existing = await self.document_model.find_one(self.document_model.id == id)
-        if existing:
-            raise ConflictError(f"Cannot insert document.\n Document with ID {id} exists")
-        await document.insert()
-        return document
 
     async def count_for_owner(self, owner: str) -> int:
         """Count projects owned by ``owner``, ignoring user scope."""

--- a/mpcontribs-api/src/mpcontribs_api/domains/projects/repository.py
+++ b/mpcontribs-api/src/mpcontribs_api/domains/projects/repository.py
@@ -4,10 +4,7 @@ from beanie import PydanticObjectId
 from pymongo import UpdateOne
 from pymongo.asynchronous.client_session import AsyncClientSession
 
-from mpcontribs_api.authz import User
-from mpcontribs_api.domains._shared.models import DeleteResponse
 from mpcontribs_api.domains._shared.repository import MongoDbRepository
-from mpcontribs_api.domains.consumers.models import ConsumerSettings
 from mpcontribs_api.domains.projects.models import (
     Column,
     Project,
@@ -17,7 +14,8 @@ from mpcontribs_api.domains.projects.models import (
     ProjectPatch,
     Stats,
 )
-from mpcontribs_api.exceptions import ConflictError, NotFoundError, PermissionError, ValidationError
+from mpcontribs_api.exceptions import ConflictError
+from mpcontribs_api.scope import Owned, Public, RoleIn, Scope
 
 
 class MongoDbProjectRepository(MongoDbRepository[Project, ProjectIn, ProjectOut, ProjectFilter, ProjectPatch]):
@@ -35,36 +33,42 @@ class MongoDbProjectRepository(MongoDbRepository[Project, ProjectIn, ProjectOut,
 
     document_model = Project
     out_model = ProjectOut
+    # Visible when public+approved, owned by the caller, or granted as a bare project role (its
+    # ``_id``). Admins bypass scope (handled by ``Scope``).
+    read_scope = Scope(Public(approved=True), Owned(), RoleIn("_id", "project_roles"))
 
-    def __init__(self, user: User, limits: ConsumerSettings | None = None) -> None:
-        super().__init__(user)
-        self._user = user
-        self._limits = limits or ConsumerSettings()
+    async def insert_one(self, id: str, project: ProjectIn) -> Project:  # pyright: ignore[reportIncompatibleMethodOverride]
+        """Insert a new project under a caller-supplied ``id``, rejecting a duplicate id.
 
-    @staticmethod
-    def _build_scope(user: User) -> dict[str, Any]:
-        """Provides scope based on current user's permitted groups and publicly released data."""
-        if user.is_admin:
-            return {}
-        ors: list[dict[str, Any]] = [{"is_public": True, "is_approved": True}]
-        if not user.is_anonymous:
-            ors.append({"owner": user.username})
-            if user.groups:
-                ors.append({"_id": {"$in": sorted(user.groups)}})
-        return {"$or": ors}
+        Projects carry a meaningful ``ShortStr`` id that is not part of the input body, so it is added here.
+        """
+        document = Project.from_input_model(project, id=id)
+        existing = await self.document_model.find_one(self.document_model.id == id)
+        if existing:
+            raise ConflictError(f"Cannot insert document.\n Document with ID {id} exists")
+        await document.insert()
+        return document
 
-    async def _check_num_projects(self, owner: str):
-        """Reject a *new* project that would push ``owner`` past the per-user cap."""
-        max_projects = self._limits.max_projects
-        # Soft limit: this count-then-insert is not atomic, so concurrent creates by the same owner
-        # can overshoot the cap by a bounded amount. Acceptable for an anti-abuse quota.
-        result = await Project.find(Project.owner == owner).count()
-        if result >= max_projects:
-            raise PermissionError(
-                f"Cannot be owner of more than {max_projects} projects",
-                owner=owner,
-                num_projects=result,
-            )
+    async def count_for_owner(self, owner: str) -> int:
+        """Count projects owned by ``owner``, ignoring user scope."""
+        return await self.document_model.find(self.document_model.owner == owner).count()
+
+    async def find_by_id_unscoped(self, id: str) -> Project | None:
+        """Return the project with ``id`` regardless of user scope, or ``None`` if absent.
+
+        The upsert path uses this to decide insert-vs-replace: a caller must not be able to "create"
+        a project over an id that already exists but is invisible to them, so existence is checked
+        without the scope filter. The service authorizes the write against the returned document.
+        """
+        return await self.document_model.find_one(self.document_model.id == id)
+
+    async def save(self, document: Project, session: AsyncClientSession | None = None) -> Project:
+        """Persist a fully-built project document (insert or full replace), keyed on its ``id``.
+
+        Mechanical write: the service has already applied every policy decision (ownership, approval,
+        server-field preservation, quota) to ``document``; this just writes it.
+        """
+        return await document.save(session=session)
 
     async def unique_columns_by_id(self, ids: list[str]) -> dict[str, str | None]:
         """Return ``{project_id: unique_column}`` for the given project ids, scoped to the user.
@@ -118,143 +122,6 @@ class MongoDbProjectRepository(MongoDbRepository[Project, ProjectIn, ProjectOut,
             for pid, (stats, cols) in updates.items()
         ]
         await self.document_model.get_pymongo_collection().bulk_write(ops, ordered=False)
-
-    async def insert_one(self, id: str, project: ProjectIn) -> Project:  # pyright: ignore[reportIncompatibleMethodOverride]
-        """Insert a new project under ``id`` (supplied by the caller), rejecting a duplicate id.
-
-        Projects carry a meaningful ``ShortStr`` id that is not part of the input body, so — unlike
-        the generic base ``insert_one`` — the id is passed explicitly and stamped onto the document here.
-        """
-        await self._check_num_projects(project.owner)
-        document = Project.from_input_model(project, id=id)
-        existing = await self.document_model.find_one(self.document_model.id == id)
-        if existing:
-            raise ConflictError(f"Cannot insert document.\n Document with ID {id} exists")
-        await document.insert()
-        return document
-
-    async def patch_one(  # pyright: ignore[reportIncompatibleMethodOverride]
-        self,
-        identifiers: dict[str, Any],
-        update: ProjectPatch,
-        session: AsyncClientSession | None = None,
-        extra_set: dict[str, Any] | None = None,
-    ) -> Project:
-        """Partially update a scoped project by id, enforcing approval rules.
-
-        - Only an admin may change ``is_approved``.
-        - Resulting state must satisfy is_public <-> is_approved condition
-
-        The ``initiative`` field is split out upstream in ``ProjectService.patch_one``, so it never
-        reaches this method as a bare slug; an assignment that also edits plain fields arrives with
-        the resolved link passed through ``extra_set`` (``{"initiative": <DBRef | None>}``) and is
-        written together with the plain fields in the single ``$set``.
-        """
-        await self._enforce_patch_rules(identifiers["id"], update)
-        return await super().patch_one(identifiers, update, session=session, extra_set=extra_set)
-
-    async def _enforce_patch_rules(self, id: str, update: ProjectPatch) -> None:
-        """Enforce project patch invariants against the scoped target.
-
-        - Only an admin may change ``is_approved``.
-        - The resulting state must satisfy the is_public -> is_approved condition.
-
-        Raises ``NotFoundError`` when the project is invisible to the caller or absent, so both the
-        plain and initiative-bearing patch paths reject unseen documents identically.
-        """
-        data = update.model_dump(exclude_unset=True)
-        if "is_approved" in data and not self._user.is_admin:
-            raise PermissionError(required_role="admin")
-
-        existing = await self.document_model.find_one(self._scope, self.document_model.id == id)
-        if existing is None:
-            raise NotFoundError(f"{self.document_model.__name__} not found", id=id)
-
-        resulting_approved = data.get("is_approved", existing.is_approved)
-        resulting_public = data.get("is_public", existing.is_public)
-        if resulting_public and not resulting_approved:
-            raise ValidationError("a project cannot be public until it is approved", id=id)
-
-    async def delete_one(
-        self, identifiers: dict[str, Any], session: AsyncClientSession | None = None
-    ) -> DeleteResponse:
-        """Delete a scoped project by id. Restricted to the owner or an admin.
-
-        Visibility (public/approved or group membership) is not enough to delete: a project can
-        only be dissolved by its owner (or an admin). A caller who cannot see the project gets a
-        404; a caller who can see it but does not own it gets a 403. The auth check runs against the
-        resolved document; the write is delegated to the base :meth:`MongoDbRepository.delete_one`.
-        """
-        id = identifiers["id"]
-        existing = await self.document_model.find_one(self._scope, self._identifier_query({"id": id}))
-        if existing is None:
-            raise NotFoundError(f"{self.document_model.__name__} not found", id=id)
-        if not (self._user.is_admin or existing.owner == self._user.username):
-            raise PermissionError(required_role="owner-or-admin")
-        return await super().delete_one(identifiers, session=session)
-
-    async def upsert_one(self, identifiers: dict[str, Any], data: ProjectIn) -> Project:
-        """Upsert a project by provided id, authorized to the current user.
-
-        Update the document if the id exists, otherwise insert a new one under that id.
-
-        - **Existing project:** only its ``owner`` or an admin may overwrite it. The stored
-          ``owner`` and all server-managed fields (see ``Project.server_managed_fields``) are
-          preserved - ``ProjectIn`` cannot carry them, so a PUT never resets approval, publication,
-          or stats.
-        - **New project:** ``owner`` is forced to the caller; server-managed fields keep their
-          defaults
-
-        Note: relies on the identifier ``id`` for identity, not the body's id.
-
-        Args:
-            identifiers (dict[str, Any]): the identifier of the project to upsert (``{"id": ...}``)
-            data (ProjectIn): the data of the project to upsert
-
-        Returns:
-            Project: the full document that either replaced an old one or was inserted
-
-        Raises:
-            PermissionError: if a non-owner, non-admin caller targets an existing project
-        """
-        # The route enforces authentication, so an anonymous caller should never reach here.
-        if self._user.username is None:
-            raise PermissionError(required_role="authenticated")
-
-        id = identifiers["id"]
-        # ``columns`` are server-owned (derived from contributions) and absent from ProjectIn, so
-        # there is no client-supplied column set to cap on the write path.
-        existing = await self.document_model.find_one(self.document_model.id == id)
-        project = self.document_model.from_input_model(data, id=id)
-        if existing is not None:
-            if not (self._user.is_admin or existing.owner == self._user.username):
-                raise PermissionError(required_role="owner-or-admin")
-            # Ownership is immutable via upsert; keep the original owner. Updating an existing
-            # project does not create a new one, so the per-user project cap does not apply.
-            project.owner = existing.owner
-            # make sure a full replacement doesn't overwrite server-defined fields
-            for field in self.document_model.server_managed_fields():
-                setattr(project, field, getattr(existing, field))
-            # Server-owned rollups are never taken from the request body; keep the stored values
-            # (they self-heal on the next contribution write via ``ContributionService``).
-            project.stats = existing.stats
-            project.columns = existing.columns
-            # Approval is an admin-only curation flag: a non-admin cannot toggle it via a full
-            # overwrite, so preserve whatever is already stored.
-            if not self._user.is_admin:
-                project.is_approved = existing.is_approved
-        else:
-            # New project: the caller owns it, regardless of the submitted owner. Enforce the
-            # per-user cap against the caller before creating another project under their name.
-            project.owner = self._user.username
-            # Approval is admin-only; a non-admin's new project always starts unapproved.
-            if not self._user.is_admin:
-                project.is_approved = False
-            await self._check_num_projects(self._user.username)
-
-        if project.is_public and not project.is_approved:
-            raise ValidationError("a project cannot be public until it is approved", id=id)
-        return await project.save()
 
     async def count_initiative_members(self, initiative_id: PydanticObjectId, exclude_project_id: str | None) -> int:
         """Count projects assigned to an initiative, ignoring user scope.

--- a/mpcontribs-api/src/mpcontribs_api/domains/projects/repository.py
+++ b/mpcontribs-api/src/mpcontribs_api/domains/projects/repository.py
@@ -68,9 +68,6 @@ class MongoDbProjectRepository(MongoDbRepository[Project, ProjectIn, ProjectOut,
     async def existing_ids(self, ids: list[str], *, scoped: bool) -> set[str]:
         """Return the subset of ``ids`` that exist, in one query.
 
-        Lets callers validate a batch of project references with a single round-trip instead of one
-        lookup per id.
-
         Args:
             ids: project ids to check
             scoped: when ``True`` the user read scope is merged in, so an id the caller cannot see is
@@ -91,10 +88,8 @@ class MongoDbProjectRepository(MongoDbRepository[Project, ProjectIn, ProjectOut,
     async def set_stats_and_columns(self, updates: dict[str, tuple[Stats, list[Column]]]) -> None:
         """Overwrite the derived ``stats``/``columns`` of the given projects in one bulk write.
 
-        A **system-computed write**: identity is the project ``_id`` alone and the user scope is
-        deliberately not applied. Stats are recomputed from a project's contributions after a write
-        (see ``ContributionService.update_project``) and must land even when the caller is a group
-        contributor who does not own the project. Missing ids match nothing and are silently skipped.
+        A server-computer write after a writing contributions to a project.
+        Missing ids a silently skipped.
 
         Args:
             updates: ``{project_id: (stats, columns)}`` to persist

--- a/mpcontribs-api/src/mpcontribs_api/domains/projects/repository.py
+++ b/mpcontribs-api/src/mpcontribs_api/domains/projects/repository.py
@@ -30,10 +30,6 @@ class MongoDbProjectRepository(MongoDbRepository[Project, ProjectIn, ProjectOut,
     # ``_id``). Admins bypass scope (handled by ``Scope``).
     read_scope = Scope(Public(approved=True), Owned(), RoleIn("_id", "project_roles"))
 
-    async def count_for_owner(self, owner: str) -> int:
-        """Count projects owned by ``owner``, ignoring user scope."""
-        return await self.document_model.find(self.document_model.owner == owner).count()
-
     async def find_by_id_unscoped(self, id: str) -> Project | None:
         """Return the project with ``id`` regardless of user scope, or ``None`` if absent.
 
@@ -95,25 +91,6 @@ class MongoDbProjectRepository(MongoDbRepository[Project, ProjectIn, ProjectOut,
             for pid, (stats, cols) in updates.items()
         ]
         await self.document_model.get_pymongo_collection().bulk_write(ops, ordered=False)
-
-    async def count_initiative_members(self, initiative_id: PydanticObjectId, exclude_project_id: str | None) -> int:
-        """Count projects assigned to an initiative, ignoring user scope.
-
-        The unapproved-initiative member limit is an integrity constraint on the initiative's true
-        size, so it must count every member regardless of who can see them — a scoped count could
-        let a collaborator overshoot the cap with projects they cannot see. ``exclude_project_id``
-        drops the project being (re)assigned so re-assigning an existing member is idempotent and
-        never trips the limit.
-
-        Args:
-            initiative_id (PydanticObjectId): the initiative whose members to count
-            exclude_project_id (str | None): a project id to exclude from the count, if any
-        """
-        collection = self.document_model.get_pymongo_collection()
-        query: dict[str, Any] = {"initiative.$id": initiative_id}
-        if exclude_project_id is not None:
-            query["_id"] = {"$ne": exclude_project_id}
-        return await collection.count_documents(query)
 
     async def clear_initiative_refs(self, initiative_id: PydanticObjectId) -> int:
         """Unset the ``initiative`` link on every project pointing at ``initiative_id``.

--- a/mpcontribs-api/src/mpcontribs_api/domains/projects/repository.py
+++ b/mpcontribs-api/src/mpcontribs_api/domains/projects/repository.py
@@ -65,6 +65,29 @@ class MongoDbProjectRepository(MongoDbRepository[Project, ProjectIn, ProjectOut,
             result[doc["_id"]] = doc.get("unique_column")
         return result
 
+    async def existing_ids(self, ids: list[str], *, scoped: bool) -> set[str]:
+        """Return the subset of ``ids`` that exist, in one query.
+
+        Lets callers validate a batch of project references with a single round-trip instead of one
+        lookup per id.
+
+        Args:
+            ids: project ids to check
+            scoped: when ``True`` the user read scope is merged in, so an id the caller cannot see is
+                reported as absent (a visibility/reference check). When ``False`` the check spans every
+                project regardless of scope (a global existence / duplicate-id check).
+
+        Returns:
+            set[str]: the subset of ``ids`` present (and, when ``scoped``, visible to the caller)
+        """
+        if not ids:
+            return set()
+        query: dict[str, Any] = {"_id": {"$in": ids}}
+        if scoped and self._scope:
+            query = {"$and": [self._scope, query]}
+        collection = self.document_model.get_pymongo_collection()
+        return {doc["_id"] async for doc in collection.find(query, {"_id": 1})}
+
     async def set_stats_and_columns(self, updates: dict[str, tuple[Stats, list[Column]]]) -> None:
         """Overwrite the derived ``stats``/``columns`` of the given projects in one bulk write.
 

--- a/mpcontribs-api/src/mpcontribs_api/domains/projects/router.py
+++ b/mpcontribs-api/src/mpcontribs_api/domains/projects/router.py
@@ -6,7 +6,7 @@ from starlette.status import HTTP_204_NO_CONTENT
 
 from mpcontribs_api.dependencies import require_user
 from mpcontribs_api.domains._shared.types import FieldSelector
-from mpcontribs_api.domains.projects.dependencies import ProjectDep, ProjectServiceDep
+from mpcontribs_api.domains.projects.dependencies import ProjectServiceDep
 from mpcontribs_api.domains.projects.models import (
     ProjectFilter,
     ProjectIn,
@@ -20,7 +20,7 @@ router = APIRouter()
 
 @router.get("")
 async def get_projects(
-    repo: ProjectDep,
+    service: ProjectServiceDep,
     pagination: Annotated[CursorParams, Depends()],
     filter: ProjectFilter = FilterDepends(ProjectFilter),
     fields: FieldSelector = None,
@@ -28,7 +28,7 @@ async def get_projects(
     """Return paginated projects matching a filter.
 
     Args:
-        repo (ProjectDep): the project repo we depend on
+        service (ProjectServiceDep): the project service we depend on
         pagination (CursorParams): arguments for cursor-based pagination
         fields (list[str] | None): optional ``_fields`` selection. Omitted -> server defaults;
             empty (``?_fields=``) -> identity fields only; ``_all`` -> the full document
@@ -37,7 +37,7 @@ async def get_projects(
         list[ProjectSummary]: a list of smaller project payloads
     """
     selected = ProjectOut.parse_fields(fields)
-    return await repo.get_many(filter=filter, pagination=pagination, fields=selected)
+    return await service.get_many(filter=filter, pagination=pagination, fields=selected)
 
 
 @router.get("/{id}")

--- a/mpcontribs-api/src/mpcontribs_api/domains/projects/router.py
+++ b/mpcontribs-api/src/mpcontribs_api/domains/projects/router.py
@@ -19,7 +19,7 @@ router = APIRouter()
 
 
 @router.get("")
-async def get_projects(
+async def read_many(
     service: ProjectServiceDep,
     pagination: Annotated[CursorParams, Depends()],
     filter: ProjectFilter = FilterDepends(ProjectFilter),
@@ -37,11 +37,11 @@ async def get_projects(
         list[ProjectSummary]: a list of smaller project payloads
     """
     selected = ProjectOut.parse_fields(fields)
-    return await service.get_many(filter=filter, pagination=pagination, fields=selected)
+    return await service.read_many(filter=filter, pagination=pagination, fields=selected)
 
 
 @router.get("/{id}")
-async def get_one(
+async def read_one(
     id: str,
     service: ProjectServiceDep,
     fields: FieldSelector = None,
@@ -58,7 +58,7 @@ async def get_one(
         ProjectOut: the requested project, actual data returned is determined by the view the user requested
     """
     selected = ProjectOut.parse_fields(fields)
-    return await service.get_one({"id": id}, fields=selected)
+    return await service.read_one({"id": id}, fields=selected)
 
 
 @router.put("/{id}", response_model=ProjectOut, dependencies=[Depends(require_user)])
@@ -84,7 +84,7 @@ async def upsert_one(
 
 
 @router.patch("/{id}", response_model=ProjectOut, dependencies=[Depends(require_user)])
-async def patch_one(
+async def update_one(
     service: ProjectServiceDep,
     id: str,
     update: ProjectPatch,
@@ -107,7 +107,7 @@ async def patch_one(
     Returns:
         ProjectOut: the full Project with updates applied
     """
-    return await service.patch_one({"id": id}, update=update)
+    return await service.update_one({"id": id}, update=update)
 
 
 @router.delete("/{id}", status_code=status.HTTP_204_NO_CONTENT, dependencies=[Depends(require_user)])

--- a/mpcontribs-api/src/mpcontribs_api/domains/projects/service.py
+++ b/mpcontribs-api/src/mpcontribs_api/domains/projects/service.py
@@ -130,7 +130,8 @@ class ProjectService:
         overshoot the cap slightly.
         """
         max_projects = self._consumer_limits.max_projects
-        count = await self._projects.count_for_owner(owner)
+        # Unscoped: the per-owner cap is a property of the owner, independent of who is asking.
+        count = await self._projects.count_matching({"owner": owner}, scoped=False)
         if count >= max_projects:
             raise PermissionError(
                 f"Cannot be owner of more than {max_projects} projects",
@@ -182,10 +183,13 @@ class ProjectService:
             )
 
         if not initiative.is_approved:
-            members = await self._projects.count_initiative_members(
-                initiative_id=initiative.id,
-                exclude_project_id=project_id,
-            )
+            # Unscoped integrity count: the member cap must see every project assigned to the
+            # initiative, even ones the caller cannot. Excluding ``project_id`` keeps re-assigning an
+            # already-assigned project idempotent so it never trips the limit.
+            members_query: dict[str, Any] = {"initiative.$id": initiative.id}
+            if project_id is not None:
+                members_query["_id"] = {"$ne": project_id}
+            members = await self._projects.count_matching(members_query, scoped=False)
             if members >= self._initiative_limits.max_projects_per_unapproved:
                 raise ConflictError(
                     message="unapproved initiative already has the maximum number of assigned projects",

--- a/mpcontribs-api/src/mpcontribs_api/domains/projects/service.py
+++ b/mpcontribs-api/src/mpcontribs_api/domains/projects/service.py
@@ -5,9 +5,10 @@ from bson import DBRef
 from mpcontribs_api.config import get_settings
 from mpcontribs_api.domains._shared.models import DeleteResponse
 from mpcontribs_api.domains.initiatives.repository import InitiativeRepository
-from mpcontribs_api.domains.projects.models import Project, ProjectIn, ProjectOut, ProjectPatch
+from mpcontribs_api.domains.projects.models import Project, ProjectFilter, ProjectIn, ProjectOut, ProjectPatch
 from mpcontribs_api.domains.projects.repository import MongoDbProjectRepository
 from mpcontribs_api.exceptions import ConflictError, NotFoundError, PermissionError
+from mpcontribs_api.pagination import CursorParams, Page
 
 
 class ProjectService:
@@ -43,6 +44,12 @@ class ProjectService:
 
         # `initiative` is server derived, so ProjectPatch can't handle it (expects str), so hand it in extra_set
         return await self._projects.patch_one(identifiers, ProjectPatch(**data), extra_set={"initiative": ref})
+
+    async def get_many(
+        self, filter: ProjectFilter, pagination: CursorParams, fields: frozenset[str] | None
+    ) -> Page[ProjectOut]:
+        """Return a page of scoped projects matching ``filter``."""
+        return await self._projects.get_many(filter=filter, pagination=pagination, fields=fields)
 
     async def get_one(self, identifiers: dict[str, Any], fields: frozenset[str] | None) -> Project | ProjectOut | None:
         """Return the single scoped project matching ``identifiers`` (``{"id": ...}``)."""

--- a/mpcontribs-api/src/mpcontribs_api/domains/projects/service.py
+++ b/mpcontribs-api/src/mpcontribs_api/domains/projects/service.py
@@ -29,15 +29,15 @@ class ProjectService:
         self._initiative_limits = get_settings().domain.initiatives
         self._consumer_limits = limits or ConsumerSettings()
 
-    async def get_many(
+    async def read_many(
         self, filter: ProjectFilter, pagination: CursorParams, fields: frozenset[str] | None
     ) -> Page[ProjectOut]:
         """Return a page of scoped projects matching ``filter``."""
-        return await self._projects.get_many(filter=filter, pagination=pagination, fields=fields)
+        return await self._projects.read_many(filter=filter, pagination=pagination, fields=fields)
 
-    async def get_one(self, identifiers: dict[str, Any], fields: frozenset[str] | None) -> Project | ProjectOut | None:
+    async def read_one(self, identifiers: dict[str, Any], fields: frozenset[str] | None) -> Project | ProjectOut | None:
         """Return the single scoped project matching ``identifiers`` (``{"id": ...}``)."""
-        return await self._projects.get_one(identifiers, fields)
+        return await self._projects.read_one(identifiers, fields)
 
     async def upsert_one(self, identifiers: dict[str, Any], data: ProjectIn) -> Project:
         """Upsert a project by id, applying every write-policy decision before persisting.
@@ -89,7 +89,7 @@ class ProjectService:
             raise ValidationError("a project cannot be public until it is approved", id=id)
         return await self._projects.upsert_one(project)
 
-    async def patch_one(self, identifiers: dict[str, Any], update: ProjectPatch) -> Project:
+    async def update_one(self, identifiers: dict[str, Any], update: ProjectPatch) -> Project:
         """Apply a project patch, enforcing approval rules and routing ``initiative`` changes.
 
         The approval rules (admin-only ``is_approved``, ``public ⇒ approved``) are checked against the
@@ -99,7 +99,7 @@ class ProjectService:
         await self._enforce_patch_rules(id, update)
 
         if "initiative" not in update.model_fields_set:
-            return await self._projects.patch_one(identifiers, update)
+            return await self._projects.update_one(identifiers, update)
 
         data = update.model_dump(exclude_unset=True)
         slug = data.pop("initiative", None)
@@ -108,7 +108,7 @@ class ProjectService:
         ref = await self._resolve_initiative_assignment(project_id=id, slug=slug)
 
         # `initiative` is server derived, so ProjectPatch can't handle it (expects str), so hand it in extra_set
-        return await self._projects.patch_one(identifiers, ProjectPatch(**data), extra_set={"initiative": ref})
+        return await self._projects.update_one(identifiers, ProjectPatch(**data), extra_set={"initiative": ref})
 
     async def delete_one(self, identifiers: dict[str, Any]) -> DeleteResponse:
         """Delete a scoped project by id. Restricted to the owner or an admin.
@@ -116,7 +116,7 @@ class ProjectService:
         Project must be deleted by an owner or admin. A caller who cannot see the project gets a 404; a
         caller who can see it but does not own it gets a 403.
         """
-        existing = await self._projects.get_one(identifiers)
+        existing = await self._projects.read_one(identifiers)
         if existing is None:
             raise NotFoundError("Project not found", **identifiers)
         if not (self._user.is_admin or existing.owner == self._user.username):
@@ -155,7 +155,7 @@ class ProjectService:
         if "is_approved" in data and not self._user.is_admin:
             raise PermissionError(required_role="admin")
 
-        existing = await self._projects.get_one({"id": id})
+        existing = await self._projects.read_one({"id": id})
         if existing is None:
             raise NotFoundError("Project not found", id=id)
         if not (self._user.is_admin or existing.owner == self._user.username):
@@ -176,7 +176,7 @@ class ProjectService:
         if slug is None:
             return None
 
-        initiative = await self._initiatives.get_one({"slug": slug})
+        initiative = await self._initiatives.read_one({"slug": slug})
         if initiative is None or initiative.id is None:
             raise NotFoundError("Initiative not found or not visible", slug=slug)
 

--- a/mpcontribs-api/src/mpcontribs_api/domains/projects/service.py
+++ b/mpcontribs-api/src/mpcontribs_api/domains/projects/service.py
@@ -6,7 +6,7 @@ from mpcontribs_api.authz import User
 from mpcontribs_api.config import get_settings
 from mpcontribs_api.domains._shared.models import DeleteResponse
 from mpcontribs_api.domains.consumers.models import ConsumerSettings
-from mpcontribs_api.domains.initiatives.repository import InitiativeRepository
+from mpcontribs_api.domains.initiatives.repository import MongoDbInitiativeRepository
 from mpcontribs_api.domains.projects.models import Project, ProjectFilter, ProjectIn, ProjectOut, ProjectPatch
 from mpcontribs_api.domains.projects.repository import MongoDbProjectRepository
 from mpcontribs_api.exceptions import ConflictError, NotFoundError, PermissionError, ValidationError
@@ -20,7 +20,7 @@ class ProjectService:
         self,
         user: User,
         projects: MongoDbProjectRepository,
-        initiatives: InitiativeRepository,
+        initiatives: MongoDbInitiativeRepository,
         limits: ConsumerSettings | None = None,
     ) -> None:
         self._user = user
@@ -87,7 +87,7 @@ class ProjectService:
 
         if project.is_public and not project.is_approved:
             raise ValidationError("a project cannot be public until it is approved", id=id)
-        return await self._projects.save(project)
+        return await self._projects.upsert_one(project)
 
     async def patch_one(self, identifiers: dict[str, Any], update: ProjectPatch) -> Project:
         """Apply a project patch, enforcing approval rules and routing ``initiative`` changes.

--- a/mpcontribs-api/src/mpcontribs_api/domains/projects/service.py
+++ b/mpcontribs-api/src/mpcontribs_api/domains/projects/service.py
@@ -2,48 +2,32 @@ from typing import Any
 
 from bson import DBRef
 
+from mpcontribs_api.authz import User
 from mpcontribs_api.config import get_settings
 from mpcontribs_api.domains._shared.models import DeleteResponse
+from mpcontribs_api.domains.consumers.models import ConsumerSettings
 from mpcontribs_api.domains.initiatives.repository import InitiativeRepository
 from mpcontribs_api.domains.projects.models import Project, ProjectFilter, ProjectIn, ProjectOut, ProjectPatch
 from mpcontribs_api.domains.projects.repository import MongoDbProjectRepository
-from mpcontribs_api.exceptions import ConflictError, NotFoundError, PermissionError
+from mpcontribs_api.exceptions import ConflictError, NotFoundError, PermissionError, ValidationError
 from mpcontribs_api.pagination import CursorParams, Page
 
 
 class ProjectService:
-    """Coordinates assigning a project to its canonical initiative across the two collections."""
+    """Owns project write policy and coordinates initiative assignment."""
 
     def __init__(
         self,
+        user: User,
         projects: MongoDbProjectRepository,
         initiatives: InitiativeRepository,
+        limits: ConsumerSettings | None = None,
     ) -> None:
+        self._user = user
         self._projects = projects
         self._initiatives = initiatives
-        self._limits = get_settings().domain.initiatives
-
-    async def patch_one(self, identifiers: dict[str, Any], update: ProjectPatch) -> Project:
-        """Apply a project patch, routing an ``initiative`` change through the assignment checks.
-
-        ``initiative`` carries the target initiative's ``slug`` (or ``null`` to unassign). When
-        present it is split out of the patch (so it never reaches the raw ``$set`` as a bare
-        string), resolved to a link — running the both-rights and member-cap checks — then written
-        together with any co-submitted plain fields in a single atomic update, so the request never
-        persists a half-applied change.
-        """
-        id = identifiers["id"]
-        if "initiative" not in update.model_fields_set:
-            return await self._projects.patch_one(identifiers, update)
-
-        data = update.model_dump(exclude_unset=True)
-        slug = data.pop("initiative", None)
-
-        # Resolve the target link (and run the both-rights + limit checks) before touching anything.
-        ref = await self._resolve_initiative_assignment(project_id=id, slug=slug)
-
-        # `initiative` is server derived, so ProjectPatch can't handle it (expects str), so hand it in extra_set
-        return await self._projects.patch_one(identifiers, ProjectPatch(**data), extra_set={"initiative": ref})
+        self._initiative_limits = get_settings().domain.initiatives
+        self._consumer_limits = limits or ConsumerSettings()
 
     async def get_many(
         self, filter: ProjectFilter, pagination: CursorParams, fields: frozenset[str] | None
@@ -56,12 +40,125 @@ class ProjectService:
         return await self._projects.get_one(identifiers, fields)
 
     async def upsert_one(self, identifiers: dict[str, Any], data: ProjectIn) -> Project:
-        """Upsert the project addressed by ``identifiers`` (``{"id": ...}``). See repository."""
-        return await self._projects.upsert_one(identifiers, data)
+        """Upsert a project by id, applying every write-policy decision before persisting.
+
+        Update the document if the id exists, otherwise insert a new one under that id.
+
+        - **Existing project:** only its ``owner`` or an admin may overwrite it. The stored ``owner``
+          and all server-managed fields (see ``Project.server_managed_fields``) are preserved, so a
+          PUT never resets approval, publication, or stats.
+        - **New project:** ``owner`` is forced to the caller, approval starts off for non-admins, and
+          the per-user cap is enforced against the caller.
+
+        Raises:
+            PermissionError: anonymous caller, or a non-owner/non-admin targeting an existing project
+            ConflictError: a new project would push the caller past the per-user project cap
+            ValidationError: the resulting project would be public while unapproved
+        """
+        # The route enforces authentication, so an anonymous caller should never reach here.
+        if self._user.username is None:
+            raise PermissionError(required_role="authenticated")
+
+        id = identifiers["id"]
+        existing = await self._projects.find_by_id_unscoped(id)
+        project = self._projects.document_model.from_input_model(data, id=id)
+
+        if existing is not None:
+            if not (self._user.is_admin or existing.owner == self._user.username):
+                raise PermissionError(required_role="owner-or-admin")
+            # Ownership is immutable via upsert; keep the original owner.
+            project.owner = existing.owner
+            # A full replacement must not overwrite server-defined fields.
+            for field in self._projects.document_model.server_managed_fields():
+                setattr(project, field, getattr(existing, field))
+            # Server owned calculated fields are not taken from request body
+            project.stats = existing.stats
+            project.columns = existing.columns
+            # Approval is an admin-only flag
+            if not self._user.is_admin:
+                project.is_approved = existing.is_approved
+        else:
+            # New project: the caller owns it, regardless of the submitted owner.
+            project.owner = self._user.username
+            # Approval is admin-only; a non-admin's new project always starts unapproved.
+            if not self._user.is_admin:
+                project.is_approved = False
+            await self._enforce_project_cap(self._user.username)
+
+        if project.is_public and not project.is_approved:
+            raise ValidationError("a project cannot be public until it is approved", id=id)
+        return await self._projects.save(project)
+
+    async def patch_one(self, identifiers: dict[str, Any], update: ProjectPatch) -> Project:
+        """Apply a project patch, enforcing approval rules and routing ``initiative`` changes.
+
+        The approval rules (admin-only ``is_approved``, ``public ⇒ approved``) are checked against the
+        scoped target before any write.
+        """
+        id = identifiers["id"]
+        await self._enforce_patch_rules(id, update)
+
+        if "initiative" not in update.model_fields_set:
+            return await self._projects.patch_one(identifiers, update)
+
+        data = update.model_dump(exclude_unset=True)
+        slug = data.pop("initiative", None)
+
+        # Resolve the target link (and run the both-rights + limit checks) before touching anything.
+        ref = await self._resolve_initiative_assignment(project_id=id, slug=slug)
+
+        # `initiative` is server derived, so ProjectPatch can't handle it (expects str), so hand it in extra_set
+        return await self._projects.patch_one(identifiers, ProjectPatch(**data), extra_set={"initiative": ref})
 
     async def delete_one(self, identifiers: dict[str, Any]) -> DeleteResponse:
-        """Delete the scoped project addressed by ``identifiers`` (``{"id": ...}``). See repository."""
+        """Delete a scoped project by id. Restricted to the owner or an admin.
+
+        Project must be deleted by an owner or admin. A caller who cannot see the project gets a 404; a
+        caller who can see it but does not own it gets a 403.
+        """
+        existing = await self._projects.get_one(identifiers)
+        if existing is None:
+            raise NotFoundError("Project not found", **identifiers)
+        if not (self._user.is_admin or existing.owner == self._user.username):
+            raise PermissionError(required_role="owner-or-admin")
         return await self._projects.delete_one(identifiers)
+
+    async def _enforce_project_cap(self, owner: str) -> None:
+        """Reject a *new* project that would push ``owner`` past the per-user cap.
+
+        Soft limit: the count-then-insert is not atomic, so concurrent creates by the same owner can
+        overshoot the cap slightly.
+        """
+        max_projects = self._consumer_limits.max_projects
+        count = await self._projects.count_for_owner(owner)
+        if count >= max_projects:
+            raise PermissionError(
+                f"Cannot be owner of more than {max_projects} projects",
+                owner=owner,
+                num_projects=count,
+            )
+
+    async def _enforce_patch_rules(self, id: str, update: ProjectPatch) -> None:
+        """Enforce project patch invariants against the scoped target.
+
+        - Only an admin may change ``is_approved``.
+        - The resulting state must satisfy the ``is_public ⇒ is_approved`` condition.
+
+        Raises ``NotFoundError`` when the project is invisible to the caller or absent, so both the
+        plain and initiative-bearing patch paths reject unseen documents identically.
+        """
+        data = update.model_dump(exclude_unset=True)
+        if "is_approved" in data and not self._user.is_admin:
+            raise PermissionError(required_role="admin")
+
+        existing = await self._projects.get_one({"id": id})
+        if existing is None:
+            raise NotFoundError("Project not found", id=id)
+
+        resulting_approved = data.get("is_approved", existing.is_approved)
+        resulting_public = data.get("is_public", existing.is_public)
+        if resulting_public and not resulting_approved:
+            raise ValidationError("a project cannot be public until it is approved", id=id)
 
     async def _resolve_initiative_assignment(self, project_id: str, slug: str | None) -> DBRef | None:
         """Validate an initiative assignment and return the link to store (or None to unassign).
@@ -77,8 +174,7 @@ class ProjectService:
         if initiative is None or initiative.id is None:
             raise NotFoundError("Initiative not found or not visible", slug=slug)
 
-        user = self._initiatives._user
-        if not (user.can_manage(id=slug, resource="initiative") or initiative.owner == user.username):
+        if not (self._user.can_manage(id=slug, resource="initiative") or initiative.owner == self._user.username):
             raise PermissionError(
                 message="user does not have adequate acceess to this resource",
                 required_role="initiative-owner-collaborator-or-admin",
@@ -90,11 +186,11 @@ class ProjectService:
                 initiative_id=initiative.id,
                 exclude_project_id=project_id,
             )
-            if members >= self._limits.max_projects_per_unapproved:
+            if members >= self._initiative_limits.max_projects_per_unapproved:
                 raise ConflictError(
                     message="unapproved initiative already has the maximum number of assigned projects",
                     slug=slug,
-                    limit=self._limits.max_projects_per_unapproved,
+                    limit=self._initiative_limits.max_projects_per_unapproved,
                 )
 
         return DBRef("initiatives", initiative.id)

--- a/mpcontribs-api/src/mpcontribs_api/domains/projects/service.py
+++ b/mpcontribs-api/src/mpcontribs_api/domains/projects/service.py
@@ -142,11 +142,14 @@ class ProjectService:
     async def _enforce_patch_rules(self, id: str, update: ProjectPatch) -> None:
         """Enforce project patch invariants against the scoped target.
 
+        - Only the project's owner or an admin may patch it. Read visibility (public/approved or a
+          project role grant) is not enough to write, mirroring ``upsert_one`` and ``delete_one``.
         - Only an admin may change ``is_approved``.
         - The resulting state must satisfy the ``is_public ⇒ is_approved`` condition.
 
         Raises ``NotFoundError`` when the project is invisible to the caller or absent, so both the
-        plain and initiative-bearing patch paths reject unseen documents identically.
+        plain and initiative-bearing patch paths reject unseen documents identically. A caller who
+        can see the project but does not own it gets a ``PermissionError`` (403).
         """
         data = update.model_dump(exclude_unset=True)
         if "is_approved" in data and not self._user.is_admin:
@@ -155,6 +158,8 @@ class ProjectService:
         existing = await self._projects.get_one({"id": id})
         if existing is None:
             raise NotFoundError("Project not found", id=id)
+        if not (self._user.is_admin or existing.owner == self._user.username):
+            raise PermissionError(required_role="owner-or-admin")
 
         resulting_approved = data.get("is_approved", existing.is_approved)
         resulting_public = data.get("is_public", existing.is_public)

--- a/mpcontribs-api/src/mpcontribs_api/domains/structures/router.py
+++ b/mpcontribs-api/src/mpcontribs_api/domains/structures/router.py
@@ -21,25 +21,25 @@ router = APIRouter()
 
 
 @router.get("")
-async def get_structures(
+async def read_many(
     service: StructureServiceDep,
     pagination: Annotated[CursorParams, Depends()],
     filter: StructureFilter = FilterDepends(StructureFilter),
     fields: FieldSelector = None,
 ):
     selected = StructureOut.parse_fields(fields)
-    return await service.get_many(filter=filter, fields=selected, pagination=pagination)
+    return await service.read_many(filter=filter, fields=selected, pagination=pagination)
 
 
 @router.get("/{id}")
-async def get_one(
+async def read_one(
     service: StructureServiceDep,
     id: str,
     fields: FieldSelector = None,
 ):
     """Return a single structure addressed by its ``_id`` or its content ``md5``."""
     selected = StructureOut.parse_fields(fields)
-    return await service.get_one(identifiers={"id": id}, fields=selected)
+    return await service.read_one(identifiers={"id": id}, fields=selected)
 
 
 @router.get("/download/{short_mime}")
@@ -70,7 +70,7 @@ async def download_structure(
 
 
 @router.post("", response_model=BulkWriteSummary[StructureOut], dependencies=[Depends(require_writer)])
-async def insert_structures(
+async def insert_many(
     service: StructureServiceDep,
     structures: list[StructureIn],
 ):
@@ -78,7 +78,7 @@ async def insert_structures(
 
 
 @router.delete("", response_model=ComponentDeleteResponse, dependencies=[Depends(require_user)])
-async def delete_structures(service: StructureServiceDep, filter: StructureFilter = FilterDepends(StructureFilter)):
+async def delete_many(service: StructureServiceDep, filter: StructureFilter = FilterDepends(StructureFilter)):
     return await service.delete_many(filter=filter)
 
 
@@ -89,10 +89,10 @@ async def delete_one(service: StructureServiceDep, id: str):
 
 
 @router.patch("/{id}", dependencies=[Depends(require_user)])
-async def patch_one(
+async def update_one(
     service: StructureServiceDep,
     id: str,
     update: StructurePatch,
 ):
     """Patch a single structure addressed by its ``_id`` or its content ``md5``."""
-    return await service.patch_one(identifiers={"id": id}, update=update)
+    return await service.update_one(identifiers={"id": id}, update=update)

--- a/mpcontribs-api/src/mpcontribs_api/domains/tables/router.py
+++ b/mpcontribs-api/src/mpcontribs_api/domains/tables/router.py
@@ -21,25 +21,25 @@ router = APIRouter()
 
 
 @router.get("")
-async def get_tables(
+async def read_many(
     service: TableServiceDep,
     pagination: Annotated[CursorParams, Depends()],
     filter: TableFilter = FilterDepends(TableFilter),
     fields: FieldSelector = None,
 ):
     selected = TableOut.parse_fields(fields)
-    return await service.get_many(filter=filter, fields=selected, pagination=pagination)
+    return await service.read_many(filter=filter, fields=selected, pagination=pagination)
 
 
 @router.get("/{id}")
-async def get_one(
+async def read_one(
     service: TableServiceDep,
     id: str,
     fields: FieldSelector = None,
 ):
     """Return a single table addressed by its ``_id`` or its content ``md5``."""
     selected = TableOut.parse_fields(fields)
-    return await service.get_one(identifiers={"id": id}, fields=selected)
+    return await service.read_one(identifiers={"id": id}, fields=selected)
 
 
 @router.get("/download/{short_mime}")
@@ -70,7 +70,7 @@ async def download_table(
 
 
 @router.post("", response_model=BulkWriteSummary[Table], dependencies=[Depends(require_writer)])
-async def insert_tables(
+async def insert_many(
     service: TableServiceDep,
     tables: list[TableIn],
 ):
@@ -78,7 +78,7 @@ async def insert_tables(
 
 
 @router.delete("", response_model=ComponentDeleteResponse, dependencies=[Depends(require_user)])
-async def delete_tables(service: TableServiceDep, filter: TableFilter = FilterDepends(TableFilter)):
+async def delete_many(service: TableServiceDep, filter: TableFilter = FilterDepends(TableFilter)):
     return await service.delete_many(filter=filter)
 
 
@@ -89,10 +89,10 @@ async def delete_one(service: TableServiceDep, id: str):
 
 
 @router.patch("/{id}", dependencies=[Depends(require_user)])
-async def patch_one(
+async def update_one(
     service: TableServiceDep,
     id: str,
     update: TablePatch,
 ):
     """Patch a single table addressed by its ``_id``."""
-    return await service.patch_one(identifiers={"id": id}, update=update)
+    return await service.update_one(identifiers={"id": id}, update=update)

--- a/mpcontribs-api/src/mpcontribs_api/scope.py
+++ b/mpcontribs-api/src/mpcontribs_api/scope.py
@@ -1,0 +1,104 @@
+from collections.abc import Callable, Collection
+from dataclasses import dataclass
+from typing import Any, Protocol, runtime_checkable
+
+from mpcontribs_api.authz import User
+
+
+@runtime_checkable
+class ScopeClause(Protocol):
+    """One term of a read-visibility rule.
+
+    Returns the MongoDB fragment that grants visibility to ``user`` under this clause, or ``None``
+    when the clause does not apply (e.g. an owner clause for an anonymous caller). Returning ``None``
+    drops the clause from the ``$or`` rather than contributing a match-nothing term.
+    """
+
+    def to_query(self, user: User) -> dict[str, Any] | None: ...
+
+
+@dataclass(frozen=True)
+class Public:
+    """Visibility of released data: public (optionally also approved) documents.
+
+    Always applies — public documents are visible to every caller, including anonymous ones — so this
+    is the baseline clause every scoped collection includes.
+    """
+
+    approved: bool = False
+
+    def to_query(self, user: User) -> dict[str, Any]:
+        if self.approved:
+            return {"is_public": True, "is_approved": True}
+        return {"is_public": True}
+
+
+@dataclass(frozen=True)
+class Owned:
+    """Visibility of the caller's own documents, keyed on an owner field.
+
+    Inapplicable to anonymous callers: ``{owner: None}`` would wrongly match owner-less documents, so
+    the clause is dropped rather than emitted.
+    """
+
+    field: str = "owner"
+
+    def to_query(self, user: User) -> dict[str, Any] | None:
+        if user.is_anonymous:
+            return None
+        return {self.field: user.username}
+
+
+@dataclass(frozen=True)
+class RoleIn:
+    """Visibility granted by the caller's roles, as a ``{field: {"$in": [...]}}`` membership test.
+
+    ``source`` names the ``User`` attribute holding the granted ids (e.g. ``"project_roles"``).
+    ``coerce`` optionally maps each raw role value to the collection's id type (e.g. ``ObjectId`` for
+    an ObjectId ``_id``); a value whose coercion fails is **dropped** — scope is fail-closed, so an
+    uncoercible (malformed) role grant is simply not honored. The clause is dropped entirely when the
+    caller holds no (usable) roles.
+    """
+
+    field: str
+    source: str
+    # TODO: Remove once _id -> PydanticObjectId coercion handling is improved
+    coerce: Callable[[Any], Any] | None = None
+
+    def to_query(self, user: User) -> dict[str, Any] | None:
+        raw: Collection[Any] = getattr(user, self.source)
+        values = self._coerce(raw)
+        if not values:
+            return None
+        return {self.field: {"$in": sorted(values)}}
+
+    def _coerce(self, raw: Collection[Any]) -> list[Any]:
+        if self.coerce is None:
+            return list(raw)
+        out: list[Any] = []
+        for value in raw:
+            try:
+                out.append(self.coerce(value))
+            except Exception:
+                # Fail-closed: a role value that cannot be coerced to the id type is not a grant.
+                continue
+        return out
+
+
+class Scope:
+    """A collection's read-visibility rule as a composition of :class:`ScopeClause` terms.
+
+    :meth:`query` turns a ``User`` into the MongoDB filter injected into every scoped read. Admins
+    bypass read scope everywhere (a global rule, matching ``User.is_admin``). A ``Scope`` with no
+    clauses filters nothing — the explicit "unscoped collection" case (components, consumers), whose
+    visibility is gated elsewhere or not at all.
+    """
+
+    def __init__(self, *clauses: ScopeClause) -> None:
+        self.clauses: tuple[ScopeClause, ...] = clauses
+
+    def query(self, user: User) -> dict[str, Any]:
+        if user.is_admin:
+            return {}
+        ors = [fragment for clause in self.clauses if (fragment := clause.to_query(user)) is not None]
+        return {"$or": ors} if ors else {}

--- a/mpcontribs-api/tests/integration/conftest.py
+++ b/mpcontribs-api/tests/integration/conftest.py
@@ -97,14 +97,6 @@ def test_app() -> FastAPI:
 @pytest.fixture
 def client(test_app: FastAPI):
     """Function-scoped client; dependency overrides are cleared after each test."""
-    from mpcontribs_api.domains.consumers.dependencies import get_effective_limits
-    from mpcontribs_api.domains.consumers.models import ConsumerSettings
-
-    # Mock-based integration tests run without a database. Resolving per-consumer limits normally
-    # awaits the (mocked) consumers collection, which would 500 the request before it reaches the
-    # code under test. Default the dependency to the global-default limits; tests that specifically
-    # assert override behavior can install their own override.
-    test_app.dependency_overrides[get_effective_limits] = lambda: ConsumerSettings()
     with TestClient(test_app, raise_server_exceptions=False) as c:
         yield c
     test_app.dependency_overrides.clear()

--- a/mpcontribs-api/tests/integration/db/test_bulk_publish.py
+++ b/mpcontribs-api/tests/integration/db/test_bulk_publish.py
@@ -63,7 +63,7 @@ class TestBulkPublishAuthorization:
         a = await _insert(PROJ_A, "c1", is_public=False)
         b = await _insert(PROJ_B, "c1", is_public=False)
 
-        summary = await _service(mongo_client, ALICE).bulk_update(
+        summary = await _service(mongo_client, ALICE).patch_many(
             ContributionFilter(), ContributionPatch(is_public=True)
         )
 
@@ -77,7 +77,7 @@ class TestBulkPublishAuthorization:
         # update constrains to writable projects, so a filter matching it modifies nothing.
         b = await _insert(PROJ_B, "pub", is_public=True)
 
-        summary = await _service(mongo_client, ALICE).bulk_update(
+        summary = await _service(mongo_client, ALICE).patch_many(
             ContributionFilter(is_public=True), ContributionPatch(is_public=False)
         )
 
@@ -89,7 +89,7 @@ class TestBulkPublishAuthorization:
         a = await _insert(PROJ_A, "c1", is_public=False)
         b = await _insert(PROJ_B, "c1", is_public=False)
 
-        summary = await _service(mongo_client, ADMIN).bulk_update(
+        summary = await _service(mongo_client, ADMIN).patch_many(
             ContributionFilter(), ContributionPatch(is_public=True)
         )
 
@@ -103,8 +103,8 @@ class TestSinglePublish:
     async def test_patch_by_id_publishes_single_contribution(self, db, mongo_client):
         a = await _insert(PROJ_A, "c1", is_public=False)
 
-        result = await _service(mongo_client, ALICE).patch_contribution_by_id(
-            str(a.id), ContributionPatch(is_public=True)
+        result = await _service(mongo_client, ALICE).patch_one(
+            {"id": str(a.id)}, ContributionPatch(is_public=True)
         )
 
         assert result.is_public is True
@@ -135,7 +135,7 @@ class TestBulkPatchPerRow:
         a = await _insert_row(PROJ_A, formula="Fe2O3", data={"x": 1.0})
         b = await _insert_row(PROJ_A, formula="Fe3O4", data={"x": 2.0})
 
-        summary = await _service(mongo_client, ALICE).bulk_update(
+        summary = await _service(mongo_client, ALICE).patch_many(
             ContributionFilter(chemical_system_id="Fe-O"), ContributionPatch(data={"y": 9.0})
         )
 
@@ -151,7 +151,7 @@ class TestBulkPatchPerRow:
         a = await _insert_row(PROJ_A, formula="Fe2O3", data={"x": 1.0})
         b = await _insert_row(PROJ_A, formula="Fe3O4", data={"x": 2.0})
 
-        summary = await _service(mongo_client, ALICE).bulk_update(
+        summary = await _service(mongo_client, ALICE).patch_many(
             ContributionFilter(chemical_system_id="Fe-O"),
             ContributionPatch(data={"y": 9.0}),
             replace_data=True,
@@ -168,7 +168,7 @@ class TestBulkPatchPerRow:
         leaf = QuantityLeaf.from_submission(2.0, "m").as_dict()
         c = await _insert_row(PROJ_A, formula="Fe2O3", data={"bandgap": leaf})
 
-        summary = await _service(mongo_client, ALICE).bulk_update(
+        summary = await _service(mongo_client, ALICE).patch_many(
             ContributionFilter(chemical_system_id="Fe-O"), ContributionPatch(data={"bandgap": 5.0})
         )
 
@@ -184,7 +184,7 @@ class TestBulkPatchPerRow:
         leaf = QuantityLeaf.from_submission(2.0, "m").as_dict()
         c = await _insert_row(PROJ_A, formula="Fe2O3", data={"bandgap": leaf})
 
-        summary = await _service(mongo_client, ALICE).bulk_update(
+        summary = await _service(mongo_client, ALICE).patch_many(
             ContributionFilter(chemical_system_id="Fe-O"), ContributionPatch(data={"bandgap": {"unit": "km"}})
         )
 
@@ -201,7 +201,7 @@ class TestBulkPatchPerRow:
         keep = await _insert_row(PROJ_A, formula="Fe2O3", data={"x": 1.0})
         clash = await _insert_row(PROJ_A, formula="Fe3O4", data={"x": 2.0})
 
-        summary = await _service(mongo_client, ALICE).bulk_update(
+        summary = await _service(mongo_client, ALICE).patch_many(
             ContributionFilter(chemical_system_id="Fe-O"), ContributionPatch(formula="Fe2O3")
         )
 
@@ -223,7 +223,7 @@ class TestBulkPatchPerRow:
         foreign.is_public = True
         await foreign.insert()
 
-        summary = await _service(mongo_client, ALICE).bulk_update(
+        summary = await _service(mongo_client, ALICE).patch_many(
             ContributionFilter(chemical_system_id="Fe-O"), ContributionPatch(data={"y": 9.0})
         )
 

--- a/mpcontribs-api/tests/integration/db/test_bulk_publish.py
+++ b/mpcontribs-api/tests/integration/db/test_bulk_publish.py
@@ -64,7 +64,7 @@ class TestBulkPublishAuthorization:
         a = await _insert(PROJ_A, "c1", is_public=False)
         b = await _insert(PROJ_B, "c1", is_public=False)
 
-        summary = await _service(mongo_client, ALICE).patch_many(
+        summary = await _service(mongo_client, ALICE).update_many(
             ContributionFilter(), ContributionPatch(is_public=True)
         )
 
@@ -78,7 +78,7 @@ class TestBulkPublishAuthorization:
         # update constrains to writable projects, so a filter matching it modifies nothing.
         b = await _insert(PROJ_B, "pub", is_public=True)
 
-        summary = await _service(mongo_client, ALICE).patch_many(
+        summary = await _service(mongo_client, ALICE).update_many(
             ContributionFilter(is_public=True), ContributionPatch(is_public=False)
         )
 
@@ -90,7 +90,7 @@ class TestBulkPublishAuthorization:
         a = await _insert(PROJ_A, "c1", is_public=False)
         b = await _insert(PROJ_B, "c1", is_public=False)
 
-        summary = await _service(mongo_client, ADMIN).patch_many(
+        summary = await _service(mongo_client, ADMIN).update_many(
             ContributionFilter(), ContributionPatch(is_public=True)
         )
 
@@ -104,7 +104,7 @@ class TestSinglePublish:
     async def test_patch_by_id_publishes_single_contribution(self, db, mongo_client):
         a = await _insert(PROJ_A, "c1", is_public=False)
 
-        result = await _service(mongo_client, ALICE).patch_one(
+        result = await _service(mongo_client, ALICE).update_one(
             {"id": str(a.id)}, ContributionPatch(is_public=True)
         )
 
@@ -136,7 +136,7 @@ class TestBulkPatchPerRow:
         a = await _insert_row(PROJ_A, formula="Fe2O3", data={"x": 1.0})
         b = await _insert_row(PROJ_A, formula="Fe3O4", data={"x": 2.0})
 
-        summary = await _service(mongo_client, ALICE).patch_many(
+        summary = await _service(mongo_client, ALICE).update_many(
             ContributionFilter(chemical_system_id="Fe-O"), ContributionPatch(data={"y": 9.0})
         )
 
@@ -152,7 +152,7 @@ class TestBulkPatchPerRow:
         a = await _insert_row(PROJ_A, formula="Fe2O3", data={"x": 1.0})
         b = await _insert_row(PROJ_A, formula="Fe3O4", data={"x": 2.0})
 
-        summary = await _service(mongo_client, ALICE).patch_many(
+        summary = await _service(mongo_client, ALICE).update_many(
             ContributionFilter(chemical_system_id="Fe-O"),
             ContributionPatch(data={"y": 9.0}),
             replace_data=True,
@@ -169,7 +169,7 @@ class TestBulkPatchPerRow:
         leaf = QuantityLeaf.from_submission(2.0, "m").as_dict()
         c = await _insert_row(PROJ_A, formula="Fe2O3", data={"bandgap": leaf})
 
-        summary = await _service(mongo_client, ALICE).patch_many(
+        summary = await _service(mongo_client, ALICE).update_many(
             ContributionFilter(chemical_system_id="Fe-O"), ContributionPatch(data={"bandgap": 5.0})
         )
 
@@ -185,7 +185,7 @@ class TestBulkPatchPerRow:
         leaf = QuantityLeaf.from_submission(2.0, "m").as_dict()
         c = await _insert_row(PROJ_A, formula="Fe2O3", data={"bandgap": leaf})
 
-        summary = await _service(mongo_client, ALICE).patch_many(
+        summary = await _service(mongo_client, ALICE).update_many(
             ContributionFilter(chemical_system_id="Fe-O"), ContributionPatch(data={"bandgap": {"unit": "km"}})
         )
 
@@ -202,7 +202,7 @@ class TestBulkPatchPerRow:
         keep = await _insert_row(PROJ_A, formula="Fe2O3", data={"x": 1.0})
         clash = await _insert_row(PROJ_A, formula="Fe3O4", data={"x": 2.0})
 
-        summary = await _service(mongo_client, ALICE).patch_many(
+        summary = await _service(mongo_client, ALICE).update_many(
             ContributionFilter(chemical_system_id="Fe-O"), ContributionPatch(formula="Fe2O3")
         )
 
@@ -224,7 +224,7 @@ class TestBulkPatchPerRow:
         foreign.is_public = True
         await foreign.insert()
 
-        summary = await _service(mongo_client, ALICE).patch_many(
+        summary = await _service(mongo_client, ALICE).update_many(
             ContributionFilter(chemical_system_id="Fe-O"), ContributionPatch(data={"y": 9.0})
         )
 
@@ -275,15 +275,15 @@ class TestPatchOneWriteScope:
         # Alice sees the public proj-b contribution but has no write role → 403, left unchanged.
         pub = await _insert(PROJ_B, "patch-foreign", is_public=True)
         with pytest.raises(PermissionError):
-            await _service(mongo_client, ALICE).patch_one({"id": pub.id}, ContributionPatch(is_public=False))
+            await _service(mongo_client, ALICE).update_one({"id": pub.id}, ContributionPatch(is_public=False))
         assert await _is_public(pub.id) is True
 
     async def test_writer_can_patch_own(self, db, mongo_client):
         own = await _insert(PROJ_A, "patch-own", is_public=True)
-        await _service(mongo_client, ALICE).patch_one({"id": own.id}, ContributionPatch(is_public=False))
+        await _service(mongo_client, ALICE).update_one({"id": own.id}, ContributionPatch(is_public=False))
         assert await _is_public(own.id) is False
 
     async def test_admin_can_patch_foreign(self, db, mongo_client):
         pub = await _insert(PROJ_B, "patch-admin", is_public=True)
-        await _service(mongo_client, ADMIN).patch_one({"id": pub.id}, ContributionPatch(is_public=False))
+        await _service(mongo_client, ADMIN).update_one({"id": pub.id}, ContributionPatch(is_public=False))
         assert await _is_public(pub.id) is False

--- a/mpcontribs-api/tests/integration/db/test_bulk_publish.py
+++ b/mpcontribs-api/tests/integration/db/test_bulk_publish.py
@@ -14,6 +14,7 @@ from mpcontribs_api.domains.contributions.service import ContributionService
 from mpcontribs_api.domains.projects.repository import MongoDbProjectRepository
 from mpcontribs_api.domains.structures.repository import MongoDbStructureRepository
 from mpcontribs_api.domains.tables.repository import MongoDbTableRepository
+from mpcontribs_api.exceptions import PermissionError
 
 pytestmark = [pytest.mark.db, pytest.mark.asyncio(loop_scope="session")]
 
@@ -231,3 +232,58 @@ class TestBulkPatchPerRow:
         assert summary.projects == [PROJ_A]
         assert (await _reload(mine.id)).data == {"x": 1.0, "y": 9.0}  # merged, not replaced
         assert (await _reload(foreign.id)).data == {"x": 1.0}  # foreign project untouched
+
+
+# ---------------------------------------------------------------------------
+# delete / single-patch write scope — a write must be gated on write access, not
+# the read scope (which also exposes public contributions). Regression guard for
+# the hole where any authenticated caller could delete/patch public contributions
+# under a project they had no write role on.
+# ---------------------------------------------------------------------------
+
+
+class TestDeleteWriteScope:
+    async def test_non_writer_cannot_bulk_delete_public_foreign(self, db, mongo_client):
+        # Alice can *see* this public proj-b contribution (read scope), but cannot write proj-b, so a
+        # broad delete must not touch it.
+        pub = await _insert(PROJ_B, "del-foreign", is_public=True)
+        summary = await _service(mongo_client, ALICE).delete_many(ContributionFilter())
+        assert summary.num_deleted == 0
+        assert await Contribution.find_one(Contribution.id == pub.id) is not None
+
+    async def test_non_writer_delete_one_public_foreign_noops(self, db, mongo_client):
+        pub = await _insert(PROJ_B, "del-one-foreign", is_public=True)
+        summary = await _service(mongo_client, ALICE).delete_one({"id": pub.id})
+        assert summary.num_deleted == 0
+        assert await Contribution.find_one(Contribution.id == pub.id) is not None
+
+    async def test_writer_can_delete_own(self, db, mongo_client):
+        own = await _insert(PROJ_A, "del-own", is_public=True)
+        summary = await _service(mongo_client, ALICE).delete_one({"id": own.id})
+        assert summary.num_deleted == 1
+        assert await Contribution.find_one(Contribution.id == own.id) is None
+
+    async def test_admin_can_delete_foreign(self, db, mongo_client):
+        pub = await _insert(PROJ_B, "del-admin", is_public=True)
+        summary = await _service(mongo_client, ADMIN).delete_one({"id": pub.id})
+        assert summary.num_deleted == 1
+        assert await Contribution.find_one(Contribution.id == pub.id) is None
+
+
+class TestPatchOneWriteScope:
+    async def test_non_writer_cannot_patch_public_foreign(self, db, mongo_client):
+        # Alice sees the public proj-b contribution but has no write role → 403, left unchanged.
+        pub = await _insert(PROJ_B, "patch-foreign", is_public=True)
+        with pytest.raises(PermissionError):
+            await _service(mongo_client, ALICE).patch_one({"id": pub.id}, ContributionPatch(is_public=False))
+        assert await _is_public(pub.id) is True
+
+    async def test_writer_can_patch_own(self, db, mongo_client):
+        own = await _insert(PROJ_A, "patch-own", is_public=True)
+        await _service(mongo_client, ALICE).patch_one({"id": own.id}, ContributionPatch(is_public=False))
+        assert await _is_public(own.id) is False
+
+    async def test_admin_can_patch_foreign(self, db, mongo_client):
+        pub = await _insert(PROJ_B, "patch-admin", is_public=True)
+        await _service(mongo_client, ADMIN).patch_one({"id": pub.id}, ContributionPatch(is_public=False))
+        assert await _is_public(pub.id) is False

--- a/mpcontribs-api/tests/integration/db/test_component_reachability.py
+++ b/mpcontribs-api/tests/integration/db/test_component_reachability.py
@@ -55,7 +55,7 @@ class TestComponentReadReachability:
     async def test_get_by_id_returns_reachable_component(self, db):
         att = await _attachment(1)
         await _contribution("mp-pub", is_public=True, attachments=[att])
-        result = await _service(ANON).get_one({"id": str(att.id)}, fields=None)
+        result = await _service(ANON).read_one({"id": str(att.id)}, fields=None)
         assert result is not None
         assert result.id == att.id
 
@@ -63,13 +63,13 @@ class TestComponentReadReachability:
         att = await _attachment(2)
         # Referenced only by a private contribution -> anonymous cannot reach it.
         await _contribution("mp-priv", is_public=False, attachments=[att])
-        result = await _service(ANON).get_one({"id": str(att.id)}, fields=None)
+        result = await _service(ANON).read_one({"id": str(att.id)}, fields=None)
         assert result is None
 
     async def test_get_by_id_hides_orphan_component(self, db):
         # No contribution references this attachment at all.
         att = await _attachment(3)
-        result = await _service(ANON).get_one({"id": str(att.id)}, fields=None)
+        result = await _service(ANON).read_one({"id": str(att.id)}, fields=None)
         assert result is None
 
     async def test_get_many_only_lists_reachable(self, db):
@@ -79,7 +79,7 @@ class TestComponentReadReachability:
         await _contribution("mp-a", is_public=True, attachments=[pub])
         await _contribution("mp-b", is_public=False, attachments=[priv])
 
-        page = await _service(ANON).get_many(filter=AttachmentFilter(), pagination=CursorParams(), fields=None)
+        page = await _service(ANON).read_many(filter=AttachmentFilter(), pagination=CursorParams(), fields=None)
         ids = {item.id for item in page.items}
 
         assert pub.id in ids

--- a/mpcontribs-api/tests/integration/db/test_components_repository.py
+++ b/mpcontribs-api/tests/integration/db/test_components_repository.py
@@ -38,13 +38,22 @@ async def _count() -> int:
     return await Attachment.find_all().count()
 
 
+def _build(repo, inputs) -> list:
+    """Coerce inputs into stored documents the way the service layer does before inserting.
+
+    The repository's ``insert_many`` now takes fully-built documents (md5 is computed by the model on
+    validation), so tests build via ``from_input`` first.
+    """
+    return [repo.document_model.from_input(i) for i in inputs]
+
+
 async def _insert(repo, inputs) -> list:
     """Insert and return just the resolved docs, asserting no per-item failures.
 
     ``insert_many`` now returns ``(indexed_successes, failures)`` (per-item reporting); most tests
     only care about the resolved documents on the success path.
     """
-    successes, failures = await repo.insert_many(inputs)
+    successes, failures = await repo.insert_many(_build(repo, inputs))
     assert failures == []
     return [doc for _, doc in successes]
 
@@ -57,7 +66,8 @@ async def _insert(repo, inputs) -> list:
 class TestInsertComponentsDedupe:
     async def test_duplicate_content_in_batch_inserted_once(self, db):
         # Two inputs share content (-> same md5); only one document should be written.
-        await _repo().insert_many([_attachment(1), _attachment(1), _attachment(2)])
+        repo = _repo()
+        await repo.insert_many(_build(repo, [_attachment(1), _attachment(1), _attachment(2)]))
         assert await _count() == 2
 
     async def test_returns_one_doc_per_input_deduped_to_same_doc(self, db):
@@ -66,9 +76,10 @@ class TestInsertComponentsDedupe:
         assert docs[0].id == docs[1].id
 
     async def test_existing_md5_not_reinserted(self, db):
-        await _repo().insert_many([_attachment(1)])
+        repo = _repo()
+        await repo.insert_many(_build(repo, [_attachment(1)]))
         # Re-submit the existing content alongside new content.
-        await _repo().insert_many([_attachment(1), _attachment(2)])
+        await repo.insert_many(_build(repo, [_attachment(1), _attachment(2)]))
         assert await _count() == 2
 
     async def test_existing_doc_returned_with_original_id(self, db):
@@ -104,7 +115,9 @@ class TestInsertComponentsChunking:
 
 class TestInsertComponent:
     async def test_single_insert_persists(self, db):
-        doc = await _repo().insert_one(_attachment(3))
+        repo = _repo()
+        [built] = _build(repo, [_attachment(3)])
+        doc = await repo.insert_one(built)
         found = await Attachment.find_one(Attachment.id == doc.id)
         assert found is not None
         assert found.md5 == doc.md5
@@ -200,7 +213,8 @@ class TestPatchComponent:
 class TestComponentDownload:
     async def test_jsonl_download_round_trips(self, db):
         """Component downloads stream a decompressable gzip of all rows."""
-        await _repo().insert_many([_attachment(1), _attachment(2)])
+        repo = _repo()
+        await repo.insert_many(_build(repo, [_attachment(1), _attachment(2)]))
         stream = _repo().download(
             format=DownloadFormat.JSONL,
             short_mime=ShortMimeFormat.GZ,

--- a/mpcontribs-api/tests/integration/db/test_components_repository.py
+++ b/mpcontribs-api/tests/integration/db/test_components_repository.py
@@ -38,6 +38,17 @@ async def _count() -> int:
     return await Attachment.find_all().count()
 
 
+async def _insert(repo, inputs) -> list:
+    """Insert and return just the resolved docs, asserting no per-item failures.
+
+    ``insert_many`` now returns ``(indexed_successes, failures)`` (per-item reporting); most tests
+    only care about the resolved documents on the success path.
+    """
+    successes, failures = await repo.insert_many(inputs)
+    assert failures == []
+    return [doc for _, doc in successes]
+
+
 # ---------------------------------------------------------------------------
 # insert_many: md5 dedupe
 # ---------------------------------------------------------------------------
@@ -49,9 +60,10 @@ class TestInsertComponentsDedupe:
         await _repo().insert_many([_attachment(1), _attachment(1), _attachment(2)])
         assert await _count() == 2
 
-    async def test_returns_one_doc_per_unique_md5(self, db):
-        result = await _repo().insert_many([_attachment(1), _attachment(1)])
-        assert len(result) == 1
+    async def test_returns_one_doc_per_input_deduped_to_same_doc(self, db):
+        docs = await _insert(_repo(), [_attachment(1), _attachment(1)])
+        assert len(docs) == 2
+        assert docs[0].id == docs[1].id
 
     async def test_existing_md5_not_reinserted(self, db):
         await _repo().insert_many([_attachment(1)])
@@ -60,13 +72,13 @@ class TestInsertComponentsDedupe:
         assert await _count() == 2
 
     async def test_existing_doc_returned_with_original_id(self, db):
-        first = await _repo().insert_many([_attachment(1)])
-        again = await _repo().insert_many([_attachment(1)])
+        first = await _insert(_repo(), [_attachment(1)])
+        again = await _insert(_repo(), [_attachment(1)])
         assert again[0].id == first[0].id
 
     async def test_inserted_docs_have_ids(self, db):
-        result = await _repo().insert_many([_attachment(1), _attachment(2)])
-        assert all(doc.id is not None for doc in result)
+        docs = await _insert(_repo(), [_attachment(1), _attachment(2)])
+        assert all(doc.id is not None for doc in docs)
 
 
 # ---------------------------------------------------------------------------
@@ -80,8 +92,8 @@ class TestInsertComponentsChunking:
         monkeypatch.setattr(get_settings().mongo, "component_insert_chunk_size", 2)
         # Distinct content -> distinct md5 so all five survive dedup.
         attachments = [_attachment(i) for i in range(5)]
-        result = await _repo().insert_many(attachments)
-        assert len(result) == 5
+        docs = await _insert(_repo(), attachments)
+        assert len(docs) == 5
         assert await _count() == 5
 
 
@@ -106,7 +118,7 @@ class TestInsertComponent:
 
 class TestDeleteComponents:
     async def test_filtered_delete_removes_only_matches(self, db):
-        keep, drop = await _repo().insert_many([_attachment(1), _attachment(2)])
+        keep, drop = await _insert(_repo(), [_attachment(1), _attachment(2)])
         result = await _repo().delete_many(AttachmentFilter(md5=drop.md5))
         assert result.num_deleted == 1
         remaining = {doc.md5 async for doc in Attachment.find_all()}
@@ -114,7 +126,7 @@ class TestDeleteComponents:
 
     async def test_delete_by_id_removes_one(self, db):
         """The inherited base delete_one removes a single component by its primary key."""
-        [doc] = await _repo().insert_many([_attachment(1)])
+        [doc] = await _insert(_repo(),[_attachment(1)])
         result = await _repo().delete_one({"id": doc.id})
         assert result.num_deleted == 1
         assert await _count() == 0
@@ -127,7 +139,7 @@ class TestDeleteComponents:
 
     async def test_delete_by_md5_removes_one(self, db):
         """A component is addressable by its content md5 (its declared identifier) as well as by id."""
-        [doc] = await _repo().insert_many([_attachment(1)])
+        [doc] = await _insert(_repo(),[_attachment(1)])
         result = await _repo().delete_one({"md5": doc.md5})
         assert result.num_deleted == 1
         assert await _count() == 0
@@ -140,14 +152,14 @@ class TestDeleteComponents:
 
 class TestAddressComponentByMd5:
     async def test_get_one_by_md5(self, db):
-        [doc] = await _repo().insert_many([_attachment(1)])
+        [doc] = await _insert(_repo(),[_attachment(1)])
         by_md5 = await _repo().get_one({"md5": doc.md5}, fields=None)
         by_id = await _repo().get_one({"id": doc.id}, fields=None)
         assert by_md5 is not None
         assert by_md5.id == by_id.id == doc.id
 
     async def test_patch_one_by_md5(self, db):
-        [doc] = await _repo().insert_many([_attachment(1, name="data.csv")])
+        [doc] = await _insert(_repo(),[_attachment(1, name="data.csv")])
         updated = await _repo().patch_one({"md5": doc.md5}, AttachmentPatch(name="renamed.png"))
         assert updated.name == "renamed.png"
 
@@ -159,18 +171,18 @@ class TestAddressComponentByMd5:
 
 class TestPatchComponent:
     async def test_patch_updates_field(self, db):
-        [doc] = await _repo().insert_many([_attachment(1, name="data.csv")])
+        [doc] = await _insert(_repo(),[_attachment(1, name="data.csv")])
         updated = await _repo().patch_one({"id": doc.id}, AttachmentPatch(name="renamed.png"))
         assert updated.name == "renamed.png"
 
     async def test_empty_patch_returns_existing(self, db):
-        [doc] = await _repo().insert_many([_attachment(1, name="data.csv")])
+        [doc] = await _insert(_repo(),[_attachment(1, name="data.csv")])
         updated = await _repo().patch_one({"id": doc.id}, AttachmentPatch())
         assert updated.id == doc.id
 
     async def test_patch_content_recomputes_md5(self, db):
         # name is not a hash field, so renaming must NOT change md5.
-        [doc] = await _repo().insert_many([_attachment(1)])
+        [doc] = await _insert(_repo(),[_attachment(1)])
         renamed = await _repo().patch_one({"id": doc.id}, AttachmentPatch(name="renamed.png"))
         assert renamed.md5 == doc.md5
         # content IS a hash field, so changing it must recompute md5.
@@ -231,7 +243,7 @@ class TestTableFrameRoundTrip:
             attrs={"title": "g", "labels": {"index": "T [K]", "value": "σ", "variable": "doping"}},
             data=frame,
         )
-        [doc] = await repo.insert_many([tin])
+        [doc] = await _insert(repo, [tin])
 
         # Stored in the canonical MongoDB shape: index/columns/data as strings.
         raw = await db["tables"].find_one({"_id": doc.id})

--- a/mpcontribs-api/tests/integration/db/test_components_repository.py
+++ b/mpcontribs-api/tests/integration/db/test_components_repository.py
@@ -159,47 +159,47 @@ class TestDeleteComponents:
 
 
 # ---------------------------------------------------------------------------
-# get_one / patch_one address a component by id or by its content md5
+# read_one / update_one address a component by id or by its content md5
 # ---------------------------------------------------------------------------
 
 
 class TestAddressComponentByMd5:
     async def test_get_one_by_md5(self, db):
         [doc] = await _insert(_repo(),[_attachment(1)])
-        by_md5 = await _repo().get_one({"md5": doc.md5}, fields=None)
-        by_id = await _repo().get_one({"id": doc.id}, fields=None)
+        by_md5 = await _repo().read_one({"md5": doc.md5}, fields=None)
+        by_id = await _repo().read_one({"id": doc.id}, fields=None)
         assert by_md5 is not None
         assert by_md5.id == by_id.id == doc.id
 
     async def test_patch_one_by_md5(self, db):
         [doc] = await _insert(_repo(),[_attachment(1, name="data.csv")])
-        updated = await _repo().patch_one({"md5": doc.md5}, AttachmentPatch(name="renamed.png"))
+        updated = await _repo().update_one({"md5": doc.md5}, AttachmentPatch(name="renamed.png"))
         assert updated.name == "renamed.png"
 
 
 # ---------------------------------------------------------------------------
-# patch_one recomputes the derived md5
+# update_one recomputes the derived md5
 # ---------------------------------------------------------------------------
 
 
 class TestPatchComponent:
     async def test_patch_updates_field(self, db):
         [doc] = await _insert(_repo(),[_attachment(1, name="data.csv")])
-        updated = await _repo().patch_one({"id": doc.id}, AttachmentPatch(name="renamed.png"))
+        updated = await _repo().update_one({"id": doc.id}, AttachmentPatch(name="renamed.png"))
         assert updated.name == "renamed.png"
 
     async def test_empty_patch_returns_existing(self, db):
         [doc] = await _insert(_repo(),[_attachment(1, name="data.csv")])
-        updated = await _repo().patch_one({"id": doc.id}, AttachmentPatch())
+        updated = await _repo().update_one({"id": doc.id}, AttachmentPatch())
         assert updated.id == doc.id
 
     async def test_patch_content_recomputes_md5(self, db):
         # name is not a hash field, so renaming must NOT change md5.
         [doc] = await _insert(_repo(),[_attachment(1)])
-        renamed = await _repo().patch_one({"id": doc.id}, AttachmentPatch(name="renamed.png"))
+        renamed = await _repo().update_one({"id": doc.id}, AttachmentPatch(name="renamed.png"))
         assert renamed.md5 == doc.md5
         # content IS a hash field, so changing it must recompute md5.
-        rehashed = await _repo().patch_one({"id": doc.id}, AttachmentPatch(content=999))
+        rehashed = await _repo().update_one({"id": doc.id}, AttachmentPatch(content=999))
         assert rehashed.md5 != doc.md5
         persisted = await Attachment.find_one(Attachment.id == doc.id)
         assert persisted.md5 == rehashed.md5
@@ -267,7 +267,7 @@ class TestTableFrameRoundTrip:
         assert raw["total_data_rows"] == 2
 
         # Read back: reassembled into the same DataFrame (index folded back as the first column).
-        out = await repo.get_one({"id": doc.id}, TableOut.parse_fields(["data"]))
+        out = await repo.read_one({"id": doc.id}, TableOut.parse_fields(["data"]))
         assert out.data.columns == ["T [K]", "1e16", "1e17"]
         assert out.data.equals(frame)
         # The raw storage keys must not leak onto the response model.

--- a/mpcontribs-api/tests/integration/db/test_consumers_repository.py
+++ b/mpcontribs-api/tests/integration/db/test_consumers_repository.py
@@ -34,14 +34,14 @@ async def _insert(consumer: ConsumerIn) -> Consumer:
 
 
 # ---------------------------------------------------------------------------
-# insert_one / get_one (by consumer_id)
+# insert_one / read_one (by consumer_id)
 # ---------------------------------------------------------------------------
 
 
 class TestInsertAndLookup:
     async def test_insert_then_lookup_by_consumer_id(self, db):
         await _insert(ConsumerIn(consumer_id="kong-1"))
-        found = await _repo().get_one({"consumer_id": "kong-1"})
+        found = await _repo().read_one({"consumer_id": "kong-1"})
         assert found is not None
         assert found.consumer_id == "kong-1"
 
@@ -51,7 +51,7 @@ class TestInsertAndLookup:
             await _insert(ConsumerIn(consumer_id="kong-dup"))
 
     async def test_lookup_missing_returns_none(self, db):
-        assert await _repo().get_one({"consumer_id": "kong-absent"}) is None
+        assert await _repo().read_one({"consumer_id": "kong-absent"}) is None
 
     async def test_partial_override_snapshots_defaults_for_siblings(self, db):
         # Admin overrides only max_projects; the stored document must carry a fully-resolved
@@ -59,7 +59,7 @@ class TestInsertAndLookup:
         await _insert(
             ConsumerIn(consumer_id="kong-partial", settings=ConsumerSettings(max_projects=1))
         )
-        stored = await _repo().get_one({"consumer_id": "kong-partial"})
+        stored = await _repo().read_one({"consumer_id": "kong-partial"})
         assert stored is not None
         assert stored.settings is not None
         assert stored.settings.max_projects == 1
@@ -67,26 +67,26 @@ class TestInsertAndLookup:
 
 
 # ---------------------------------------------------------------------------
-# get_one (document id)
+# read_one (document id)
 # ---------------------------------------------------------------------------
 
 
 class TestGetByDocumentId:
     async def test_returns_out_model(self, db):
         created = await _insert(ConsumerIn(consumer_id="kong-doc"))
-        result = await _repo().get_one({"id": created.id}, None)
+        result = await _repo().read_one({"id": created.id}, None)
         assert result is not None
         assert result.consumer_id == "kong-doc"
 
     async def test_missing_returns_none(self, db):
         from beanie import PydanticObjectId
 
-        result = await _repo().get_one({"id": PydanticObjectId()}, None)
+        result = await _repo().read_one({"id": PydanticObjectId()}, None)
         assert result is None
 
 
 # ---------------------------------------------------------------------------
-# patch_one — partial, sibling-preserving
+# update_one — partial, sibling-preserving
 # ---------------------------------------------------------------------------
 
 
@@ -95,7 +95,7 @@ class TestPatchConsumer:
         created = await _insert(ConsumerIn(consumer_id="kong-patch"))
         original_columns = created.settings.max_columns
 
-        updated = await _repo().patch_one(
+        updated = await _repo().update_one(
             {"id": created.id},
             update=ConsumerPatch(settings=ConsumerSettings(max_projects=1)),
         )
@@ -105,7 +105,7 @@ class TestPatchConsumer:
 
     async def test_empty_patch_returns_existing_unchanged(self, db):
         created = await _insert(ConsumerIn(consumer_id="kong-noop"))
-        result = await _repo().patch_one({"id": created.id}, update=ConsumerPatch())
+        result = await _repo().update_one({"id": created.id}, update=ConsumerPatch())
         assert result.consumer_id == "kong-noop"
         assert result.settings.max_projects == created.settings.max_projects
 
@@ -113,7 +113,7 @@ class TestPatchConsumer:
         from beanie import PydanticObjectId
 
         with pytest.raises(NotFoundError):
-            await _repo().patch_one(
+            await _repo().update_one(
                 {"id": PydanticObjectId()},
                 update=ConsumerPatch(settings=ConsumerSettings(max_projects=1)),
             )
@@ -128,7 +128,7 @@ class TestDeleteConsumer:
     async def test_delete_removes_override(self, db):
         created = await _insert(ConsumerIn(consumer_id="kong-del"))
         await _repo().delete_one({"id": created.id})
-        assert await _repo().get_one({"consumer_id": "kong-del"}) is None
+        assert await _repo().read_one({"consumer_id": "kong-del"}) is None
 
     async def test_delete_missing_raises_not_found(self, db):
         from beanie import PydanticObjectId
@@ -157,7 +157,7 @@ class TestUpsertMany:
         assert {c.consumer_id for c in summary.succeeded} == {"kong-up-0", "kong-up-1", "kong-up-2"}
         # All three are actually persisted.
         for i in range(3):
-            assert await _repo().get_one({"consumer_id": f"kong-up-{i}"}) is not None
+            assert await _repo().read_one({"consumer_id": f"kong-up-{i}"}) is not None
 
     async def test_one_conflict_does_not_abort_the_batch(self, db):
         # Pre-existing consumer occupies the unique consumer_id the middle item will collide with.
@@ -174,8 +174,8 @@ class TestUpsertMany:
         assert [f.index for f in summary.failed] == [1]
         assert summary.failed[0].error_code == "conflict"
         assert {c.consumer_id for c in summary.succeeded} == {"kong-fresh-a", "kong-fresh-b"}
-        assert await _repo().get_one({"consumer_id": "kong-fresh-a"}) is not None
-        assert await _repo().get_one({"consumer_id": "kong-fresh-b"}) is not None
+        assert await _repo().read_one({"consumer_id": "kong-fresh-a"}) is not None
+        assert await _repo().read_one({"consumer_id": "kong-fresh-b"}) is not None
 
     async def test_empty_batch_is_a_noop_summary(self, db):
         summary = await _repo().upsert_many([])

--- a/mpcontribs-api/tests/integration/db/test_consumers_repository.py
+++ b/mpcontribs-api/tests/integration/db/test_consumers_repository.py
@@ -138,6 +138,53 @@ class TestDeleteConsumer:
 
 
 # ---------------------------------------------------------------------------
+# upsert_many — the base repository's concurrent, per-item-reporting bulk upsert
+# ---------------------------------------------------------------------------
+
+
+class TestUpsertMany:
+    """The inherited ``MongoDbRepository.upsert_many`` upserts concurrently and reports per item.
+
+    Consumers exercise the base default directly: they use the base repository and carry a unique
+    index (``consumer_id``) so a colliding item produces a real per-item conflict.
+    """
+
+    async def test_all_succeed(self, db):
+        docs = [Consumer.from_input_model(ConsumerIn(consumer_id=f"kong-up-{i}")) for i in range(3)]
+        summary = await _repo().upsert_many(docs)
+        assert summary.total == 3
+        assert summary.failed == []
+        assert {c.consumer_id for c in summary.succeeded} == {"kong-up-0", "kong-up-1", "kong-up-2"}
+        # All three are actually persisted.
+        for i in range(3):
+            assert await _repo().get_one({"consumer_id": f"kong-up-{i}"}) is not None
+
+    async def test_one_conflict_does_not_abort_the_batch(self, db):
+        # Pre-existing consumer occupies the unique consumer_id the middle item will collide with.
+        await _insert(ConsumerIn(consumer_id="kong-taken"))
+        docs = [
+            Consumer.from_input_model(ConsumerIn(consumer_id="kong-fresh-a")),
+            Consumer.from_input_model(ConsumerIn(consumer_id="kong-taken")),  # unique-index conflict
+            Consumer.from_input_model(ConsumerIn(consumer_id="kong-fresh-b")),
+        ]
+        summary = await _repo().upsert_many(docs)
+
+        assert summary.total == 3
+        # The conflict is reported at its input index, not raised; the siblings still commit.
+        assert [f.index for f in summary.failed] == [1]
+        assert summary.failed[0].error_code == "conflict"
+        assert {c.consumer_id for c in summary.succeeded} == {"kong-fresh-a", "kong-fresh-b"}
+        assert await _repo().get_one({"consumer_id": "kong-fresh-a"}) is not None
+        assert await _repo().get_one({"consumer_id": "kong-fresh-b"}) is not None
+
+    async def test_empty_batch_is_a_noop_summary(self, db):
+        summary = await _repo().upsert_many([])
+        assert summary.total == 0
+        assert summary.succeeded == []
+        assert summary.failed == []
+
+
+# ---------------------------------------------------------------------------
 # get_effective_limits — the resolution actually consumed by the write paths
 # ---------------------------------------------------------------------------
 

--- a/mpcontribs-api/tests/integration/db/test_consumers_repository.py
+++ b/mpcontribs-api/tests/integration/db/test_consumers_repository.py
@@ -24,6 +24,15 @@ def _repo() -> MongoDbConsumerRepository:
     return MongoDbConsumerRepository(ADMIN)
 
 
+async def _insert(consumer: ConsumerIn) -> Consumer:
+    """Persist a consumer the way the service does: build the document, then hand it to the repo.
+
+    The repository is document-in, so the input→document conversion (``from_input_model``, which
+    resolves the settings snapshot) lives here rather than in the repo.
+    """
+    return await _repo().insert_one(Consumer.from_input_model(consumer))
+
+
 # ---------------------------------------------------------------------------
 # insert_one / get_one (by consumer_id)
 # ---------------------------------------------------------------------------
@@ -31,15 +40,15 @@ def _repo() -> MongoDbConsumerRepository:
 
 class TestInsertAndLookup:
     async def test_insert_then_lookup_by_consumer_id(self, db):
-        await _repo().insert_one(ConsumerIn(consumer_id="kong-1"))
+        await _insert(ConsumerIn(consumer_id="kong-1"))
         found = await _repo().get_one({"consumer_id": "kong-1"})
         assert found is not None
         assert found.consumer_id == "kong-1"
 
     async def test_duplicate_consumer_id_raises_conflict(self, db):
-        await _repo().insert_one(ConsumerIn(consumer_id="kong-dup"))
+        await _insert(ConsumerIn(consumer_id="kong-dup"))
         with pytest.raises(ConflictError):
-            await _repo().insert_one(ConsumerIn(consumer_id="kong-dup"))
+            await _insert(ConsumerIn(consumer_id="kong-dup"))
 
     async def test_lookup_missing_returns_none(self, db):
         assert await _repo().get_one({"consumer_id": "kong-absent"}) is None
@@ -47,7 +56,7 @@ class TestInsertAndLookup:
     async def test_partial_override_snapshots_defaults_for_siblings(self, db):
         # Admin overrides only max_projects; the stored document must carry a fully-resolved
         # settings block, with untouched limits snapshotted from the global defaults.
-        await _repo().insert_one(
+        await _insert(
             ConsumerIn(consumer_id="kong-partial", settings=ConsumerSettings(max_projects=1))
         )
         stored = await _repo().get_one({"consumer_id": "kong-partial"})
@@ -64,7 +73,7 @@ class TestInsertAndLookup:
 
 class TestGetByDocumentId:
     async def test_returns_out_model(self, db):
-        created = await _repo().insert_one(ConsumerIn(consumer_id="kong-doc"))
+        created = await _insert(ConsumerIn(consumer_id="kong-doc"))
         result = await _repo().get_one({"id": created.id}, None)
         assert result is not None
         assert result.consumer_id == "kong-doc"
@@ -83,7 +92,7 @@ class TestGetByDocumentId:
 
 class TestPatchConsumer:
     async def test_patch_changes_only_named_limit(self, db):
-        created = await _repo().insert_one(ConsumerIn(consumer_id="kong-patch"))
+        created = await _insert(ConsumerIn(consumer_id="kong-patch"))
         original_columns = created.settings.max_columns
 
         updated = await _repo().patch_one(
@@ -95,7 +104,7 @@ class TestPatchConsumer:
         assert updated.settings.max_columns == original_columns
 
     async def test_empty_patch_returns_existing_unchanged(self, db):
-        created = await _repo().insert_one(ConsumerIn(consumer_id="kong-noop"))
+        created = await _insert(ConsumerIn(consumer_id="kong-noop"))
         result = await _repo().patch_one({"id": created.id}, update=ConsumerPatch())
         assert result.consumer_id == "kong-noop"
         assert result.settings.max_projects == created.settings.max_projects
@@ -117,7 +126,7 @@ class TestPatchConsumer:
 
 class TestDeleteConsumer:
     async def test_delete_removes_override(self, db):
-        created = await _repo().insert_one(ConsumerIn(consumer_id="kong-del"))
+        created = await _insert(ConsumerIn(consumer_id="kong-del"))
         await _repo().delete_one({"id": created.id})
         assert await _repo().get_one({"consumer_id": "kong-del"}) is None
 
@@ -141,7 +150,7 @@ class TestEffectiveLimits:
         assert limits.max_projects == get_settings().consumer.max_projects
 
     async def test_stored_override_is_returned(self, db):
-        await _repo().insert_one(
+        await _insert(
             ConsumerIn(consumer_id="kong-eff", settings=ConsumerSettings(max_projects=42))
         )
         user = User(consumer_id="kong-eff", username="google:alice@example.com", groups=frozenset())

--- a/mpcontribs-api/tests/integration/db/test_consumers_repository.py
+++ b/mpcontribs-api/tests/integration/db/test_consumers_repository.py
@@ -2,7 +2,6 @@ import pytest
 
 from mpcontribs_api.authz import User
 from mpcontribs_api.config import get_settings
-from mpcontribs_api.domains.consumers.dependencies import get_effective_limits
 from mpcontribs_api.domains.consumers.models import (
     Consumer,
     ConsumerIn,
@@ -10,6 +9,7 @@ from mpcontribs_api.domains.consumers.models import (
     ConsumerSettings,
 )
 from mpcontribs_api.domains.consumers.repository import MongoDbConsumerRepository
+from mpcontribs_api.domains.consumers.service import ConsumerService
 from mpcontribs_api.exceptions import ConflictError, NotFoundError
 
 # Same loop-scope contract as the other db suites (see test_projects_repository).
@@ -185,15 +185,20 @@ class TestUpsertMany:
 
 
 # ---------------------------------------------------------------------------
-# get_effective_limits — the resolution actually consumed by the write paths
+# ConsumerService.effective_limits — the resolution actually consumed by the write paths
 # ---------------------------------------------------------------------------
+
+
+def _service(user: User) -> ConsumerService:
+    """A ConsumerService wired like the FastAPI factory, for ``user``."""
+    return ConsumerService(consumer=MongoDbConsumerRepository(user))
 
 
 class TestEffectiveLimits:
     async def test_no_consumer_id_returns_defaults_without_lookup(self, db):
         # A caller with no Kong consumer_id (anonymous/dev) never touches the override collection.
         user = User(username="google:alice@example.com", groups=frozenset())
-        limits = await get_effective_limits(user)
+        limits = await _service(user).effective_limits(user.consumer_id)
         assert limits.max_projects == get_settings().consumer.max_projects
 
     async def test_stored_override_is_returned(self, db):
@@ -201,10 +206,10 @@ class TestEffectiveLimits:
             ConsumerIn(consumer_id="kong-eff", settings=ConsumerSettings(max_projects=42))
         )
         user = User(consumer_id="kong-eff", username="google:alice@example.com", groups=frozenset())
-        limits = await get_effective_limits(user)
+        limits = await _service(user).effective_limits(user.consumer_id)
         assert limits.max_projects == 42
 
     async def test_consumer_id_without_override_falls_back_to_defaults(self, db):
         user = User(consumer_id="kong-unknown", username="google:alice@example.com", groups=frozenset())
-        limits = await get_effective_limits(user)
+        limits = await _service(user).effective_limits(user.consumer_id)
         assert limits.max_projects == get_settings().consumer.max_projects

--- a/mpcontribs-api/tests/integration/db/test_contributions_repository.py
+++ b/mpcontribs-api/tests/integration/db/test_contributions_repository.py
@@ -10,7 +10,6 @@ from mpcontribs_api.domains.contributions.models import (
     ContributionPatch,
 )
 from mpcontribs_api.domains.contributions.repository import MongoDbContributionRepository
-from mpcontribs_api.exceptions import PermissionError as AppPermissionError
 from mpcontribs_api.exceptions import ConflictError, NotFoundError, ValidationError
 from mpcontribs_api.pagination import CursorParams
 

--- a/mpcontribs-api/tests/integration/db/test_contributions_repository.py
+++ b/mpcontribs-api/tests/integration/db/test_contributions_repository.py
@@ -160,40 +160,39 @@ class TestNullableIdentifierHierarchy:
         assert key in found
 
     async def test_duplicate_chemical_system_only_collides_on_unique_index(self, db):
-        from pymongo.errors import DuplicateKeyError
-
         ci = _contrib_in(project="chem-only", material_id=None, formula=None)
         await _repo().insert_one(Contribution.from_input_model(ci))
         dup = _contrib_in(project="chem-only", material_id=None, formula=None)
         # Same (project, chemical_system_id) with null material_id/formula/unique_value is one
-        # unique key — the second insert must be rejected.
-        with pytest.raises(DuplicateKeyError):
+        # unique key — the second insert must be rejected. The document-in repo translates the
+        # unique-index DuplicateKeyError into a domain ConflictError.
+        with pytest.raises(ConflictError):
             await _repo().insert_one(Contribution.from_input_model(dup))
 
 
 # ---------------------------------------------------------------------------
-# insert_many_contributions (bulk)
+# insert_many (bulk)
 # ---------------------------------------------------------------------------
 
 
 class TestInsertManyContributions:
     async def test_all_docs_persisted(self, db):
         docs = [Contribution.from_input_model(_contrib_in(identifier=f"mp-{4100 + i}")) for i in range(5)]
-        await _repo().insert_many_contributions(docs)
+        await _repo().insert_many(docs)
         for doc in docs:
             found = await Contribution.find_one(Contribution.id == doc.id)
             assert found is not None
 
     async def test_returns_insert_result(self, db):
         docs = [Contribution.from_input_model(_contrib_in(identifier=f"mp-{4200 + i}")) for i in range(3)]
-        result = await _repo().insert_many_contributions(docs)
+        result = await _repo().insert_many(docs)
         assert result is not None
 
     async def test_empty_list_raises_type_error(self, db):
         # Motor's insert_many requires at least one document; callers are
         # responsible for guarding against empty batches.
         with pytest.raises(TypeError, match="non-empty"):
-            await _repo().insert_many_contributions([])
+            await _repo().insert_many([])
 
 
 # ---------------------------------------------------------------------------

--- a/mpcontribs-api/tests/integration/db/test_contributions_repository.py
+++ b/mpcontribs-api/tests/integration/db/test_contributions_repository.py
@@ -533,7 +533,7 @@ class TestUpsertContributionById:
     async def test_insert_when_id_absent_persists_document(self, db):
         new_id = PydanticObjectId()
         payload = _contrib_in(identifier="mp-4002", _id=new_id)
-        result = await _repo(ADMIN).upsert_contribution_by_id(str(new_id), payload)
+        result = await _repo(ADMIN).upsert_one({"id": str(new_id)}, payload)
         # Must be the resolved document, not an un-awaited query object.
         assert isinstance(result, Contribution)
         stored = await Contribution.find_one(Contribution.id == new_id)
@@ -543,7 +543,7 @@ class TestUpsertContributionById:
     async def test_update_when_id_present_applies_change(self, db):
         existing = await _insert(identifier="mp-4001")
         payload = _contrib_in(identifier="mp-4001", formula="Li2O", _id=existing.id)
-        result = await _repo(ADMIN).upsert_contribution_by_id(str(existing.id), payload)
+        result = await _repo(ADMIN).upsert_one({"id": str(existing.id)}, payload)
         assert isinstance(result, Contribution)
         stored = await Contribution.find_one(Contribution.id == existing.id)
         assert stored is not None
@@ -565,7 +565,7 @@ class TestUpsertContributionById:
         existing = await _insert(identifier="mp-4004", unique_value="batch-A")
         assert existing.unique_value == "batch-A"
         payload = _contrib_in(identifier="mp-4004", _id=existing.id)
-        await _repo(ADMIN).upsert_contribution_by_id(str(existing.id), payload, unique_value=None)
+        await _repo(ADMIN).upsert_one({"id": str(existing.id)}, payload, unique_value=None)
         stored = await Contribution.find_one(Contribution.id == existing.id)
         assert stored is not None
         assert stored.unique_value is None
@@ -577,7 +577,7 @@ class TestUpsertContributionById:
         victim = await _insert(project="uid-dup", identifier="mp-200")
         payload = _contrib_in(project="uid-dup", identifier="mp-100", _id=victim.id)
         with pytest.raises(ConflictError):
-            await _repo(ADMIN).upsert_contribution_by_id(str(victim.id), payload)
+            await _repo(ADMIN).upsert_one({"id": str(victim.id)}, payload)
 
 
 class TestDeleteByIdsScope:
@@ -585,7 +585,7 @@ class TestDeleteByIdsScope:
         pub = await _insert(identifier="dbi-pub", is_public=True)
         priv = await _insert(identifier="dbi-priv", is_public=False)
         # Anonymous scope only sees public docs; deleting both ids must spare the private one.
-        result = await _repo(ANON).delete_by_ids([pub.id, priv.id])
+        result = await _repo(ANON).delete_many(ContributionFilter(id__in=[pub.id, priv.id]))
         assert result.num_deleted == 1
         remaining = {d.material_id for d in await Contribution.find().to_list()}
         assert "dbi-priv" in remaining
@@ -594,5 +594,5 @@ class TestDeleteByIdsScope:
     async def test_admin_deletes_all_ids(self, db):
         a = await _insert(identifier="dbi-a", is_public=False)
         b = await _insert(identifier="dbi-b", is_public=False)
-        result = await _repo(ADMIN).delete_by_ids([a.id, b.id])
+        result = await _repo(ADMIN).delete_many(ContributionFilter(id__in=[a.id, b.id]))
         assert result.num_deleted == 2

--- a/mpcontribs-api/tests/integration/db/test_contributions_repository.py
+++ b/mpcontribs-api/tests/integration/db/test_contributions_repository.py
@@ -196,7 +196,7 @@ class TestInsertManyContributions:
 
 
 # ---------------------------------------------------------------------------
-# get_many (scoped list + pagination + projection)
+# read_many (scoped list + pagination + projection)
 # ---------------------------------------------------------------------------
 
 
@@ -204,7 +204,7 @@ class TestGetContributions:
     async def test_admin_sees_private_and_public(self, db):
         p = await _insert(identifier="ga-pub", is_public=True)
         pr = await _insert(identifier="ga-priv", is_public=False)
-        page = await _repo(ADMIN).get_many(
+        page = await _repo(ADMIN).read_many(
             pagination=CursorParams(), filter=_noop_filter(), fields=None
         )
         ids = {str(c.id) for c in page.items}
@@ -214,7 +214,7 @@ class TestGetContributions:
     async def test_anonymous_sees_only_public(self, db):
         pub = await _insert(identifier="anon-pub", is_public=True)
         priv = await _insert(identifier="anon-priv", is_public=False)
-        page = await _repo(ANON).get_many(
+        page = await _repo(ANON).read_many(
             pagination=CursorParams(), filter=_noop_filter(), fields=None
         )
         ids = {str(c.id) for c in page.items}
@@ -224,7 +224,7 @@ class TestGetContributions:
     async def test_authenticated_non_admin_sees_public(self, db):
         pub = await _insert(identifier="alice-pub", is_public=True)
         priv = await _insert(identifier="alice-priv", is_public=False)
-        page = await _repo(ALICE).get_many(
+        page = await _repo(ALICE).read_many(
             pagination=CursorParams(), filter=_noop_filter(), fields=None
         )
         ids = {str(c.id) for c in page.items}
@@ -233,7 +233,7 @@ class TestGetContributions:
 
     async def test_response_is_page_shape(self, db):
         await _insert(identifier="pg-shape")
-        page = await _repo(ADMIN).get_many(
+        page = await _repo(ADMIN).read_many(
             pagination=CursorParams(), filter=_noop_filter(), fields=None
         )
         assert hasattr(page, "items")
@@ -242,7 +242,7 @@ class TestGetContributions:
     async def test_limit_respected(self, db):
         for i in range(5):
             await _insert(identifier=f"lim-{i:02d}", is_public=True)
-        page = await _repo(ADMIN).get_many(
+        page = await _repo(ADMIN).read_many(
             pagination=CursorParams(limit=3), filter=_noop_filter(), fields=None
         )
         assert len(page.items) <= 3
@@ -250,11 +250,11 @@ class TestGetContributions:
     async def test_cursor_paginates_forward(self, db):
         for i in range(4):
             await _insert(identifier=f"cur-{i:02d}", is_public=True)
-        p1 = await _repo(ADMIN).get_many(
+        p1 = await _repo(ADMIN).read_many(
             pagination=CursorParams(limit=2), filter=_noop_filter(), fields=None
         )
         assert p1.next_cursor is not None
-        p2 = await _repo(ADMIN).get_many(
+        p2 = await _repo(ADMIN).read_many(
             pagination=CursorParams(limit=2, cursor=p1.next_cursor), filter=_noop_filter(), fields=None
         )
         ids1 = {str(c.id) for c in p1.items}
@@ -267,7 +267,7 @@ class TestGetContributions:
         identifiers: set[str] = set()
         cursor = None
         while True:
-            page = await _repo(ADMIN).get_many(
+            page = await _repo(ADMIN).read_many(
                 pagination=CursorParams(limit=2, cursor=cursor), filter=_noop_filter(), fields=None
             )
             identifiers.update(c.material_id for c in page.items if c.material_id)
@@ -279,7 +279,7 @@ class TestGetContributions:
     async def test_next_cursor_none_on_last_page(self, db):
         for i in range(2):
             await _insert(identifier=f"last-pg-{i:02d}", is_public=True)
-        page = await _repo(ADMIN).get_many(
+        page = await _repo(ADMIN).read_many(
             pagination=CursorParams(limit=100), filter=_noop_filter(), fields=None
         )
         assert page.next_cursor is None
@@ -287,7 +287,7 @@ class TestGetContributions:
     async def test_projection_returns_only_requested_fields(self, db):
         await _insert(identifier="proj-fields", is_public=True)
         fields = ContributionOut.parse_fields(["formula"])
-        page = await _repo(ADMIN).get_many(
+        page = await _repo(ADMIN).read_many(
             pagination=CursorParams(), filter=_noop_filter(), fields=fields
         )
         assert len(page.items) >= 1
@@ -299,7 +299,7 @@ class TestGetContributions:
         await _insert(identifier="flt-fe", formula="Fe2O3", is_public=True)
         await _insert(identifier="flt-li", formula="Li2O", is_public=True)
         f = ContributionFilter(formula="Fe2O3")
-        page = await _repo(ADMIN).get_many(
+        page = await _repo(ADMIN).read_many(
             pagination=CursorParams(), filter=f, fields=None
         )
         formulas = {c.formula for c in page.items}
@@ -309,7 +309,7 @@ class TestGetContributions:
         await _insert(identifier="ilike-abc", is_public=True)
         await _insert(identifier="ilike-xyz", is_public=True)
         f = ContributionFilter(material_id__ilike="ilike-a")
-        page = await _repo(ADMIN).get_many(
+        page = await _repo(ADMIN).read_many(
             pagination=CursorParams(), filter=f, fields=None
         )
         identifiers = {c.material_id for c in page.items}
@@ -320,83 +320,83 @@ class TestGetContributions:
         await _insert(identifier="pub-only-pub", is_public=True)
         await _insert(identifier="pub-only-priv", is_public=False)
         f = ContributionFilter(is_public=True)
-        page = await _repo(ADMIN).get_many(
+        page = await _repo(ADMIN).read_many(
             pagination=CursorParams(), filter=f, fields=None
         )
         assert all(c.is_public is True for c in page.items)
 
 # ---------------------------------------------------------------------------
-# get_one (by id)
+# read_one (by id)
 # ---------------------------------------------------------------------------
 
 
 class TestGetContributionById:
     async def test_returns_doc_for_valid_id(self, db):
         doc = await _insert(identifier="get-id")
-        result = await _repo(ADMIN).get_one({"id": doc.id}, fields=None)
+        result = await _repo(ADMIN).read_one({"id": doc.id}, fields=None)
         assert result is not None
         assert result.material_id == "get-id"
 
     async def test_returns_none_for_missing_id(self, db):
-        result = await _repo(ADMIN).get_one({"id": PydanticObjectId()}, fields=None)
+        result = await _repo(ADMIN).read_one({"id": PydanticObjectId()}, fields=None)
         assert result is None
 
     async def test_admin_can_get_private_doc(self, db):
         doc = await _insert(identifier="get-priv", is_public=False)
-        result = await _repo(ADMIN).get_one({"id": doc.id}, fields=None)
+        result = await _repo(ADMIN).read_one({"id": doc.id}, fields=None)
         assert result is not None
 
     async def test_anon_cannot_get_private_doc(self, db):
         doc = await _insert(identifier="get-anon-priv", is_public=False)
-        result = await _repo(ANON).get_one({"id": doc.id}, fields=None)
+        result = await _repo(ANON).read_one({"id": doc.id}, fields=None)
         assert result is None
 
     async def test_anon_can_get_public_doc(self, db):
         doc = await _insert(identifier="get-anon-pub", is_public=True)
-        result = await _repo(ANON).get_one({"id": doc.id}, fields=None)
+        result = await _repo(ANON).read_one({"id": doc.id}, fields=None)
         assert result is not None
 
     async def test_projection_limits_fields(self, db):
         doc = await _insert(identifier="get-proj", is_public=True)
         fields = ContributionOut.parse_fields(["formula"])
-        result = await _repo(ADMIN).get_one({"id": doc.id}, fields=fields)
+        result = await _repo(ADMIN).read_one({"id": doc.id}, fields=fields)
         assert result is not None
         assert result.formula == "Fe2O3"
         assert not hasattr(result, "data")
 
 
 # ---------------------------------------------------------------------------
-# get_one (by the semantic composite identity)
+# read_one (by the semantic composite identity)
 # ---------------------------------------------------------------------------
 
 
 class TestGetContributionBySemanticIdentifiers:
     async def test_finds_existing_doc(self, db):
         await _insert(project="find-proj", identifier="find-id")
-        result = await _repo(ADMIN).get_one(_identity(project="find-proj", material_id="find-id"), fields=None)
+        result = await _repo(ADMIN).read_one(_identity(project="find-proj", material_id="find-id"), fields=None)
         assert result is not None
         assert result.project == "find-proj"
         assert result.material_id == "find-id"
 
     async def test_returns_none_for_missing_combination(self, db):
         await _insert(project="miss-proj", identifier="miss-id")
-        result = await _repo(ADMIN).get_one(_identity(project="miss-proj", material_id="wrong-id"), fields=None)
+        result = await _repo(ADMIN).read_one(_identity(project="miss-proj", material_id="wrong-id"), fields=None)
         assert result is None
 
     async def test_scope_prevents_anon_finding_private(self, db):
         await _insert(project="anon-scope", identifier="priv-doc", is_public=False)
-        result = await _repo(ANON).get_one(_identity(project="anon-scope", material_id="priv-doc"), fields=None)
+        result = await _repo(ANON).read_one(_identity(project="anon-scope", material_id="priv-doc"), fields=None)
         assert result is None
 
     async def test_scope_allows_anon_finding_public(self, db):
         await _insert(project="anon-scope-pub", identifier="pub-doc", is_public=True)
-        result = await _repo(ANON).get_one(_identity(project="anon-scope-pub", material_id="pub-doc"), fields=None)
+        result = await _repo(ANON).read_one(_identity(project="anon-scope-pub", material_id="pub-doc"), fields=None)
         assert result is not None
 
     async def test_composite_identity_is_unique_lookup(self, db):
         await _insert(project="same-proj", identifier="id-a")
         await _insert(project="same-proj", identifier="id-b")
-        result = await _repo(ADMIN).get_one(_identity(project="same-proj", material_id="id-a"), fields=None)
+        result = await _repo(ADMIN).read_one(_identity(project="same-proj", material_id="id-a"), fields=None)
         assert result is not None
         assert result.material_id == "id-a"
 
@@ -404,30 +404,30 @@ class TestGetContributionBySemanticIdentifiers:
         # The semantic set must be the complete composite key, not a subset.
         await _insert(project="partial-proj", identifier="partial-id")
         with pytest.raises(ValidationError):
-            await _repo(ADMIN).get_one({"project": "partial-proj", "material_id": "partial-id"}, fields=None)
+            await _repo(ADMIN).read_one({"project": "partial-proj", "material_id": "partial-id"}, fields=None)
 
 
 # ---------------------------------------------------------------------------
-# patch_one (scoped partial update by id or composite identity)
+# update_one (scoped partial update by id or composite identity)
 # ---------------------------------------------------------------------------
 
 
 class TestPatchContributionById:
     async def test_updates_formula(self, db):
         doc = await _insert(identifier="patch-formula")
-        await _repo(ADMIN).patch_one({"id": doc.id}, ContributionPatch(formula="Li2O"))
+        await _repo(ADMIN).update_one({"id": doc.id}, ContributionPatch(formula="Li2O"))
         found = await Contribution.find_one(Contribution.id == doc.id)
         assert found.formula == "Li2O"
 
     async def test_unset_fields_not_overwritten(self, db):
         doc = await _insert(identifier="patch-preserve", formula="Fe2O3")
-        await _repo(ADMIN).patch_one({"id": doc.id}, ContributionPatch(needs_build=False))
+        await _repo(ADMIN).update_one({"id": doc.id}, ContributionPatch(needs_build=False))
         found = await Contribution.find_one(Contribution.id == doc.id)
         assert found.formula == "Fe2O3"
 
     async def test_empty_patch_is_a_noop(self, db):
         doc = await _insert(identifier="patch-empty", formula="Fe2O3")
-        result = await _repo(ADMIN).patch_one({"id": doc.id}, ContributionPatch())
+        result = await _repo(ADMIN).update_one({"id": doc.id}, ContributionPatch())
         assert result is not None
         found = await Contribution.find_one(Contribution.id == doc.id)
         assert found.formula == "Fe2O3"
@@ -435,7 +435,7 @@ class TestPatchContributionById:
     async def test_patch_by_semantic_identifiers(self, db):
         # The same patch reachable through the full composite identity.
         await _insert(project="patch-sem", identifier="sem-id", formula="Fe2O3")
-        await _repo(ADMIN).patch_one(
+        await _repo(ADMIN).update_one(
             _identity(project="patch-sem", material_id="sem-id"), ContributionPatch(formula="Li2O")
         )
         found = await Contribution.find_one(Contribution.project == "patch-sem")
@@ -444,14 +444,14 @@ class TestPatchContributionById:
     async def test_raises_validation_error_for_bad_id(self, db):
         repo = _repo(ADMIN)
         with pytest.raises(ValidationError):
-            await repo.patch_one(repo.coerce_identifiers({"id": "bad-id"}), ContributionPatch(formula="Fe2O3"))
+            await repo.update_one(repo.coerce_identifiers({"id": "bad-id"}), ContributionPatch(formula="Fe2O3"))
 
     async def test_anon_cannot_patch_private_doc(self, db):
         from mpcontribs_api.exceptions import NotFoundError
 
         doc = await _insert(identifier="patch-anon-priv", is_public=False)
         with pytest.raises(NotFoundError):
-            await _repo(ANON).patch_one({"id": doc.id}, ContributionPatch(formula="Fe2O3"))
+            await _repo(ANON).update_one({"id": doc.id}, ContributionPatch(formula="Fe2O3"))
 
     async def test_patch_onto_existing_identity_raises_conflict(self, db):
         # Two contributions differing only by material_id, so distinct identities.
@@ -460,7 +460,7 @@ class TestPatchContributionById:
         # Patching victim's material_id onto the first doc's makes the identities collide; the unique
         # index rejects the write, which the repo surfaces as a ConflictError (409) not a raw 500.
         with pytest.raises(ConflictError):
-            await _repo(ADMIN).patch_one({"id": victim.id}, ContributionPatch(material_id="mp-100"))
+            await _repo(ADMIN).update_one({"id": victim.id}, ContributionPatch(material_id="mp-100"))
 
 
 # ---------------------------------------------------------------------------

--- a/mpcontribs-api/tests/integration/db/test_download.py
+++ b/mpcontribs-api/tests/integration/db/test_download.py
@@ -58,12 +58,13 @@ async def _collect(stream) -> bytes:
 async def _download_bytes(repo: MongoDbContributionRepository, *, format="jsonl", fields=None, filter=None) -> bytes:
     from mpcontribs_api.domains._shared.types import DownloadFormat, ShortMimeFormat
 
-    stream = await repo.download_contributions(
+    stream = repo.download(
         format=DownloadFormat(format),
         short_mime=ShortMimeFormat.GZ,
         ignore_cache=True,
         filter=filter or ContributionFilter(),
         fields=fields,
+        bucket_name="",
         key_name="",
         s3=MagicMock(),
     )

--- a/mpcontribs-api/tests/integration/db/test_initiatives_repository.py
+++ b/mpcontribs-api/tests/integration/db/test_initiatives_repository.py
@@ -4,7 +4,7 @@ Authorization (authenticated-create, manage-rights, admin-only approval, owner-o
 ``public ⇒ approved`` invariant, and the per-owner unapproved quota moved to
 :class:`InitiativeService` (see ``test_initiatives_service.py``). What remains here is the toolbox:
 scoped reads (visibility, filters), the mechanical ``insert`` (owner-stamp + dup-slug reject), and
-the shared ``count_matching`` primitive. State-seeding uses the base ``patch_one`` (a mechanical
+the shared ``count_matching`` primitive. State-seeding uses the base ``update_one`` (a mechanical
 ``$set`` with no auth), which the repo no longer overrides.
 """
 
@@ -59,7 +59,7 @@ async def _insert(slug: str, owner_user: User = ALICE, name: str = "An Initiativ
 
 async def _publish(slug: str) -> None:
     """Mark ``slug`` approved+public via the base (mechanical, no-auth) patch — for scope seeding."""
-    await _repo(ADMIN).patch_one({"slug": slug}, InitiativePatch(is_approved=True, is_public=True))
+    await _repo(ADMIN).update_one({"slug": slug}, InitiativePatch(is_approved=True, is_public=True))
 
 
 # ---------------------------------------------------------------------------
@@ -112,16 +112,16 @@ class TestCountUnapprovedForOwner:
 class TestReadScope:
     async def test_private_unapproved_visibility(self, db):
         await _insert("scoped-priv", ALICE)
-        assert await _repo(ALICE).get_one({"slug": "scoped-priv"}, fields=None) is not None  # owner
-        assert await _repo(ADMIN).get_one({"slug": "scoped-priv"}, fields=None) is not None  # admin
-        assert await _repo(_collaborator("scoped-priv")).get_one({"slug": "scoped-priv"}, fields=None) is not None
-        assert await _repo(ANON).get_one({"slug": "scoped-priv"}, fields=None) is None  # anon
-        assert await _repo(BOB).get_one({"slug": "scoped-priv"}, fields=None) is None  # unrelated user
+        assert await _repo(ALICE).read_one({"slug": "scoped-priv"}, fields=None) is not None  # owner
+        assert await _repo(ADMIN).read_one({"slug": "scoped-priv"}, fields=None) is not None  # admin
+        assert await _repo(_collaborator("scoped-priv")).read_one({"slug": "scoped-priv"}, fields=None) is not None
+        assert await _repo(ANON).read_one({"slug": "scoped-priv"}, fields=None) is None  # anon
+        assert await _repo(BOB).read_one({"slug": "scoped-priv"}, fields=None) is None  # unrelated user
 
     async def test_public_approved_visible_to_anon(self, db):
         await _insert("scoped-pub", ALICE)
         await _publish("scoped-pub")
-        assert await _repo(ANON).get_one({"slug": "scoped-pub"}, fields=None) is not None
+        assert await _repo(ANON).read_one({"slug": "scoped-pub"}, fields=None) is not None
 
 
 # ---------------------------------------------------------------------------
@@ -133,7 +133,7 @@ class TestListAndFilter:
     async def test_list_scoped_to_caller(self, db):
         await _insert("mine-1", ALICE)
         await _insert("bobs-1", BOB)  # Bob's private initiative, invisible to Alice
-        page = await _repo(ALICE).get_many(InitiativeFilter(), pagination=CursorParams(), fields=None)
+        page = await _repo(ALICE).read_many(InitiativeFilter(), pagination=CursorParams(), fields=None)
         slugs = {i.slug for i in page.items}
         assert "mine-1" in slugs
         assert "bobs-1" not in slugs
@@ -142,7 +142,7 @@ class TestListAndFilter:
         await _insert("appr-1", ALICE)
         await _insert("unappr-1", ALICE)
         await _publish("appr-1")
-        page = await _repo(ADMIN).get_many(InitiativeFilter(is_approved=True), pagination=CursorParams(), fields=None)
+        page = await _repo(ADMIN).read_many(InitiativeFilter(is_approved=True), pagination=CursorParams(), fields=None)
         slugs = {i.slug for i in page.items}
         assert "appr-1" in slugs
         assert "unappr-1" not in slugs
@@ -150,5 +150,5 @@ class TestListAndFilter:
     async def test_filter_by_owner(self, db):
         await _insert("owned-alice", ALICE)
         await _insert("owned-bob", BOB)
-        page = await _repo(ADMIN).get_many(InitiativeFilter(owner=BOB_EMAIL), pagination=CursorParams(), fields=None)
+        page = await _repo(ADMIN).read_many(InitiativeFilter(owner=BOB_EMAIL), pagination=CursorParams(), fields=None)
         assert {i.slug for i in page.items} == {"owned-bob"}

--- a/mpcontribs-api/tests/integration/db/test_initiatives_repository.py
+++ b/mpcontribs-api/tests/integration/db/test_initiatives_repository.py
@@ -4,8 +4,8 @@ Authorization (authenticated-create, manage-rights, admin-only approval, owner-o
 ``public ⇒ approved`` invariant, and the per-owner unapproved quota moved to
 :class:`InitiativeService` (see ``test_initiatives_service.py``). What remains here is the toolbox:
 scoped reads (visibility, filters), the mechanical ``insert`` (owner-stamp + dup-slug reject), and
-``count_unapproved_for_owner``. State-seeding uses the base ``patch_one`` (a mechanical ``$set`` with
-no auth), which the repo no longer overrides.
+the shared ``count_matching`` primitive. State-seeding uses the base ``patch_one`` (a mechanical
+``$set`` with no auth), which the repo no longer overrides.
 """
 
 import pytest
@@ -81,7 +81,7 @@ class TestInsert:
 
 
 # ---------------------------------------------------------------------------
-# count_unapproved_for_owner  (toolbox primitive; the cap decision lives in the service)
+# count_matching for the unapproved-owner quota  (toolbox primitive; the cap decision lives in the service)
 # ---------------------------------------------------------------------------
 
 
@@ -91,14 +91,17 @@ class TestCountUnapprovedForOwner:
         await _insert("cnt-b", ALICE)
         await _insert("cnt-bob", BOB)
         await _publish("cnt-a")  # approved no longer counts
-        assert await _repo(ADMIN).count_unapproved_for_owner(ALICE_EMAIL) == 1
-        assert await _repo(ADMIN).count_unapproved_for_owner(BOB_EMAIL) == 1
+        query_alice = {"owner": ALICE_EMAIL, "is_approved": False}
+        query_bob = {"owner": BOB_EMAIL, "is_approved": False}
+        assert await _repo(ADMIN).count_matching(query_alice, scoped=False) == 1
+        assert await _repo(ADMIN).count_matching(query_bob, scoped=False) == 1
 
     async def test_is_unscoped(self, db):
-        # The count is the owner's true total, independent of who asks (Bob cannot see Alice's).
+        # scoped=False yields the owner's true total, independent of who asks (Bob cannot see Alice's).
         await _insert("cnt-priv-1", ALICE)
         await _insert("cnt-priv-2", ALICE)
-        assert await _repo(BOB).count_unapproved_for_owner(ALICE_EMAIL) == 2
+        query = {"owner": ALICE_EMAIL, "is_approved": False}
+        assert await _repo(BOB).count_matching(query, scoped=False) == 2
 
 
 # ---------------------------------------------------------------------------

--- a/mpcontribs-api/tests/integration/db/test_initiatives_repository.py
+++ b/mpcontribs-api/tests/integration/db/test_initiatives_repository.py
@@ -1,7 +1,16 @@
+"""Real-DB tests for :class:`InitiativeRepository` as a query/persistence toolbox.
+
+Authorization (authenticated-create, manage-rights, admin-only approval, owner-or-admin delete), the
+``public ⇒ approved`` invariant, and the per-owner unapproved quota moved to
+:class:`InitiativeService` (see ``test_initiatives_service.py``). What remains here is the toolbox:
+scoped reads (visibility, filters), the mechanical ``insert`` (owner-stamp + dup-slug reject), and
+``count_unapproved_for_owner``. State-seeding uses the base ``patch_one`` (a mechanical ``$set`` with
+no auth), which the repo no longer overrides.
+"""
+
 import pytest
 
 from mpcontribs_api.authz import User
-from mpcontribs_api.config import get_settings
 from mpcontribs_api.domains.initiatives.models import (
     Initiative,
     InitiativeFilter,
@@ -9,7 +18,7 @@ from mpcontribs_api.domains.initiatives.models import (
     InitiativePatch,
 )
 from mpcontribs_api.domains.initiatives.repository import InitiativeRepository
-from mpcontribs_api.exceptions import ConflictError, NotFoundError, PermissionError, ValidationError
+from mpcontribs_api.exceptions import ConflictError
 from mpcontribs_api.pagination import CursorParams
 
 # Share the session event loop (see the projects repo test for why).
@@ -39,20 +48,22 @@ def _collaborator(slug: str, username: str = BOB_EMAIL) -> User:
 
 
 async def _insert(slug: str, owner_user: User = ALICE, name: str = "An Initiative") -> Initiative:
-    return await _repo(owner_user).insert_one(InitiativeIn(slug=slug, name=name))
+    """Seed via the repository's mechanical insert (owner passed explicitly, as the service would)."""
+    return await _repo(owner_user).insert_one(InitiativeIn(slug=slug, name=name), owner=owner_user.username)
 
 
-async def _approve(slug: str) -> Initiative:
-    return await _repo(ADMIN).patch_one({"slug": slug}, InitiativePatch(is_approved=True))
+async def _publish(slug: str) -> None:
+    """Mark ``slug`` approved+public via the base (mechanical, no-auth) patch — for scope seeding."""
+    await _repo(ADMIN).patch_one({"slug": slug}, InitiativePatch(is_approved=True, is_public=True))
 
 
 # ---------------------------------------------------------------------------
-# Create + owner forcing
+# insert (mechanical: owner-stamp + dup-slug reject)
 # ---------------------------------------------------------------------------
 
 
 class TestInsert:
-    async def test_forces_owner_and_starts_private_unapproved(self, db):
+    async def test_stamps_owner_and_starts_private_unapproved(self, db):
         created = await _insert("battery-genome", ALICE)
         assert created.owner == ALICE_EMAIL
         assert created.is_public is False
@@ -63,93 +74,35 @@ class TestInsert:
         with pytest.raises(ConflictError):
             await _insert("dup-slug", BOB)  # globally unique, even across owners
 
-    async def test_anonymous_cannot_create(self, db):
-        with pytest.raises(PermissionError):
-            await _repo(ANON).insert_one(InitiativeIn(slug="anon-init", name="x"))
-
-    async def test_invalid_slug_rejected(self, db):
-        with pytest.raises(ValidationError):
-            InitiativeIn(slug="Not A Slug!", name="x")
-
-
-class TestUnapprovedPerOwnerLimit:
-    async def test_owner_capped_at_configured_unapproved(self, db):
-        limit = get_settings().domain.initiatives.max_unapproved_per_owner
-        for i in range(limit):
-            await _insert(f"cap-{i}", ALICE)
-        with pytest.raises(ConflictError):
-            await _insert("cap-over", ALICE)
-
-    async def test_approved_do_not_count_against_quota(self, db):
-        limit = get_settings().domain.initiatives.max_unapproved_per_owner
-        for i in range(limit):
-            await _insert(f"quota-{i}", ALICE)
-        await _approve("quota-0")  # frees a slot
-        # A fresh unapproved initiative now fits again.
-        assert await _insert("quota-extra", ALICE) is not None
-
-    async def test_admin_is_exempt(self, db):
-        limit = get_settings().domain.initiatives.max_unapproved_per_owner
-        for i in range(limit + 2):
-            await _repo(ADMIN).insert_one(InitiativeIn(slug=f"admin-{i}", name="x"))
-
 
 # ---------------------------------------------------------------------------
-# Approval + public invariant
+# count_unapproved_for_owner  (toolbox primitive; the cap decision lives in the service)
 # ---------------------------------------------------------------------------
 
 
-class TestApprovalAndPublic:
-    async def test_only_admin_may_approve(self, db):
-        await _insert("approve-me", ALICE)
-        with pytest.raises(PermissionError):
-            await _repo(ALICE).patch_one({"slug": "approve-me"}, InitiativePatch(is_approved=True))
-        approved = await _approve("approve-me")
-        assert approved.is_approved is True
+class TestCountUnapprovedForOwner:
+    async def test_counts_only_unapproved_of_that_owner(self, db):
+        await _insert("cnt-a", ALICE)
+        await _insert("cnt-b", ALICE)
+        await _insert("cnt-bob", BOB)
+        await _publish("cnt-a")  # approved no longer counts
+        assert await _repo(ADMIN).count_unapproved_for_owner(ALICE_EMAIL) == 1
+        assert await _repo(ADMIN).count_unapproved_for_owner(BOB_EMAIL) == 1
 
-    async def test_cannot_make_public_while_unapproved(self, db):
-        await _insert("public-fail", ALICE)
-        with pytest.raises(ValidationError):
-            await _repo(ALICE).patch_one({"slug": "public-fail"}, InitiativePatch(is_public=True))
-
-    async def test_public_allowed_once_approved(self, db):
-        await _insert("public-ok", ALICE)
-        await _approve("public-ok")
-        patched = await _repo(ALICE).patch_one({"slug": "public-ok"}, InitiativePatch(is_public=True))
-        assert patched.is_public is True
-
-    async def test_admin_can_approve_and_publish_together(self, db):
-        await _insert("publish-both", ALICE)
-        patched = await _repo(ADMIN).patch_one({"slug": "publish-both"}, InitiativePatch(is_approved=True, is_public=True))
-        assert patched.is_approved is True and patched.is_public is True
+    async def test_is_unscoped(self, db):
+        # The count is the owner's true total, independent of who asks (Bob cannot see Alice's).
+        await _insert("cnt-priv-1", ALICE)
+        await _insert("cnt-priv-2", ALICE)
+        assert await _repo(BOB).count_unapproved_for_owner(ALICE_EMAIL) == 2
 
 
 # ---------------------------------------------------------------------------
-# Manage rights (patch) + read scope
+# Read scope (visibility)
 # ---------------------------------------------------------------------------
 
 
-class TestManageAndScope:
-    async def test_owner_can_rename(self, db):
-        await _insert("rename-me", ALICE)
-        patched = await _repo(ALICE).patch_one({"slug": "rename-me"}, InitiativePatch(name="Renamed"))
-        assert patched.name == "Renamed"
-
-    async def test_collaborator_can_patch(self, db):
-        await _insert("collab-patch", ALICE)
-        patched = await _repo(_collaborator("collab-patch")).patch_one({"slug": "collab-patch"}, InitiativePatch(name="By Collaborator"))
-        assert patched.name == "By Collaborator"
-
-    async def test_visible_but_unmanaged_cannot_patch(self, db):
-        # An approved+public initiative is visible to everyone, but a stranger still cannot manage it.
-        await _insert("visible-public", ALICE)
-        await _approve("visible-public")
-        await _repo(ALICE).patch_one({"slug": "visible-public"}, InitiativePatch(is_public=True))
-        stranger = User(username="google:carol@example.com", groups=frozenset())
-        with pytest.raises(PermissionError):
-            await _repo(stranger).patch_one({"slug": "visible-public"}, InitiativePatch(name="hijack"))
-
-    async def test_private_unapproved_scope(self, db):
+class TestReadScope:
+    async def test_private_unapproved_visibility(self, db):
         await _insert("scoped-priv", ALICE)
         assert await _repo(ALICE).get_one({"slug": "scoped-priv"}, fields=None) is not None  # owner
         assert await _repo(ADMIN).get_one({"slug": "scoped-priv"}, fields=None) is not None  # admin
@@ -159,31 +112,8 @@ class TestManageAndScope:
 
     async def test_public_approved_visible_to_anon(self, db):
         await _insert("scoped-pub", ALICE)
-        await _approve("scoped-pub")
-        await _repo(ALICE).patch_one({"slug": "scoped-pub"}, InitiativePatch(is_public=True))
+        await _publish("scoped-pub")
         assert await _repo(ANON).get_one({"slug": "scoped-pub"}, fields=None) is not None
-
-
-# ---------------------------------------------------------------------------
-# Delete (owner or admin only)
-# ---------------------------------------------------------------------------
-
-
-class TestDelete:
-    async def test_owner_can_delete(self, db):
-        await _insert("del-owner", ALICE)
-        result = await _repo(ALICE).delete_one({"slug": "del-owner"})
-        assert result.num_deleted == 1
-        assert await _repo(ADMIN).get_one({"slug": "del-owner"}, fields=None) is None
-
-    async def test_collaborator_cannot_delete(self, db):
-        await _insert("del-collab", ALICE)
-        with pytest.raises(PermissionError):
-            await _repo(_collaborator("del-collab")).delete_one({"slug": "del-collab"})
-
-    async def test_missing_is_not_found(self, db):
-        with pytest.raises(NotFoundError):
-            await _repo(ADMIN).delete_one({"slug": "nope-missing"})
 
 
 # ---------------------------------------------------------------------------
@@ -203,7 +133,7 @@ class TestListAndFilter:
     async def test_filter_by_is_approved(self, db):
         await _insert("appr-1", ALICE)
         await _insert("unappr-1", ALICE)
-        await _approve("appr-1")
+        await _publish("appr-1")
         page = await _repo(ADMIN).get_many(CursorParams(), InitiativeFilter(is_approved=True), fields=None)
         slugs = {i.slug for i in page.items}
         assert "appr-1" in slugs
@@ -214,20 +144,3 @@ class TestListAndFilter:
         await _insert("owned-bob", BOB)
         page = await _repo(ADMIN).get_many(CursorParams(), InitiativeFilter(owner=BOB_EMAIL), fields=None)
         assert {i.slug for i in page.items} == {"owned-bob"}
-
-
-# ---------------------------------------------------------------------------
-# Admin bypass
-# ---------------------------------------------------------------------------
-
-
-class TestAdminBypass:
-    async def test_admin_can_patch_non_owned(self, db):
-        await _insert("admin-patch", ALICE)
-        patched = await _repo(ADMIN).patch_one({"slug": "admin-patch"}, InitiativePatch(name="Admin Renamed"))
-        assert patched.name == "Admin Renamed"
-
-    async def test_admin_can_delete_non_owned(self, db):
-        await _insert("admin-del", ALICE)
-        result = await _repo(ADMIN).delete_one({"slug": "admin-del"})
-        assert result.num_deleted == 1

--- a/mpcontribs-api/tests/integration/db/test_initiatives_repository.py
+++ b/mpcontribs-api/tests/integration/db/test_initiatives_repository.py
@@ -1,4 +1,4 @@
-"""Real-DB tests for :class:`InitiativeRepository` as a query/persistence toolbox.
+"""Real-DB tests for :class:`MongoDbInitiativeRepository` as a query/persistence toolbox.
 
 Authorization (authenticated-create, manage-rights, admin-only approval, owner-or-admin delete), the
 ``public ⇒ approved`` invariant, and the per-owner unapproved quota moved to
@@ -17,7 +17,7 @@ from mpcontribs_api.domains.initiatives.models import (
     InitiativeIn,
     InitiativePatch,
 )
-from mpcontribs_api.domains.initiatives.repository import InitiativeRepository
+from mpcontribs_api.domains.initiatives.repository import MongoDbInitiativeRepository
 from mpcontribs_api.exceptions import ConflictError
 from mpcontribs_api.pagination import CursorParams
 
@@ -38,8 +38,8 @@ ALICE_EMAIL = "google:alice@example.com"
 BOB_EMAIL = "google:bob@example.com"
 
 
-def _repo(user: User) -> InitiativeRepository:
-    return InitiativeRepository(user)
+def _repo(user: User) -> MongoDbInitiativeRepository:
+    return MongoDbInitiativeRepository(user)
 
 
 def _collaborator(slug: str, username: str = BOB_EMAIL) -> User:

--- a/mpcontribs-api/tests/integration/db/test_initiatives_repository.py
+++ b/mpcontribs-api/tests/integration/db/test_initiatives_repository.py
@@ -48,8 +48,13 @@ def _collaborator(slug: str, username: str = BOB_EMAIL) -> User:
 
 
 async def _insert(slug: str, owner_user: User = ALICE, name: str = "An Initiative") -> Initiative:
-    """Seed via the repository's mechanical insert (owner passed explicitly, as the service would)."""
-    return await _repo(owner_user).insert_one(InitiativeIn(slug=slug, name=name), owner=owner_user.username)
+    """Seed the way the service does: build the document (owner-stamped) then hand it to the repo.
+
+    The repository is document-in, so the input→document conversion (``from_input_model``, which
+    stamps ``owner``) lives in the caller, not the repo.
+    """
+    document = Initiative.from_input_model(InitiativeIn(slug=slug, name=name), owner=owner_user.username)
+    return await _repo(owner_user).insert_one(document)
 
 
 async def _publish(slug: str) -> None:

--- a/mpcontribs-api/tests/integration/db/test_initiatives_repository.py
+++ b/mpcontribs-api/tests/integration/db/test_initiatives_repository.py
@@ -133,7 +133,7 @@ class TestListAndFilter:
     async def test_list_scoped_to_caller(self, db):
         await _insert("mine-1", ALICE)
         await _insert("bobs-1", BOB)  # Bob's private initiative, invisible to Alice
-        page = await _repo(ALICE).get_many(CursorParams(), InitiativeFilter(), fields=None)
+        page = await _repo(ALICE).get_many(InitiativeFilter(), pagination=CursorParams(), fields=None)
         slugs = {i.slug for i in page.items}
         assert "mine-1" in slugs
         assert "bobs-1" not in slugs
@@ -142,7 +142,7 @@ class TestListAndFilter:
         await _insert("appr-1", ALICE)
         await _insert("unappr-1", ALICE)
         await _publish("appr-1")
-        page = await _repo(ADMIN).get_many(CursorParams(), InitiativeFilter(is_approved=True), fields=None)
+        page = await _repo(ADMIN).get_many(InitiativeFilter(is_approved=True), pagination=CursorParams(), fields=None)
         slugs = {i.slug for i in page.items}
         assert "appr-1" in slugs
         assert "unappr-1" not in slugs
@@ -150,5 +150,5 @@ class TestListAndFilter:
     async def test_filter_by_owner(self, db):
         await _insert("owned-alice", ALICE)
         await _insert("owned-bob", BOB)
-        page = await _repo(ADMIN).get_many(CursorParams(), InitiativeFilter(owner=BOB_EMAIL), fields=None)
+        page = await _repo(ADMIN).get_many(InitiativeFilter(owner=BOB_EMAIL), pagination=CursorParams(), fields=None)
         assert {i.slug for i in page.items} == {"owned-bob"}

--- a/mpcontribs-api/tests/integration/db/test_initiatives_service.py
+++ b/mpcontribs-api/tests/integration/db/test_initiatives_service.py
@@ -4,7 +4,7 @@ from beanie import Link
 from mpcontribs_api.authz import User
 from mpcontribs_api.config import get_settings
 from mpcontribs_api.domains.initiatives.models import Initiative, InitiativeIn, InitiativePatch
-from mpcontribs_api.domains.initiatives.repository import InitiativeRepository
+from mpcontribs_api.domains.initiatives.repository import MongoDbInitiativeRepository
 from mpcontribs_api.domains.initiatives.service import InitiativeService
 from mpcontribs_api.domains.projects.models import Project, ProjectIn, ProjectPatch
 from mpcontribs_api.domains.projects.repository import MongoDbProjectRepository
@@ -31,7 +31,7 @@ def _service(user: User) -> ProjectService:
     return ProjectService(
         user=user,
         projects=MongoDbProjectRepository(user),
-        initiatives=InitiativeRepository(user),
+        initiatives=MongoDbInitiativeRepository(user),
     )
 
 
@@ -52,7 +52,7 @@ async def _insert_project(pid: str, owner: str = ALICE_EMAIL) -> Project:
 
 
 async def _insert_initiative(slug: str, owner_user: User = ALICE):
-    return await InitiativeRepository(owner_user).insert_one(
+    return await MongoDbInitiativeRepository(owner_user).insert_one(
         InitiativeIn(slug=slug, name="Init"), owner=owner_user.username
     )
 
@@ -112,7 +112,7 @@ class TestBothRights:
         # but she neither owns nor collaborates on it, so she still cannot assign to it.
         await _insert_project("proj-c", owner=CAROL_EMAIL)
         await _insert_initiative("init-c", ALICE)
-        await InitiativeRepository(ADMIN).patch_one(
+        await MongoDbInitiativeRepository(ADMIN).patch_one(
             {"slug": "init-c"}, InitiativePatch(is_approved=True, is_public=True)
         )
         with pytest.raises(PermissionError):
@@ -170,12 +170,12 @@ class TestMemberCap:
         # this test isolates the *initiative member* cap, not the project-count cap.
         monkeypatch.setattr(get_settings().consumer, "max_projects", cap + 5)
         await _insert_initiative("init-approved", ALICE)
-        await InitiativeRepository(ADMIN).patch_one({"slug": "init-approved"}, InitiativePatch(is_approved=True))
+        await MongoDbInitiativeRepository(ADMIN).patch_one({"slug": "init-approved"}, InitiativePatch(is_approved=True))
         for i in range(cap + 2):  # comfortably past the unapproved cap
             await _insert_project(f"appr-proj-{i}", owner=ALICE_EMAIL)
             await _service(ALICE).patch_one({"id": f"appr-proj-{i}"}, ProjectPatch(initiative="init-approved"))
         count = await MongoDbProjectRepository(ADMIN).count_initiative_members(
-            initiative_id=(await InitiativeRepository(ADMIN).get_one({"slug": "init-approved"})).id,  # type: ignore[union-attr]
+            initiative_id=(await MongoDbInitiativeRepository(ADMIN).get_one({"slug": "init-approved"})).id,  # type: ignore[union-attr]
             exclude_project_id=None,
         )
         assert count == cap + 2
@@ -219,7 +219,7 @@ class TestAdminAndUnassign:
 
 def _initiative_service(user: User) -> InitiativeService:
     return InitiativeService(
-        user=user, initiatives=InitiativeRepository(user), projects=MongoDbProjectRepository(user)
+        user=user, initiatives=MongoDbInitiativeRepository(user), projects=MongoDbProjectRepository(user)
     )
 
 

--- a/mpcontribs-api/tests/integration/db/test_initiatives_service.py
+++ b/mpcontribs-api/tests/integration/db/test_initiatives_service.py
@@ -3,13 +3,14 @@ from beanie import Link
 
 from mpcontribs_api.authz import User
 from mpcontribs_api.config import get_settings
-from mpcontribs_api.domains.initiatives.models import Initiative, InitiativeIn, InitiativePatch
+from mpcontribs_api.domains.initiatives.models import Initiative, InitiativeFilter, InitiativeIn, InitiativePatch
 from mpcontribs_api.domains.initiatives.repository import MongoDbInitiativeRepository
 from mpcontribs_api.domains.initiatives.service import InitiativeService
 from mpcontribs_api.domains.projects.models import Project, ProjectIn, ProjectPatch
 from mpcontribs_api.domains.projects.repository import MongoDbProjectRepository
 from mpcontribs_api.domains.projects.service import ProjectService
 from mpcontribs_api.exceptions import ConflictError, NotFoundError, PermissionError, ValidationError
+from mpcontribs_api.pagination import CursorParams
 
 pytestmark = [pytest.mark.db, pytest.mark.asyncio(loop_scope="session")]
 
@@ -349,3 +350,50 @@ class TestInitiativeDelete:
         reloaded = await MongoDbProjectRepository(ADMIN).find_by_id_unscoped("del-refs-proj")
         assert reloaded is not None
         assert _assigned_id(reloaded) is None
+
+
+# ---------------------------------------------------------------------------
+# Read scope — get_many / get_one filter by visibility; out-of-scope writes 404
+# ---------------------------------------------------------------------------
+
+
+class TestInitiativeReadScope:
+    async def test_get_many_hides_private_unowned(self, db):
+        # A stranger (no roles) sees only public+approved initiatives, never Alice's private one.
+        await _insert_initiative("scope-priv", ALICE)
+        await _insert_initiative("scope-pub", ALICE)
+        await _approve("scope-pub")
+        await _initiative_service(ADMIN).patch_one({"slug": "scope-pub"}, InitiativePatch(is_public=True))
+        stranger = User(username=CAROL_EMAIL, groups=frozenset())
+        page = await _initiative_service(stranger).get_many(
+            filter=InitiativeFilter(), pagination=CursorParams(), fields=None
+        )
+        slugs = {i.slug for i in page.items}
+        assert "scope-pub" in slugs
+        assert "scope-priv" not in slugs
+
+    async def test_get_one_private_unowned_returns_none(self, db):
+        await _insert_initiative("scope-one-priv", ALICE)
+        stranger = User(username=CAROL_EMAIL, groups=frozenset())
+        assert await _initiative_service(stranger).get_one({"slug": "scope-one-priv"}, fields=None) is None
+
+    async def test_owner_sees_own_private_initiative(self, db):
+        await _insert_initiative("scope-own", ALICE)
+        found = await _initiative_service(ALICE).get_one({"slug": "scope-own"}, fields=None)
+        assert found is not None and found.slug == "scope-own"
+
+
+class TestInitiativeOutOfScopeWrites:
+    async def test_patch_private_unowned_is_not_found(self, db):
+        # A private initiative is invisible to a stranger, so patching it is a 404, not a 403 — the
+        # 404-before-403 rule (existence is not leaked to callers who cannot see the resource).
+        await _insert_initiative("oos-patch", ALICE)
+        stranger = User(username=CAROL_EMAIL, groups=frozenset())
+        with pytest.raises(NotFoundError):
+            await _initiative_service(stranger).patch_one({"slug": "oos-patch"}, InitiativePatch(name="hijack"))
+
+    async def test_delete_private_unowned_is_not_found(self, db):
+        await _insert_initiative("oos-del", ALICE)
+        stranger = User(username=CAROL_EMAIL, groups=frozenset())
+        with pytest.raises(NotFoundError):
+            await _initiative_service(stranger).delete_one({"slug": "oos-del"})

--- a/mpcontribs-api/tests/integration/db/test_initiatives_service.py
+++ b/mpcontribs-api/tests/integration/db/test_initiatives_service.py
@@ -28,6 +28,7 @@ CAROL_EMAIL = "google:carol@example.com"
 
 def _service(user: User) -> ProjectService:
     return ProjectService(
+        user=user,
         projects=MongoDbProjectRepository(user),
         initiatives=InitiativeRepository(user),
     )

--- a/mpcontribs-api/tests/integration/db/test_initiatives_service.py
+++ b/mpcontribs-api/tests/integration/db/test_initiatives_service.py
@@ -40,21 +40,21 @@ def _collaborator(slug: str, username: str = BOB_EMAIL) -> User:
 
 
 async def _insert_project(pid: str, owner: str = ALICE_EMAIL) -> Project:
-    return await MongoDbProjectRepository(ADMIN).insert_one(
-        pid,
+    document = Project.from_input_model(
         ProjectIn(
             title=pid[:30],
             authors="Author",
             description="desc",
             owner=owner,
         ),
+        id=pid,
     )
+    return await MongoDbProjectRepository(ADMIN).insert_one(document)
 
 
 async def _insert_initiative(slug: str, owner_user: User = ALICE):
-    return await MongoDbInitiativeRepository(owner_user).insert_one(
-        InitiativeIn(slug=slug, name="Init"), owner=owner_user.username
-    )
+    document = Initiative.from_input_model(InitiativeIn(slug=slug, name="Init"), owner=owner_user.username)
+    return await MongoDbInitiativeRepository(owner_user).insert_one(document)
 
 
 def _assigned_id(project: Project):

--- a/mpcontribs-api/tests/integration/db/test_initiatives_service.py
+++ b/mpcontribs-api/tests/integration/db/test_initiatives_service.py
@@ -3,12 +3,13 @@ from beanie import Link
 
 from mpcontribs_api.authz import User
 from mpcontribs_api.config import get_settings
-from mpcontribs_api.domains.initiatives.models import InitiativeIn, InitiativePatch
+from mpcontribs_api.domains.initiatives.models import Initiative, InitiativeIn, InitiativePatch
 from mpcontribs_api.domains.initiatives.repository import InitiativeRepository
+from mpcontribs_api.domains.initiatives.service import InitiativeService
 from mpcontribs_api.domains.projects.models import Project, ProjectIn, ProjectPatch
 from mpcontribs_api.domains.projects.repository import MongoDbProjectRepository
 from mpcontribs_api.domains.projects.service import ProjectService
-from mpcontribs_api.exceptions import ConflictError, NotFoundError, PermissionError
+from mpcontribs_api.exceptions import ConflictError, NotFoundError, PermissionError, ValidationError
 
 pytestmark = [pytest.mark.db, pytest.mark.asyncio(loop_scope="session")]
 
@@ -51,7 +52,9 @@ async def _insert_project(pid: str, owner: str = ALICE_EMAIL) -> Project:
 
 
 async def _insert_initiative(slug: str, owner_user: User = ALICE):
-    return await InitiativeRepository(owner_user).insert_one(InitiativeIn(slug=slug, name="Init"))
+    return await InitiativeRepository(owner_user).insert_one(
+        InitiativeIn(slug=slug, name="Init"), owner=owner_user.username
+    )
 
 
 def _assigned_id(project: Project):
@@ -202,3 +205,147 @@ class TestAdminAndUnassign:
         bob_plain = User(username=BOB_EMAIL, groups=frozenset())
         updated = await _service(bob_plain).patch_one({"id": "detach-proj"}, ProjectPatch(initiative=None))
         assert _assigned_id(updated) is None
+
+
+# ===========================================================================
+# InitiativeService — create / patch / delete authorization
+#
+# The initiative write policy (authenticated-create, per-owner unapproved quota, manage rights,
+# admin-only approval, public⇒approved, owner-or-admin delete) lives on InitiativeService; these
+# drive it against the real DB. The ProjectService assignment tests above are a separate concern —
+# assignment is an initiative-facing operation on the *project* service.
+# ===========================================================================
+
+
+def _initiative_service(user: User) -> InitiativeService:
+    return InitiativeService(
+        user=user, initiatives=InitiativeRepository(user), projects=MongoDbProjectRepository(user)
+    )
+
+
+async def _approve(slug: str) -> Initiative:
+    return await _initiative_service(ADMIN).patch_one({"slug": slug}, InitiativePatch(is_approved=True))
+
+
+class TestInitiativeCreate:
+    async def test_forces_owner_and_starts_private_unapproved(self, db):
+        created = await _initiative_service(ALICE).insert_one(InitiativeIn(slug="svc-create", name="X"))
+        assert created.owner == ALICE_EMAIL
+        assert created.is_public is False
+        assert created.is_approved is False
+
+    async def test_anonymous_cannot_create(self, db):
+        with pytest.raises(PermissionError):
+            await _initiative_service(User()).insert_one(InitiativeIn(slug="svc-anon", name="X"))
+
+    async def test_duplicate_slug_is_conflict(self, db):
+        await _initiative_service(ALICE).insert_one(InitiativeIn(slug="svc-dup", name="X"))
+        bob = User(username=BOB_EMAIL, groups=frozenset())
+        with pytest.raises(ConflictError):
+            await _initiative_service(bob).insert_one(InitiativeIn(slug="svc-dup", name="X"))
+
+    async def test_owner_capped_at_configured_unapproved(self, db):
+        limit = get_settings().domain.initiatives.max_unapproved_per_owner
+        for i in range(limit):
+            await _initiative_service(ALICE).insert_one(InitiativeIn(slug=f"svc-cap-{i}", name="X"))
+        with pytest.raises(ConflictError):
+            await _initiative_service(ALICE).insert_one(InitiativeIn(slug="svc-cap-over", name="X"))
+
+    async def test_approved_frees_a_quota_slot(self, db):
+        limit = get_settings().domain.initiatives.max_unapproved_per_owner
+        for i in range(limit):
+            await _initiative_service(ALICE).insert_one(InitiativeIn(slug=f"svc-quota-{i}", name="X"))
+        await _approve("svc-quota-0")
+        assert await _initiative_service(ALICE).insert_one(InitiativeIn(slug="svc-quota-extra", name="X")) is not None
+
+    async def test_admin_is_exempt_from_quota(self, db):
+        limit = get_settings().domain.initiatives.max_unapproved_per_owner
+        for i in range(limit + 2):
+            await _initiative_service(ADMIN).insert_one(InitiativeIn(slug=f"svc-admin-{i}", name="X"))
+
+
+class TestInitiativePatchAuth:
+    async def test_only_admin_may_approve(self, db):
+        await _insert_initiative("svc-approve", ALICE)
+        with pytest.raises(PermissionError):
+            await _initiative_service(ALICE).patch_one({"slug": "svc-approve"}, InitiativePatch(is_approved=True))
+        approved = await _approve("svc-approve")
+        assert approved.is_approved is True
+
+    async def test_cannot_make_public_while_unapproved(self, db):
+        await _insert_initiative("svc-pub-fail", ALICE)
+        with pytest.raises(ValidationError):
+            await _initiative_service(ALICE).patch_one({"slug": "svc-pub-fail"}, InitiativePatch(is_public=True))
+
+    async def test_public_allowed_once_approved(self, db):
+        await _insert_initiative("svc-pub-ok", ALICE)
+        await _approve("svc-pub-ok")
+        patched = await _initiative_service(ALICE).patch_one({"slug": "svc-pub-ok"}, InitiativePatch(is_public=True))
+        assert patched.is_public is True
+
+    async def test_owner_can_rename(self, db):
+        await _insert_initiative("svc-rename", ALICE)
+        patched = await _initiative_service(ALICE).patch_one({"slug": "svc-rename"}, InitiativePatch(name="Renamed"))
+        assert patched.name == "Renamed"
+
+    async def test_collaborator_can_patch(self, db):
+        await _insert_initiative("svc-collab", ALICE)
+        patched = await _initiative_service(_collaborator("svc-collab")).patch_one(
+            {"slug": "svc-collab"}, InitiativePatch(name="By Collaborator")
+        )
+        assert patched.name == "By Collaborator"
+
+    async def test_visible_but_unmanaged_cannot_patch(self, db):
+        await _insert_initiative("svc-visible", ALICE)
+        await _initiative_service(ADMIN).patch_one(
+            {"slug": "svc-visible"}, InitiativePatch(is_approved=True, is_public=True)
+        )
+        stranger = User(username=CAROL_EMAIL, groups=frozenset())
+        with pytest.raises(PermissionError):
+            await _initiative_service(stranger).patch_one({"slug": "svc-visible"}, InitiativePatch(name="hijack"))
+
+    async def test_missing_is_not_found(self, db):
+        with pytest.raises(NotFoundError):
+            await _initiative_service(ADMIN).patch_one({"slug": "svc-patch-ghost"}, InitiativePatch(name="x"))
+
+    async def test_admin_can_patch_non_owned(self, db):
+        await _insert_initiative("svc-admin-patch", ALICE)
+        patched = await _initiative_service(ADMIN).patch_one(
+            {"slug": "svc-admin-patch"}, InitiativePatch(name="Admin Renamed")
+        )
+        assert patched.name == "Admin Renamed"
+
+
+class TestInitiativeDelete:
+    async def test_owner_can_delete(self, db):
+        await _insert_initiative("svc-del-owner", ALICE)
+        result = await _initiative_service(ALICE).delete_one({"slug": "svc-del-owner"})
+        assert result.num_deleted == 1
+
+    async def test_collaborator_cannot_delete(self, db):
+        await _insert_initiative("svc-del-collab", ALICE)
+        with pytest.raises(PermissionError):
+            await _initiative_service(_collaborator("svc-del-collab")).delete_one({"slug": "svc-del-collab"})
+
+    async def test_missing_is_not_found(self, db):
+        with pytest.raises(NotFoundError):
+            await _initiative_service(ADMIN).delete_one({"slug": "svc-del-ghost"})
+
+    async def test_admin_can_delete_non_owned(self, db):
+        await _insert_initiative("svc-admin-del", ALICE)
+        result = await _initiative_service(ADMIN).delete_one({"slug": "svc-admin-del"})
+        assert result.num_deleted == 1
+
+    async def test_delete_clears_member_project_links(self, db):
+        # Deleting an initiative must unset the `initiative` link on its members, leaving no
+        # dangling reference behind (round-trip: assign, delete, re-read from the DB).
+        await _insert_project("del-refs-proj", owner=ALICE_EMAIL)
+        init = await _insert_initiative("svc-del-refs", ALICE)
+        assigned = await _service(ALICE).patch_one({"id": "del-refs-proj"}, ProjectPatch(initiative="svc-del-refs"))
+        assert _assigned_id(assigned) == init.id
+
+        await _initiative_service(ALICE).delete_one({"slug": "svc-del-refs"})
+
+        reloaded = await MongoDbProjectRepository(ADMIN).find_by_id_unscoped("del-refs-proj")
+        assert reloaded is not None
+        assert _assigned_id(reloaded) is None

--- a/mpcontribs-api/tests/integration/db/test_initiatives_service.py
+++ b/mpcontribs-api/tests/integration/db/test_initiatives_service.py
@@ -174,9 +174,9 @@ class TestMemberCap:
         for i in range(cap + 2):  # comfortably past the unapproved cap
             await _insert_project(f"appr-proj-{i}", owner=ALICE_EMAIL)
             await _service(ALICE).patch_one({"id": f"appr-proj-{i}"}, ProjectPatch(initiative="init-approved"))
-        count = await MongoDbProjectRepository(ADMIN).count_initiative_members(
-            initiative_id=(await MongoDbInitiativeRepository(ADMIN).get_one({"slug": "init-approved"})).id,  # type: ignore[union-attr]
-            exclude_project_id=None,
+        initiative_id = (await MongoDbInitiativeRepository(ADMIN).get_one({"slug": "init-approved"})).id  # type: ignore[union-attr]
+        count = await MongoDbProjectRepository(ADMIN).count_matching(
+            {"initiative.$id": initiative_id}, scoped=False
         )
         assert count == cap + 2
 

--- a/mpcontribs-api/tests/integration/db/test_initiatives_service.py
+++ b/mpcontribs-api/tests/integration/db/test_initiatives_service.py
@@ -75,30 +75,30 @@ class TestAssign:
     async def test_owner_of_both_can_assign(self, db):
         await _insert_project("proj-a", owner=ALICE_EMAIL)
         init = await _insert_initiative("init-a", ALICE)
-        updated = await _service(ALICE).patch_one({"id": "proj-a"}, ProjectPatch(initiative="init-a"))
+        updated = await _service(ALICE).update_one({"id": "proj-a"}, ProjectPatch(initiative="init-a"))
         assert _assigned_id(updated) == init.id
 
     async def test_collaborator_can_assign_own_project(self, db):
         await _insert_project("proj-b", owner=BOB_EMAIL)
         init = await _insert_initiative("init-collab", ALICE)
         bob = _collaborator("init-collab")
-        updated = await _service(bob).patch_one({"id": "proj-b"}, ProjectPatch(initiative="init-collab"))
+        updated = await _service(bob).update_one({"id": "proj-b"}, ProjectPatch(initiative="init-collab"))
         assert _assigned_id(updated) == init.id
 
     async def test_plain_patch_passes_through_untouched(self, db):
         await _insert_project("proj-plain", owner=ALICE_EMAIL)
         init = await _insert_initiative("init-plain", ALICE)
-        await _service(ALICE).patch_one({"id": "proj-plain"}, ProjectPatch(initiative="init-plain"))
+        await _service(ALICE).update_one({"id": "proj-plain"}, ProjectPatch(initiative="init-plain"))
         # A patch that does not mention `initiative` must not disturb the existing assignment.
-        updated = await _service(ALICE).patch_one({"id": "proj-plain"}, ProjectPatch(title="new-title"))
+        updated = await _service(ALICE).update_one({"id": "proj-plain"}, ProjectPatch(title="new-title"))
         assert updated.title == "new-title"
         assert _assigned_id(updated) == init.id
 
     async def test_unassign_clears_link(self, db):
         await _insert_project("proj-un", owner=ALICE_EMAIL)
         await _insert_initiative("init-un", ALICE)
-        await _service(ALICE).patch_one({"id": "proj-un"}, ProjectPatch(initiative="init-un"))
-        updated = await _service(ALICE).patch_one({"id": "proj-un"}, ProjectPatch(initiative=None))
+        await _service(ALICE).update_one({"id": "proj-un"}, ProjectPatch(initiative="init-un"))
+        updated = await _service(ALICE).update_one({"id": "proj-un"}, ProjectPatch(initiative=None))
         assert _assigned_id(updated) is None
 
 
@@ -113,30 +113,30 @@ class TestBothRights:
         # but she neither owns nor collaborates on it, so she still cannot assign to it.
         await _insert_project("proj-c", owner=CAROL_EMAIL)
         await _insert_initiative("init-c", ALICE)
-        await MongoDbInitiativeRepository(ADMIN).patch_one(
+        await MongoDbInitiativeRepository(ADMIN).update_one(
             {"slug": "init-c"}, InitiativePatch(is_approved=True, is_public=True)
         )
         with pytest.raises(PermissionError):
-            await _service(CAROL).patch_one({"id": "proj-c"}, ProjectPatch(initiative="init-c"))
+            await _service(CAROL).update_one({"id": "proj-c"}, ProjectPatch(initiative="init-c"))
 
     async def test_invisible_initiative_is_not_found(self, db):
         # Alice's private initiative is invisible to Carol, so it reads as not-found (not a 403).
         await _insert_project("proj-c2", owner=CAROL_EMAIL)
         await _insert_initiative("init-priv", ALICE)
         with pytest.raises(NotFoundError):
-            await _service(CAROL).patch_one({"id": "proj-c2"}, ProjectPatch(initiative="init-priv"))
+            await _service(CAROL).update_one({"id": "proj-c2"}, ProjectPatch(initiative="init-priv"))
 
     async def test_manager_without_project_write_rejected(self, db):
         # Alice manages the initiative but cannot see/write Bob's private project.
         await _insert_project("proj-bob", owner=BOB_EMAIL)
         await _insert_initiative("init-d", ALICE)
         with pytest.raises(NotFoundError):
-            await _service(ALICE).patch_one({"id": "proj-bob"}, ProjectPatch(initiative="init-d"))
+            await _service(ALICE).update_one({"id": "proj-bob"}, ProjectPatch(initiative="init-d"))
 
     async def test_assign_to_missing_initiative_is_not_found(self, db):
         await _insert_project("proj-ghost", owner=ALICE_EMAIL)
         with pytest.raises(NotFoundError):
-            await _service(ALICE).patch_one({"id": "proj-ghost"}, ProjectPatch(initiative="ghost-init"))
+            await _service(ALICE).update_one({"id": "proj-ghost"}, ProjectPatch(initiative="ghost-init"))
 
 
 # ---------------------------------------------------------------------------
@@ -150,19 +150,19 @@ class TestMemberCap:
         await _insert_initiative("init-cap", ALICE)
         for i in range(cap):
             await _insert_project(f"cap-proj-{i}", owner=ALICE_EMAIL)
-            await _service(ALICE).patch_one({"id": f"cap-proj-{i}"}, ProjectPatch(initiative="init-cap"))
+            await _service(ALICE).update_one({"id": f"cap-proj-{i}"}, ProjectPatch(initiative="init-cap"))
         await _insert_project("cap-proj-over", owner=ALICE_EMAIL)
         with pytest.raises(ConflictError):
-            await _service(ALICE).patch_one({"id": "cap-proj-over"}, ProjectPatch(initiative="init-cap"))
+            await _service(ALICE).update_one({"id": "cap-proj-over"}, ProjectPatch(initiative="init-cap"))
 
     async def test_reassigning_existing_member_is_idempotent(self, db):
         cap = get_settings().domain.initiatives.max_projects_per_unapproved
         await _insert_initiative("init-idem", ALICE)
         for i in range(cap):
             await _insert_project(f"idem-proj-{i}", owner=ALICE_EMAIL)
-            await _service(ALICE).patch_one({"id": f"idem-proj-{i}"}, ProjectPatch(initiative="init-idem"))
+            await _service(ALICE).update_one({"id": f"idem-proj-{i}"}, ProjectPatch(initiative="init-idem"))
         # At the cap, re-assigning a project that is already a member must not trip the limit.
-        again = await _service(ALICE).patch_one({"id": "idem-proj-0"}, ProjectPatch(initiative="init-idem"))
+        again = await _service(ALICE).update_one({"id": "idem-proj-0"}, ProjectPatch(initiative="init-idem"))
         assert again.initiative is not None
 
     async def test_approved_initiative_has_no_member_cap(self, db, monkeypatch):
@@ -171,11 +171,11 @@ class TestMemberCap:
         # this test isolates the *initiative member* cap, not the project-count cap.
         monkeypatch.setattr(get_settings().consumer, "max_projects", cap + 5)
         await _insert_initiative("init-approved", ALICE)
-        await MongoDbInitiativeRepository(ADMIN).patch_one({"slug": "init-approved"}, InitiativePatch(is_approved=True))
+        await MongoDbInitiativeRepository(ADMIN).update_one({"slug": "init-approved"}, InitiativePatch(is_approved=True))
         for i in range(cap + 2):  # comfortably past the unapproved cap
             await _insert_project(f"appr-proj-{i}", owner=ALICE_EMAIL)
-            await _service(ALICE).patch_one({"id": f"appr-proj-{i}"}, ProjectPatch(initiative="init-approved"))
-        initiative_id = (await MongoDbInitiativeRepository(ADMIN).get_one({"slug": "init-approved"})).id  # type: ignore[union-attr]
+            await _service(ALICE).update_one({"id": f"appr-proj-{i}"}, ProjectPatch(initiative="init-approved"))
+        initiative_id = (await MongoDbInitiativeRepository(ADMIN).read_one({"slug": "init-approved"})).id  # type: ignore[union-attr]
         count = await MongoDbProjectRepository(ADMIN).count_matching(
             {"initiative.$id": initiative_id}, scoped=False
         )
@@ -192,7 +192,7 @@ class TestAdminAndUnassign:
         # Alice's private initiative is manageable by an admin even though the admin holds no role.
         await _insert_project("adm-proj", owner=ALICE_EMAIL)
         init = await _insert_initiative("adm-init", ALICE)
-        updated = await _service(ADMIN).patch_one({"id": "adm-proj"}, ProjectPatch(initiative="adm-init"))
+        updated = await _service(ADMIN).update_one({"id": "adm-proj"}, ProjectPatch(initiative="adm-init"))
         assert _assigned_id(updated) == init.id
 
     async def test_project_owner_can_unassign_without_initiative_rights(self, db):
@@ -200,11 +200,11 @@ class TestAdminAndUnassign:
         # his own project — unassignment needs only project-write access.
         await _insert_project("detach-proj", owner=BOB_EMAIL)
         await _insert_initiative("detach-init", ALICE)
-        await _service(_collaborator("detach-init", username=BOB_EMAIL)).patch_one(
+        await _service(_collaborator("detach-init", username=BOB_EMAIL)).update_one(
             {"id": "detach-proj"}, ProjectPatch(initiative="detach-init")
         )
         bob_plain = User(username=BOB_EMAIL, groups=frozenset())
-        updated = await _service(bob_plain).patch_one({"id": "detach-proj"}, ProjectPatch(initiative=None))
+        updated = await _service(bob_plain).update_one({"id": "detach-proj"}, ProjectPatch(initiative=None))
         assert _assigned_id(updated) is None
 
 
@@ -225,7 +225,7 @@ def _initiative_service(user: User) -> InitiativeService:
 
 
 async def _approve(slug: str) -> Initiative:
-    return await _initiative_service(ADMIN).patch_one({"slug": slug}, InitiativePatch(is_approved=True))
+    return await _initiative_service(ADMIN).update_one({"slug": slug}, InitiativePatch(is_approved=True))
 
 
 class TestInitiativeCreate:
@@ -269,49 +269,49 @@ class TestInitiativePatchAuth:
     async def test_only_admin_may_approve(self, db):
         await _insert_initiative("svc-approve", ALICE)
         with pytest.raises(PermissionError):
-            await _initiative_service(ALICE).patch_one({"slug": "svc-approve"}, InitiativePatch(is_approved=True))
+            await _initiative_service(ALICE).update_one({"slug": "svc-approve"}, InitiativePatch(is_approved=True))
         approved = await _approve("svc-approve")
         assert approved.is_approved is True
 
     async def test_cannot_make_public_while_unapproved(self, db):
         await _insert_initiative("svc-pub-fail", ALICE)
         with pytest.raises(ValidationError):
-            await _initiative_service(ALICE).patch_one({"slug": "svc-pub-fail"}, InitiativePatch(is_public=True))
+            await _initiative_service(ALICE).update_one({"slug": "svc-pub-fail"}, InitiativePatch(is_public=True))
 
     async def test_public_allowed_once_approved(self, db):
         await _insert_initiative("svc-pub-ok", ALICE)
         await _approve("svc-pub-ok")
-        patched = await _initiative_service(ALICE).patch_one({"slug": "svc-pub-ok"}, InitiativePatch(is_public=True))
+        patched = await _initiative_service(ALICE).update_one({"slug": "svc-pub-ok"}, InitiativePatch(is_public=True))
         assert patched.is_public is True
 
     async def test_owner_can_rename(self, db):
         await _insert_initiative("svc-rename", ALICE)
-        patched = await _initiative_service(ALICE).patch_one({"slug": "svc-rename"}, InitiativePatch(name="Renamed"))
+        patched = await _initiative_service(ALICE).update_one({"slug": "svc-rename"}, InitiativePatch(name="Renamed"))
         assert patched.name == "Renamed"
 
     async def test_collaborator_can_patch(self, db):
         await _insert_initiative("svc-collab", ALICE)
-        patched = await _initiative_service(_collaborator("svc-collab")).patch_one(
+        patched = await _initiative_service(_collaborator("svc-collab")).update_one(
             {"slug": "svc-collab"}, InitiativePatch(name="By Collaborator")
         )
         assert patched.name == "By Collaborator"
 
     async def test_visible_but_unmanaged_cannot_patch(self, db):
         await _insert_initiative("svc-visible", ALICE)
-        await _initiative_service(ADMIN).patch_one(
+        await _initiative_service(ADMIN).update_one(
             {"slug": "svc-visible"}, InitiativePatch(is_approved=True, is_public=True)
         )
         stranger = User(username=CAROL_EMAIL, groups=frozenset())
         with pytest.raises(PermissionError):
-            await _initiative_service(stranger).patch_one({"slug": "svc-visible"}, InitiativePatch(name="hijack"))
+            await _initiative_service(stranger).update_one({"slug": "svc-visible"}, InitiativePatch(name="hijack"))
 
     async def test_missing_is_not_found(self, db):
         with pytest.raises(NotFoundError):
-            await _initiative_service(ADMIN).patch_one({"slug": "svc-patch-ghost"}, InitiativePatch(name="x"))
+            await _initiative_service(ADMIN).update_one({"slug": "svc-patch-ghost"}, InitiativePatch(name="x"))
 
     async def test_admin_can_patch_non_owned(self, db):
         await _insert_initiative("svc-admin-patch", ALICE)
-        patched = await _initiative_service(ADMIN).patch_one(
+        patched = await _initiative_service(ADMIN).update_one(
             {"slug": "svc-admin-patch"}, InitiativePatch(name="Admin Renamed")
         )
         assert patched.name == "Admin Renamed"
@@ -342,7 +342,7 @@ class TestInitiativeDelete:
         # dangling reference behind (round-trip: assign, delete, re-read from the DB).
         await _insert_project("del-refs-proj", owner=ALICE_EMAIL)
         init = await _insert_initiative("svc-del-refs", ALICE)
-        assigned = await _service(ALICE).patch_one({"id": "del-refs-proj"}, ProjectPatch(initiative="svc-del-refs"))
+        assigned = await _service(ALICE).update_one({"id": "del-refs-proj"}, ProjectPatch(initiative="svc-del-refs"))
         assert _assigned_id(assigned) == init.id
 
         await _initiative_service(ALICE).delete_one({"slug": "svc-del-refs"})
@@ -353,7 +353,7 @@ class TestInitiativeDelete:
 
 
 # ---------------------------------------------------------------------------
-# Read scope — get_many / get_one filter by visibility; out-of-scope writes 404
+# Read scope — read_many / read_one filter by visibility; out-of-scope writes 404
 # ---------------------------------------------------------------------------
 
 
@@ -363,9 +363,9 @@ class TestInitiativeReadScope:
         await _insert_initiative("scope-priv", ALICE)
         await _insert_initiative("scope-pub", ALICE)
         await _approve("scope-pub")
-        await _initiative_service(ADMIN).patch_one({"slug": "scope-pub"}, InitiativePatch(is_public=True))
+        await _initiative_service(ADMIN).update_one({"slug": "scope-pub"}, InitiativePatch(is_public=True))
         stranger = User(username=CAROL_EMAIL, groups=frozenset())
-        page = await _initiative_service(stranger).get_many(
+        page = await _initiative_service(stranger).read_many(
             filter=InitiativeFilter(), pagination=CursorParams(), fields=None
         )
         slugs = {i.slug for i in page.items}
@@ -375,11 +375,11 @@ class TestInitiativeReadScope:
     async def test_get_one_private_unowned_returns_none(self, db):
         await _insert_initiative("scope-one-priv", ALICE)
         stranger = User(username=CAROL_EMAIL, groups=frozenset())
-        assert await _initiative_service(stranger).get_one({"slug": "scope-one-priv"}, fields=None) is None
+        assert await _initiative_service(stranger).read_one({"slug": "scope-one-priv"}, fields=None) is None
 
     async def test_owner_sees_own_private_initiative(self, db):
         await _insert_initiative("scope-own", ALICE)
-        found = await _initiative_service(ALICE).get_one({"slug": "scope-own"}, fields=None)
+        found = await _initiative_service(ALICE).read_one({"slug": "scope-own"}, fields=None)
         assert found is not None and found.slug == "scope-own"
 
 
@@ -390,7 +390,7 @@ class TestInitiativeOutOfScopeWrites:
         await _insert_initiative("oos-patch", ALICE)
         stranger = User(username=CAROL_EMAIL, groups=frozenset())
         with pytest.raises(NotFoundError):
-            await _initiative_service(stranger).patch_one({"slug": "oos-patch"}, InitiativePatch(name="hijack"))
+            await _initiative_service(stranger).update_one({"slug": "oos-patch"}, InitiativePatch(name="hijack"))
 
     async def test_delete_private_unowned_is_not_found(self, db):
         await _insert_initiative("oos-del", ALICE)

--- a/mpcontribs-api/tests/integration/db/test_project_groups_repository.py
+++ b/mpcontribs-api/tests/integration/db/test_project_groups_repository.py
@@ -45,7 +45,8 @@ def _group_in(name: str, owner: str = ALICE_EMAIL, **overrides) -> ProjectGroupI
 
 
 async def _insert(name: str, owner: str = ALICE_EMAIL, **overrides) -> ProjectGroup:
-    return await _repo(ADMIN).insert_one(_group_in(name, owner, **overrides))
+    # Document-in repo: build the stored document here (the service's job), then hand it over.
+    return await _repo(ADMIN).insert_one(ProjectGroup.from_input_model(_group_in(name, owner, **overrides)))
 
 
 # ---------------------------------------------------------------------------

--- a/mpcontribs-api/tests/integration/db/test_project_groups_repository.py
+++ b/mpcontribs-api/tests/integration/db/test_project_groups_repository.py
@@ -8,7 +8,7 @@ from mpcontribs_api.domains.project_groups.models import (
     ProjectGroupIn,
     ProjectGroupPatch,
 )
-from mpcontribs_api.domains.project_groups.repository import ProjectGroupRepository
+from mpcontribs_api.domains.project_groups.repository import MongoDbProjectGroupRepository
 from mpcontribs_api.exceptions import ConflictError, NotFoundError, ValidationError
 from mpcontribs_api.pagination import CursorParams
 
@@ -29,8 +29,8 @@ ALICE_EMAIL = "google:alice@example.com"
 BOB_EMAIL = "google:bob@example.com"
 
 
-def _repo(user: User) -> ProjectGroupRepository:
-    return ProjectGroupRepository(user)
+def _repo(user: User) -> MongoDbProjectGroupRepository:
+    return MongoDbProjectGroupRepository(user)
 
 
 def _group_in(name: str, owner: str = ALICE_EMAIL, **overrides) -> ProjectGroupIn:

--- a/mpcontribs-api/tests/integration/db/test_project_groups_repository.py
+++ b/mpcontribs-api/tests/integration/db/test_project_groups_repository.py
@@ -9,7 +9,7 @@ from mpcontribs_api.domains.project_groups.models import (
     ProjectGroupPatch,
 )
 from mpcontribs_api.domains.project_groups.repository import ProjectGroupRepository
-from mpcontribs_api.exceptions import ConflictError, NotFoundError, PermissionError, ValidationError
+from mpcontribs_api.exceptions import ConflictError, NotFoundError, ValidationError
 from mpcontribs_api.pagination import CursorParams
 
 # Share the session event loop (see the projects repo test for why).
@@ -108,16 +108,9 @@ class TestGroupRoleScope:
         )
         assert group.id in {g.id for g in page.items}
 
-    async def test_role_grants_scope_but_not_delete(self, db):
-        # Scope makes the group visible, but deletion remains owner-or-admin (403 for a role holder).
-        group = await _insert("role-del")
-        with pytest.raises(PermissionError):
-            await _repo(_role_user(group.id)).delete_one({"name": "role-del", "owner": ALICE_EMAIL})
-        assert await ProjectGroup.find_one(ProjectGroup.name == "role-del") is not None
-
 
 # ---------------------------------------------------------------------------
-# delete_one  (identifier-keyed, single-resource, raises)
+# delete_one  (mechanical: scoped delete; the owner-or-admin gate lives in the service)
 # ---------------------------------------------------------------------------
 
 
@@ -139,18 +132,6 @@ class TestDeleteOne:
             await _repo(ANON).delete_one({"name": "del-scoped", "owner": ALICE_EMAIL})
         # ...and it is untouched.
         assert await ProjectGroup.find_one(ProjectGroup.name == "del-scoped") is not None
-
-    async def test_owner_can_delete_own(self, db):
-        await _insert("del-own", owner=ALICE_EMAIL)
-        result = await _repo(ALICE).delete_one({"name": "del-own", "owner": ALICE_EMAIL})
-        assert result.num_deleted == 1
-
-    async def test_visible_public_non_owner_forbidden(self, db):
-        # Bob can *see* Alice's public group but does not own it → 403, and it is left intact.
-        await _insert("del-pub", owner=ALICE_EMAIL, is_public=True)
-        with pytest.raises(PermissionError):
-            await _repo(BOB).delete_one({"name": "del-pub", "owner": ALICE_EMAIL})
-        assert await ProjectGroup.find_one(ProjectGroup.name == "del-pub") is not None
 
     async def test_wrong_identifier_keys_raise_validation(self, db):
         with pytest.raises(ValidationError):
@@ -174,7 +155,7 @@ class TestPatchOne:
 
 
 # ---------------------------------------------------------------------------
-# delete  (arbitrary-filter bulk)
+# delete_many  (mechanical, scoped bulk; the non-admin owner-forcing lives in the service)
 # ---------------------------------------------------------------------------
 
 
@@ -194,16 +175,6 @@ class TestDeleteByFilter:
             filter=ProjectGroupFilter(owner="google:nobody@example.com")
         )
         assert result.num_deleted == 0
-
-    async def test_non_admin_bulk_restricted_to_own(self, db):
-        # A broad filter from a non-admin is pinned to their own groups: a public group owned by
-        # someone else must survive even though the filter would otherwise match it.
-        await _insert("own-bulk", owner=ALICE_EMAIL, is_public=True)
-        await _insert("other-bulk", owner=BOB_EMAIL, is_public=True)
-        result = await _repo(ALICE).delete_many(filter=ProjectGroupFilter(is_public=True))
-        assert result.num_deleted == 1
-        assert await ProjectGroup.find_one(ProjectGroup.name == "own-bulk") is None
-        assert await ProjectGroup.find_one(ProjectGroup.name == "other-bulk") is not None
 
 
 # ---------------------------------------------------------------------------

--- a/mpcontribs-api/tests/integration/db/test_project_groups_repository.py
+++ b/mpcontribs-api/tests/integration/db/test_project_groups_repository.py
@@ -50,26 +50,26 @@ async def _insert(name: str, owner: str = ALICE_EMAIL, **overrides) -> ProjectGr
 
 
 # ---------------------------------------------------------------------------
-# get_one
+# read_one
 # ---------------------------------------------------------------------------
 
 
 class TestGetOne:
     async def test_returns_group_by_identifiers(self, db):
         await _insert("group-a")
-        found = await _repo(ADMIN).get_one({"name": "group-a", "owner": ALICE_EMAIL}, fields=None)
+        found = await _repo(ADMIN).read_one({"name": "group-a", "owner": ALICE_EMAIL}, fields=None)
         assert found is not None
         assert found.name == "group-a"
         assert found.owner == ALICE_EMAIL
 
     async def test_returns_none_when_absent(self, db):
-        found = await _repo(ADMIN).get_one({"name": "missing", "owner": ALICE_EMAIL}, fields=None)
+        found = await _repo(ADMIN).read_one({"name": "missing", "owner": ALICE_EMAIL}, fields=None)
         assert found is None
 
     async def test_out_of_scope_returns_none(self, db):
         # Alice's private group is invisible to an anonymous caller.
         await _insert("group-priv")
-        found = await _repo(ANON).get_one({"name": "group-priv", "owner": ALICE_EMAIL}, fields=None)
+        found = await _repo(ANON).read_one({"name": "group-priv", "owner": ALICE_EMAIL}, fields=None)
         assert found is None
 
 
@@ -86,25 +86,25 @@ def _role_user(group_id, username: str = "google:carol@example.com") -> User:
 class TestGroupRoleScope:
     async def test_role_grants_visibility(self, db):
         group = await _insert("role-vis")  # Alice's private group
-        found = await _repo(_role_user(group.id)).get_one({"name": "role-vis", "owner": ALICE_EMAIL}, fields=None)
+        found = await _repo(_role_user(group.id)).read_one({"name": "role-vis", "owner": ALICE_EMAIL}, fields=None)
         assert found is not None
         assert found.id == group.id
 
     async def test_without_role_not_visible(self, db):
         await _insert("role-none")
-        found = await _repo(BOB).get_one({"name": "role-none", "owner": ALICE_EMAIL}, fields=None)
+        found = await _repo(BOB).read_one({"name": "role-none", "owner": ALICE_EMAIL}, fields=None)
         assert found is None
 
     async def test_malformed_role_is_ignored(self, db):
         await _insert("role-bad")
         member = User(username="google:carol@example.com", groups=frozenset({"project-group:not-an-oid"}))
         # A malformed role id must not raise; it simply grants nothing.
-        found = await _repo(member).get_one({"name": "role-bad", "owner": ALICE_EMAIL}, fields=None)
+        found = await _repo(member).read_one({"name": "role-bad", "owner": ALICE_EMAIL}, fields=None)
         assert found is None
 
     async def test_role_appears_in_listing(self, db):
         group = await _insert("role-list")
-        page = await _repo(_role_user(group.id)).get_many(
+        page = await _repo(_role_user(group.id)).read_many(
             pagination=CursorParams(), filter=ProjectGroupFilter(), fields=None
         )
         assert group.id in {g.id for g in page.items}
@@ -140,19 +140,19 @@ class TestDeleteOne:
 
 
 # ---------------------------------------------------------------------------
-# patch_one
+# update_one
 # ---------------------------------------------------------------------------
 
 
 class TestPatchOne:
     async def test_updates_field(self, db):
         await _insert("patch-a", description="before")
-        updated = await _repo(ADMIN).patch_one({"name": "patch-a", "owner": ALICE_EMAIL}, ProjectGroupPatch(description="after"))
+        updated = await _repo(ADMIN).update_one({"name": "patch-a", "owner": ALICE_EMAIL}, ProjectGroupPatch(description="after"))
         assert updated.description == "after"
 
     async def test_absent_raises_not_found(self, db):
         with pytest.raises(NotFoundError):
-            await _repo(ADMIN).patch_one({"name": "ghost", "owner": ALICE_EMAIL}, ProjectGroupPatch(description="x"))
+            await _repo(ADMIN).update_one({"name": "ghost", "owner": ALICE_EMAIL}, ProjectGroupPatch(description="x"))
 
 
 # ---------------------------------------------------------------------------

--- a/mpcontribs-api/tests/integration/db/test_project_groups_service.py
+++ b/mpcontribs-api/tests/integration/db/test_project_groups_service.py
@@ -237,21 +237,21 @@ class TestBulkDeleteAuthorization:
 
 
 # ---------------------------------------------------------------------------
-# patch_one — owner-or-admin, mirroring delete_one
+# update_one — owner-or-admin, mirroring delete_one
 # ---------------------------------------------------------------------------
 
 
 class TestPatchAuthorization:
     async def test_owner_can_patch_own(self, db):
         await _insert_group("patch-own", owner=ALICE_EMAIL)
-        updated = await _service(ALICE).patch_one(
+        updated = await _service(ALICE).update_one(
             {"name": "patch-own", "owner": ALICE_EMAIL}, ProjectGroupPatch(description="by owner")
         )
         assert updated.description == "by owner"
 
     async def test_admin_can_patch_any(self, db):
         await _insert_group("patch-admin", owner=ALICE_EMAIL)
-        updated = await _service(ADMIN).patch_one(
+        updated = await _service(ADMIN).update_one(
             {"name": "patch-admin", "owner": ALICE_EMAIL}, ProjectGroupPatch(description="by admin")
         )
         assert updated.description == "by admin"
@@ -264,7 +264,7 @@ class TestPatchAuthorization:
             )
         )
         with pytest.raises(PermissionError):
-            await _service(BOB).patch_one(
+            await _service(BOB).update_one(
                 {"name": "patch-pub", "owner": ALICE_EMAIL}, ProjectGroupPatch(description="hijacked")
             )
         doc = await ProjectGroup.find_one(ProjectGroup.name == "patch-pub")
@@ -274,7 +274,7 @@ class TestPatchAuthorization:
         # A project-group role makes the group visible, but patching stays owner-or-admin (403).
         group = await _insert_group("patch-role", owner=ALICE_EMAIL)
         with pytest.raises(PermissionError):
-            await _service(_role_user(group.id)).patch_one(
+            await _service(_role_user(group.id)).update_one(
                 {"name": "patch-role", "owner": ALICE_EMAIL}, ProjectGroupPatch(description="hijacked")
             )
         doc = await ProjectGroup.find_one(ProjectGroup.name == "patch-role")
@@ -283,7 +283,7 @@ class TestPatchAuthorization:
     async def test_out_of_scope_is_not_found(self, db):
         await _insert_group("patch-hidden", owner=ALICE_EMAIL)
         with pytest.raises(NotFoundError):
-            await _service(ANON).patch_one(
+            await _service(ANON).update_one(
                 {"name": "patch-hidden", "owner": ALICE_EMAIL}, ProjectGroupPatch(description="hijacked")
             )
 

--- a/mpcontribs-api/tests/integration/db/test_project_groups_service.py
+++ b/mpcontribs-api/tests/integration/db/test_project_groups_service.py
@@ -3,7 +3,7 @@ from beanie import PydanticObjectId
 
 from mpcontribs_api.authz import User
 from mpcontribs_api.domains.project_groups.models import ProjectGroup, ProjectGroupFilter, ProjectGroupIn
-from mpcontribs_api.domains.project_groups.repository import ProjectGroupRepository
+from mpcontribs_api.domains.project_groups.repository import MongoDbProjectGroupRepository
 from mpcontribs_api.domains.project_groups.service import ProjectGroupService
 from mpcontribs_api.domains.projects.models import ProjectIn
 from mpcontribs_api.domains.projects.repository import MongoDbProjectRepository
@@ -26,7 +26,7 @@ BOB_EMAIL = "google:bob@example.com"
 
 
 def _service(user: User = ADMIN) -> ProjectGroupService:
-    return ProjectGroupService(user=user, groups=ProjectGroupRepository(user), projects=MongoDbProjectRepository(user))
+    return ProjectGroupService(user=user, groups=MongoDbProjectGroupRepository(user), projects=MongoDbProjectRepository(user))
 
 
 def _role_user(group_id, username: str = "google:carol@example.com") -> User:
@@ -46,7 +46,7 @@ async def _insert_project(pid: str, owner: str = ALICE_EMAIL, **overrides):
 
 
 async def _insert_group(name: str, owner: str = ALICE_EMAIL) -> ProjectGroup:
-    return await ProjectGroupRepository(ADMIN).insert_one(
+    return await MongoDbProjectGroupRepository(ADMIN).insert_one(
         ProjectGroupIn(name=name, owner=owner, projects=[], description="d")
     )
 
@@ -174,7 +174,7 @@ class TestDeleteAuthorization:
 
     async def test_visible_public_non_owner_forbidden(self, db):
         # Bob can *see* Alice's public group but does not own it → 403, and it is left intact.
-        await ProjectGroupRepository(ADMIN).insert_one(
+        await MongoDbProjectGroupRepository(ADMIN).insert_one(
             ProjectGroupIn(name="del-pub", owner=ALICE_EMAIL, projects=[], description="d", is_public=True)
         )
         with pytest.raises(PermissionError):
@@ -204,10 +204,10 @@ class TestBulkDeleteAuthorization:
     async def test_non_admin_bulk_restricted_to_own(self, db):
         # A broad filter from a non-admin is pinned to their own groups: a public group owned by
         # someone else must survive even though the filter would otherwise match it.
-        await ProjectGroupRepository(ADMIN).insert_one(
+        await MongoDbProjectGroupRepository(ADMIN).insert_one(
             ProjectGroupIn(name="own-bulk", owner=ALICE_EMAIL, projects=[], description="d", is_public=True)
         )
-        await ProjectGroupRepository(ADMIN).insert_one(
+        await MongoDbProjectGroupRepository(ADMIN).insert_one(
             ProjectGroupIn(name="other-bulk", owner=BOB_EMAIL, projects=[], description="d", is_public=True)
         )
         result = await _service(ALICE).delete_many(filter=ProjectGroupFilter(is_public=True))

--- a/mpcontribs-api/tests/integration/db/test_project_groups_service.py
+++ b/mpcontribs-api/tests/integration/db/test_project_groups_service.py
@@ -2,12 +2,12 @@ import pytest
 from beanie import PydanticObjectId
 
 from mpcontribs_api.authz import User
-from mpcontribs_api.domains.project_groups.models import ProjectGroup, ProjectGroupIn
+from mpcontribs_api.domains.project_groups.models import ProjectGroup, ProjectGroupFilter, ProjectGroupIn
 from mpcontribs_api.domains.project_groups.repository import ProjectGroupRepository
 from mpcontribs_api.domains.project_groups.service import ProjectGroupService
 from mpcontribs_api.domains.projects.models import ProjectIn
 from mpcontribs_api.domains.projects.repository import MongoDbProjectRepository
-from mpcontribs_api.exceptions import ConflictError, NotFoundError
+from mpcontribs_api.exceptions import ConflictError, NotFoundError, PermissionError
 
 pytestmark = [pytest.mark.db, pytest.mark.asyncio(loop_scope="session")]
 
@@ -18,6 +18,7 @@ pytestmark = [pytest.mark.db, pytest.mark.asyncio(loop_scope="session")]
 
 ADMIN = User(username="google:admin@example.com", groups=frozenset({"admin"}))
 ALICE = User(username="google:alice@example.com", groups=frozenset({"mp-team"}))
+BOB = User(username="google:bob@example.com", groups=frozenset())
 ANON = User()
 
 ALICE_EMAIL = "google:alice@example.com"
@@ -25,7 +26,12 @@ BOB_EMAIL = "google:bob@example.com"
 
 
 def _service(user: User = ADMIN) -> ProjectGroupService:
-    return ProjectGroupService(groups=ProjectGroupRepository(user), projects=MongoDbProjectRepository(user))
+    return ProjectGroupService(user=user, groups=ProjectGroupRepository(user), projects=MongoDbProjectRepository(user))
+
+
+def _role_user(group_id, username: str = "google:carol@example.com") -> User:
+    """A non-owner authenticated user granted access to one group via its project-group role."""
+    return User(username=username, groups=frozenset({f"project-group:{group_id}"}))
 
 
 async def _insert_project(pid: str, owner: str = ALICE_EMAIL, **overrides):
@@ -148,3 +154,71 @@ class TestDelete:
         assert summary.succeeded == []
         assert summary.failed[0].error_code == "not_found"
         assert await _members(group.id) == ["mp-1"]
+
+
+# ---------------------------------------------------------------------------
+# delete_one — owner-or-admin (403 vs 404)
+# ---------------------------------------------------------------------------
+
+
+class TestDeleteAuthorization:
+    async def test_owner_can_delete_own(self, db):
+        await _insert_group("del-own", owner=ALICE_EMAIL)
+        result = await _service(ALICE).delete_one({"name": "del-own", "owner": ALICE_EMAIL})
+        assert result.num_deleted == 1
+
+    async def test_admin_can_delete_any(self, db):
+        await _insert_group("del-admin", owner=ALICE_EMAIL)
+        result = await _service(ADMIN).delete_one({"name": "del-admin", "owner": ALICE_EMAIL})
+        assert result.num_deleted == 1
+
+    async def test_visible_public_non_owner_forbidden(self, db):
+        # Bob can *see* Alice's public group but does not own it → 403, and it is left intact.
+        await ProjectGroupRepository(ADMIN).insert_one(
+            ProjectGroupIn(name="del-pub", owner=ALICE_EMAIL, projects=[], description="d", is_public=True)
+        )
+        with pytest.raises(PermissionError):
+            await _service(BOB).delete_one({"name": "del-pub", "owner": ALICE_EMAIL})
+        assert await ProjectGroup.find_one(ProjectGroup.name == "del-pub") is not None
+
+    async def test_role_holder_can_see_but_not_delete(self, db):
+        # A project-group role makes the group visible, but deletion stays owner-or-admin (403).
+        group = await _insert_group("del-role", owner=ALICE_EMAIL)
+        with pytest.raises(PermissionError):
+            await _service(_role_user(group.id)).delete_one({"name": "del-role", "owner": ALICE_EMAIL})
+        assert await ProjectGroup.find_one(ProjectGroup.name == "del-role") is not None
+
+    async def test_out_of_scope_is_not_found(self, db):
+        await _insert_group("del-hidden", owner=ALICE_EMAIL)
+        with pytest.raises(NotFoundError):
+            await _service(ANON).delete_one({"name": "del-hidden", "owner": ALICE_EMAIL})
+        assert await ProjectGroup.find_one(ProjectGroup.name == "del-hidden") is not None
+
+
+# ---------------------------------------------------------------------------
+# delete_many — non-admin restricted to own
+# ---------------------------------------------------------------------------
+
+
+class TestBulkDeleteAuthorization:
+    async def test_non_admin_bulk_restricted_to_own(self, db):
+        # A broad filter from a non-admin is pinned to their own groups: a public group owned by
+        # someone else must survive even though the filter would otherwise match it.
+        await ProjectGroupRepository(ADMIN).insert_one(
+            ProjectGroupIn(name="own-bulk", owner=ALICE_EMAIL, projects=[], description="d", is_public=True)
+        )
+        await ProjectGroupRepository(ADMIN).insert_one(
+            ProjectGroupIn(name="other-bulk", owner=BOB_EMAIL, projects=[], description="d", is_public=True)
+        )
+        result = await _service(ALICE).delete_many(filter=ProjectGroupFilter(is_public=True))
+        assert result.num_deleted == 1
+        assert await ProjectGroup.find_one(ProjectGroup.name == "own-bulk") is None
+        assert await ProjectGroup.find_one(ProjectGroup.name == "other-bulk") is not None
+
+    async def test_admin_bulk_deletes_all_matching(self, db):
+        await _insert_group("abulk-1", owner=ALICE_EMAIL)
+        await _insert_group("abulk-2", owner=ALICE_EMAIL)
+        await _insert_group("abulk-bob", owner=BOB_EMAIL)
+        result = await _service(ADMIN).delete_many(filter=ProjectGroupFilter(owner=ALICE_EMAIL))
+        assert result.num_deleted == 2
+        assert await ProjectGroup.find_one(ProjectGroup.owner == BOB_EMAIL) is not None

--- a/mpcontribs-api/tests/integration/db/test_project_groups_service.py
+++ b/mpcontribs-api/tests/integration/db/test_project_groups_service.py
@@ -5,7 +5,7 @@ from mpcontribs_api.authz import User
 from mpcontribs_api.domains.project_groups.models import ProjectGroup, ProjectGroupFilter, ProjectGroupIn
 from mpcontribs_api.domains.project_groups.repository import MongoDbProjectGroupRepository
 from mpcontribs_api.domains.project_groups.service import ProjectGroupService
-from mpcontribs_api.domains.projects.models import ProjectIn
+from mpcontribs_api.domains.projects.models import Project, ProjectIn
 from mpcontribs_api.domains.projects.repository import MongoDbProjectRepository
 from mpcontribs_api.exceptions import ConflictError, NotFoundError, PermissionError
 
@@ -42,12 +42,13 @@ async def _insert_project(pid: str, owner: str = ALICE_EMAIL, **overrides):
         "owner": owner,
     }
     payload.update(overrides)
-    return await MongoDbProjectRepository(ADMIN).insert_one(pid, ProjectIn(**payload))
+    document = Project.from_input_model(ProjectIn(**payload), id=pid)
+    return await MongoDbProjectRepository(ADMIN).insert_one(document)
 
 
 async def _insert_group(name: str, owner: str = ALICE_EMAIL) -> ProjectGroup:
     return await MongoDbProjectGroupRepository(ADMIN).insert_one(
-        ProjectGroupIn(name=name, owner=owner, projects=[], description="d")
+        ProjectGroup.from_input_model(ProjectGroupIn(name=name, owner=owner, projects=[], description="d"))
     )
 
 
@@ -116,13 +117,13 @@ class TestAdd:
 class TestInsert:
     async def test_non_admin_owner_forced_to_caller(self, db):
         # Alice submits Bob as owner; the caller's identity must win so she can manage the group.
-        group = await _service(ALICE).insert(
+        group = await _service(ALICE).insert_one(
             ProjectGroupIn(name="ins-forced", owner=BOB_EMAIL, projects=[], description="d")
         )
         assert group.owner == ALICE_EMAIL
 
     async def test_admin_may_set_owner_on_behalf(self, db):
-        group = await _service(ADMIN).insert(
+        group = await _service(ADMIN).insert_one(
             ProjectGroupIn(name="ins-onbehalf", owner=BOB_EMAIL, projects=[], description="d")
         )
         assert group.owner == BOB_EMAIL
@@ -175,7 +176,9 @@ class TestDeleteAuthorization:
     async def test_visible_public_non_owner_forbidden(self, db):
         # Bob can *see* Alice's public group but does not own it → 403, and it is left intact.
         await MongoDbProjectGroupRepository(ADMIN).insert_one(
-            ProjectGroupIn(name="del-pub", owner=ALICE_EMAIL, projects=[], description="d", is_public=True)
+            ProjectGroup.from_input_model(
+                ProjectGroupIn(name="del-pub", owner=ALICE_EMAIL, projects=[], description="d", is_public=True)
+            )
         )
         with pytest.raises(PermissionError):
             await _service(BOB).delete_one({"name": "del-pub", "owner": ALICE_EMAIL})
@@ -205,10 +208,14 @@ class TestBulkDeleteAuthorization:
         # A broad filter from a non-admin is pinned to their own groups: a public group owned by
         # someone else must survive even though the filter would otherwise match it.
         await MongoDbProjectGroupRepository(ADMIN).insert_one(
-            ProjectGroupIn(name="own-bulk", owner=ALICE_EMAIL, projects=[], description="d", is_public=True)
+            ProjectGroup.from_input_model(
+                ProjectGroupIn(name="own-bulk", owner=ALICE_EMAIL, projects=[], description="d", is_public=True)
+            )
         )
         await MongoDbProjectGroupRepository(ADMIN).insert_one(
-            ProjectGroupIn(name="other-bulk", owner=BOB_EMAIL, projects=[], description="d", is_public=True)
+            ProjectGroup.from_input_model(
+                ProjectGroupIn(name="other-bulk", owner=BOB_EMAIL, projects=[], description="d", is_public=True)
+            )
         )
         result = await _service(ALICE).delete_many(filter=ProjectGroupFilter(is_public=True))
         assert result.num_deleted == 1

--- a/mpcontribs-api/tests/integration/db/test_project_groups_service.py
+++ b/mpcontribs-api/tests/integration/db/test_project_groups_service.py
@@ -286,3 +286,61 @@ class TestPatchAuthorization:
             await _service(ANON).patch_one(
                 {"name": "patch-hidden", "owner": ALICE_EMAIL}, ProjectGroupPatch(description="hijacked")
             )
+
+
+# ---------------------------------------------------------------------------
+# Membership (add/remove projects) — owner-or-admin, mirroring patch/delete
+# ---------------------------------------------------------------------------
+
+
+async def _insert_public_group(name: str, owner: str = ALICE_EMAIL) -> ProjectGroup:
+    return await MongoDbProjectGroupRepository(ADMIN).insert_one(
+        ProjectGroup.from_input_model(
+            ProjectGroupIn(name=name, owner=owner, projects=[], description="d", is_public=True)
+        )
+    )
+
+
+class TestMembershipAuthorization:
+    async def test_owner_can_add_projects(self, db):
+        group = await _insert_group("mem-own")
+        await _insert_project("mem-p1")
+        summary = await _service(ALICE).add_projects({"id": str(group.id)}, ["mem-p1"])
+        assert summary.succeeded == ["mem-p1"]
+        assert await _members(group.id) == ["mem-p1"]
+
+    async def test_admin_can_add_projects(self, db):
+        group = await _insert_group("mem-admin")
+        await _insert_project("mem-p2")
+        summary = await _service(ADMIN).add_projects({"id": str(group.id)}, ["mem-p2"])
+        assert summary.succeeded == ["mem-p2"]
+
+    async def test_visible_public_non_owner_cannot_add(self, db):
+        # Bob can see Alice's public group but does not own it → 403, membership untouched.
+        group = await _insert_public_group("mem-pub-add")
+        await _insert_project("mem-p3")
+        with pytest.raises(PermissionError):
+            await _service(BOB).add_projects({"id": str(group.id)}, ["mem-p3"])
+        assert await _members(group.id) == []
+
+    async def test_role_holder_cannot_add(self, db):
+        # A project-group role grants visibility, but membership management stays owner-or-admin.
+        group = await _insert_group("mem-role-add")
+        await _insert_project("mem-p4")
+        with pytest.raises(PermissionError):
+            await _service(_role_user(group.id)).add_projects({"id": str(group.id)}, ["mem-p4"])
+        assert await _members(group.id) == []
+
+    async def test_visible_public_non_owner_cannot_delete(self, db):
+        group = await _insert_public_group("mem-pub-del")
+        await _insert_project("mem-p5")
+        await _service(ADMIN).add_projects({"id": str(group.id)}, ["mem-p5"])
+        with pytest.raises(PermissionError):
+            await _service(BOB).delete_projects({"id": str(group.id)}, ["mem-p5"])
+        assert await _members(group.id) == ["mem-p5"]
+
+    async def test_out_of_scope_add_is_not_found(self, db):
+        # Anon cannot see Alice's private group → 404 (existence not leaked as a 403).
+        group = await _insert_group("mem-hidden")
+        with pytest.raises(NotFoundError):
+            await _service(ANON).add_projects({"id": str(group.id)}, ["mem-p6"])

--- a/mpcontribs-api/tests/integration/db/test_project_groups_service.py
+++ b/mpcontribs-api/tests/integration/db/test_project_groups_service.py
@@ -2,7 +2,12 @@ import pytest
 from beanie import PydanticObjectId
 
 from mpcontribs_api.authz import User
-from mpcontribs_api.domains.project_groups.models import ProjectGroup, ProjectGroupFilter, ProjectGroupIn
+from mpcontribs_api.domains.project_groups.models import (
+    ProjectGroup,
+    ProjectGroupFilter,
+    ProjectGroupIn,
+    ProjectGroupPatch,
+)
 from mpcontribs_api.domains.project_groups.repository import MongoDbProjectGroupRepository
 from mpcontribs_api.domains.project_groups.service import ProjectGroupService
 from mpcontribs_api.domains.projects.models import Project, ProjectIn
@@ -229,3 +234,55 @@ class TestBulkDeleteAuthorization:
         result = await _service(ADMIN).delete_many(filter=ProjectGroupFilter(owner=ALICE_EMAIL))
         assert result.num_deleted == 2
         assert await ProjectGroup.find_one(ProjectGroup.owner == BOB_EMAIL) is not None
+
+
+# ---------------------------------------------------------------------------
+# patch_one — owner-or-admin, mirroring delete_one
+# ---------------------------------------------------------------------------
+
+
+class TestPatchAuthorization:
+    async def test_owner_can_patch_own(self, db):
+        await _insert_group("patch-own", owner=ALICE_EMAIL)
+        updated = await _service(ALICE).patch_one(
+            {"name": "patch-own", "owner": ALICE_EMAIL}, ProjectGroupPatch(description="by owner")
+        )
+        assert updated.description == "by owner"
+
+    async def test_admin_can_patch_any(self, db):
+        await _insert_group("patch-admin", owner=ALICE_EMAIL)
+        updated = await _service(ADMIN).patch_one(
+            {"name": "patch-admin", "owner": ALICE_EMAIL}, ProjectGroupPatch(description="by admin")
+        )
+        assert updated.description == "by admin"
+
+    async def test_visible_public_non_owner_forbidden(self, db):
+        # Bob can *see* Alice's public group but does not own it → 403, and it is left unchanged.
+        await MongoDbProjectGroupRepository(ADMIN).insert_one(
+            ProjectGroup.from_input_model(
+                ProjectGroupIn(name="patch-pub", owner=ALICE_EMAIL, projects=[], description="d", is_public=True)
+            )
+        )
+        with pytest.raises(PermissionError):
+            await _service(BOB).patch_one(
+                {"name": "patch-pub", "owner": ALICE_EMAIL}, ProjectGroupPatch(description="hijacked")
+            )
+        doc = await ProjectGroup.find_one(ProjectGroup.name == "patch-pub")
+        assert doc is not None and doc.description == "d"
+
+    async def test_role_holder_can_see_but_not_patch(self, db):
+        # A project-group role makes the group visible, but patching stays owner-or-admin (403).
+        group = await _insert_group("patch-role", owner=ALICE_EMAIL)
+        with pytest.raises(PermissionError):
+            await _service(_role_user(group.id)).patch_one(
+                {"name": "patch-role", "owner": ALICE_EMAIL}, ProjectGroupPatch(description="hijacked")
+            )
+        doc = await ProjectGroup.find_one(ProjectGroup.name == "patch-role")
+        assert doc is not None and doc.description == "d"
+
+    async def test_out_of_scope_is_not_found(self, db):
+        await _insert_group("patch-hidden", owner=ALICE_EMAIL)
+        with pytest.raises(NotFoundError):
+            await _service(ANON).patch_one(
+                {"name": "patch-hidden", "owner": ALICE_EMAIL}, ProjectGroupPatch(description="hijacked")
+            )

--- a/mpcontribs-api/tests/integration/db/test_projects_repository.py
+++ b/mpcontribs-api/tests/integration/db/test_projects_repository.py
@@ -95,7 +95,7 @@ class TestAuthorizationScope:
     async def test_admin_sees_all(self, db):
         await _insert("scope-priv", is_public=False)
         await _insert("scope-pub", is_public=True, is_approved=True)
-        page = await _repo(ADMIN).get_many(filter=_noop_filter(), pagination=CursorParams(), fields=None)
+        page = await _repo(ADMIN).read_many(filter=_noop_filter(), pagination=CursorParams(), fields=None)
         ids = {p.id for p in page.items}
         assert "scope-priv" in ids
         assert "scope-pub" in ids
@@ -104,7 +104,7 @@ class TestAuthorizationScope:
         await _insert("anon-priv", is_public=False)
         await _insert("anon-pub", is_public=True, is_approved=True)
         await _insert("anon-pub-unapproved", is_public=True, is_approved=False)
-        page = await _repo(ANON).get_many(filter=_noop_filter(), pagination=CursorParams(), fields=None)
+        page = await _repo(ANON).read_many(filter=_noop_filter(), pagination=CursorParams(), fields=None)
         ids = {p.id for p in page.items}
         assert "anon-pub" in ids
         assert "anon-priv" not in ids
@@ -114,7 +114,7 @@ class TestAuthorizationScope:
         await _insert("auth-alice-priv", owner=ALICE_EMAIL, is_public=False)
         await _insert("auth-bob-priv", owner=BOB_EMAIL, is_public=False)
         await _insert("auth-pub", is_public=True, is_approved=True)
-        page = await _repo(ALICE).get_many(filter=_noop_filter(), pagination=CursorParams(), fields=None)
+        page = await _repo(ALICE).read_many(filter=_noop_filter(), pagination=CursorParams(), fields=None)
         ids = {p.id for p in page.items}
         assert "auth-alice-priv" in ids
         assert "auth-pub" in ids
@@ -124,44 +124,44 @@ class TestAuthorizationScope:
         # A bare project role (the project id) grants visibility of an otherwise-private project.
         member = User(username="google:carol@example.com", groups=frozenset({"scope-granted"}))
         await _insert("scope-granted", owner=ALICE_EMAIL, is_public=False)
-        page = await _repo(member).get_many(filter=_noop_filter(), pagination=CursorParams(), fields=None)
+        page = await _repo(member).read_many(filter=_noop_filter(), pagination=CursorParams(), fields=None)
         assert "scope-granted" in {p.id for p in page.items}
 
 
 # ---------------------------------------------------------------------------
-# get_one
+# read_one
 # ---------------------------------------------------------------------------
 
 
 class TestGetProjectById:
     async def test_returns_project_for_valid_id(self, db):
         await _insert("get-by-id")
-        result = await _repo(ADMIN).get_one({"id": "get-by-id"}, fields=None)
+        result = await _repo(ADMIN).read_one({"id": "get-by-id"}, fields=None)
         assert result is not None
         assert result.id == "get-by-id"
 
     async def test_returns_none_for_missing_id(self, db):
-        result = await _repo(ADMIN).get_one({"id": "does-not-exist"}, fields=None)
+        result = await _repo(ADMIN).read_one({"id": "does-not-exist"}, fields=None)
         assert result is None
 
     async def test_admin_can_get_private_project(self, db):
         await _insert("get-priv", is_public=False)
-        result = await _repo(ADMIN).get_one({"id": "get-priv"}, fields=None)
+        result = await _repo(ADMIN).read_one({"id": "get-priv"}, fields=None)
         assert result is not None
 
     async def test_anon_cannot_get_private_project(self, db):
         await _insert("get-priv-anon", is_public=False)
-        result = await _repo(ANON).get_one({"id": "get-priv-anon"}, fields=None)
+        result = await _repo(ANON).read_one({"id": "get-priv-anon"}, fields=None)
         assert result is None
 
 
 # ---------------------------------------------------------------------------
-# get_many — id filtering
+# read_many — id filtering
 #
 # Regression: Beanie stores the primary key under Mongo's ``_id`` (``id`` is an
 # alias), but fastapi-filter keys queries on the raw field name. Without the
 # ``id`` -> ``_id`` remap in BaseFilter these filters matched nothing even
-# though get_one (which queries ``_id`` directly) found the document.
+# though read_one (which queries ``_id`` directly) found the document.
 # ---------------------------------------------------------------------------
 
 
@@ -170,7 +170,7 @@ class TestGetProjectsIdFilter:
         from mpcontribs_api.domains.projects.models import ProjectFilter
 
         await _insert("filter-id-hit")
-        page = await _repo(ADMIN).get_many(
+        page = await _repo(ADMIN).read_many(
             filter=ProjectFilter(id="filter-id-hit"), pagination=CursorParams(), fields=None
         )
         assert {p.id for p in page.items} == {"filter-id-hit"}
@@ -181,7 +181,7 @@ class TestGetProjectsIdFilter:
         await _insert("filter-id-in-a")
         await _insert("filter-id-in-b")
         await _insert("filter-id-in-c")
-        page = await _repo(ADMIN).get_many(
+        page = await _repo(ADMIN).read_many(
             filter=ProjectFilter(id__in=["filter-id-in-a", "filter-id-in-b"]),
             pagination=CursorParams(),
             fields=None,
@@ -193,7 +193,7 @@ class TestGetProjectsIdFilter:
 
         await _insert("filter-id-neq-keep")
         await _insert("filter-id-neq-drop")
-        page = await _repo(ADMIN).get_many(
+        page = await _repo(ADMIN).read_many(
             filter=ProjectFilter(id__neq="filter-id-neq-drop"), pagination=CursorParams(), fields=None
         )
         ids = {p.id for p in page.items}
@@ -202,7 +202,7 @@ class TestGetProjectsIdFilter:
 
 
 # ---------------------------------------------------------------------------
-# get_many — tags filtering
+# read_many — tags filtering
 #
 # ``tags__contains`` maps to MongoDB ``$all``: a project matches only when its
 # tags are a superset of every value supplied (the query list is a subset of
@@ -218,7 +218,7 @@ class TestGetProjectsTagsFilter:
         await _insert("tags-superset", tags=["alpha", "beta", "gamma"])
         await _insert("tags-partial", tags=["alpha", "beta"])
         await _insert("tags-none", tags=["delta"])
-        page = await _repo(ADMIN).get_many(
+        page = await _repo(ADMIN).read_many(
             filter=ProjectFilter(tags__contains=["alpha", "gamma"]),
             pagination=CursorParams(),
             fields=None,
@@ -230,7 +230,7 @@ class TestGetProjectsTagsFilter:
 
         await _insert("tags-single-hit", tags=["alpha", "beta"])
         await _insert("tags-single-miss", tags=["beta", "gamma"])
-        page = await _repo(ADMIN).get_many(
+        page = await _repo(ADMIN).read_many(
             filter=ProjectFilter(tags__contains=["alpha"]),
             pagination=CursorParams(),
             fields=None,
@@ -244,7 +244,7 @@ class TestGetProjectsTagsFilter:
         await _insert("tags-csv-miss", tags=["alpha"])
         # FilterDepends collapses the list query param to a comma string; the
         # BaseFilter validator must re-expand it.
-        page = await _repo(ADMIN).get_many(
+        page = await _repo(ADMIN).read_many(
             filter=ProjectFilter(tags__contains="alpha,beta"),
             pagination=CursorParams(),
             fields=None,
@@ -261,7 +261,7 @@ class TestFieldProjection:
     async def test_projection_returns_only_requested_fields(self, db):
         await _insert("proj-fields", is_public=True, is_approved=True)
         fields = ProjectOut.parse_fields(["title"])
-        page = await _repo(ADMIN).get_many(filter=_noop_filter(), pagination=CursorParams(), fields=fields)
+        page = await _repo(ADMIN).read_many(filter=_noop_filter(), pagination=CursorParams(), fields=fields)
         assert len(page.items) == 1
         item = page.items[0]
         assert item.title == "proj-fields"
@@ -270,7 +270,7 @@ class TestFieldProjection:
 
     async def test_no_projection_returns_all_fields(self, db):
         await _insert("proj-all", is_public=True, is_approved=True)
-        page = await _repo(ADMIN).get_many(filter=_noop_filter(), pagination=CursorParams(), fields=None)
+        page = await _repo(ADMIN).read_many(filter=_noop_filter(), pagination=CursorParams(), fields=None)
         item = page.items[0]
         assert item.title is not None
         assert item.authors is not None
@@ -285,27 +285,27 @@ class TestPagination:
     async def test_limit_is_respected(self, db):
         for i in range(5):
             await _insert(f"pag-limit-{i:02d}", is_public=True, is_approved=True)
-        page = await _repo(ADMIN).get_many(filter=_noop_filter(), pagination=CursorParams(limit=3), fields=None)
+        page = await _repo(ADMIN).read_many(filter=_noop_filter(), pagination=CursorParams(limit=3), fields=None)
         assert len(page.items) == 3
 
     async def test_next_cursor_set_when_more_items(self, db):
         for i in range(4):
             await _insert(f"pag-cursor-{i:02d}", is_public=True, is_approved=True)
-        page = await _repo(ADMIN).get_many(filter=_noop_filter(), pagination=CursorParams(limit=2), fields=None)
+        page = await _repo(ADMIN).read_many(filter=_noop_filter(), pagination=CursorParams(limit=2), fields=None)
         assert page.next_cursor is not None
 
     async def test_next_cursor_none_on_last_page(self, db):
         for i in range(3):
             await _insert(f"pag-last-{i:02d}", is_public=True, is_approved=True)
-        page = await _repo(ADMIN).get_many(filter=_noop_filter(), pagination=CursorParams(limit=10), fields=None)
+        page = await _repo(ADMIN).read_many(filter=_noop_filter(), pagination=CursorParams(limit=10), fields=None)
         assert page.next_cursor is None
 
     async def test_cursor_fetches_next_page(self, db):
         for i in range(4):
             await _insert(f"pag-next-{i:02d}", is_public=True, is_approved=True)
-        page1 = await _repo(ADMIN).get_many(filter=_noop_filter(), pagination=CursorParams(limit=2), fields=None)
+        page1 = await _repo(ADMIN).read_many(filter=_noop_filter(), pagination=CursorParams(limit=2), fields=None)
         assert page1.next_cursor is not None
-        page2 = await _repo(ADMIN).get_many(
+        page2 = await _repo(ADMIN).read_many(
             filter=_noop_filter(), pagination=CursorParams(limit=2, cursor=page1.next_cursor), fields=None
         )
         ids1 = {p.id for p in page1.items}
@@ -318,7 +318,7 @@ class TestPagination:
         all_ids: set[str] = set()
         cursor = None
         while True:
-            page = await _repo(ADMIN).get_many(
+            page = await _repo(ADMIN).read_many(
                 filter=_noop_filter(), pagination=CursorParams(limit=2, cursor=cursor), fields=None
             )
             all_ids.update(p.id for p in page.items)
@@ -329,31 +329,31 @@ class TestPagination:
 
 
 # ---------------------------------------------------------------------------
-# patch_one  (base mechanics: scoped $set; policy lives in the service)
+# update_one  (base mechanics: scoped $set; policy lives in the service)
 # ---------------------------------------------------------------------------
 
 
 class TestPatchProject:
     async def test_updates_single_field(self, db):
         await _insert("patch-me")
-        await _repo(ADMIN).patch_one({"id": "patch-me"}, ProjectPatch(title="Updated Title"))
+        await _repo(ADMIN).update_one({"id": "patch-me"}, ProjectPatch(title="Updated Title"))
         found = await Project.find_one(Project.id == "patch-me")
         assert found.title == "Updated Title"
 
     async def test_unset_fields_not_overwritten(self, db):
         await _insert("patch-preserve")
         original = await Project.find_one(Project.id == "patch-preserve")
-        await _repo(ADMIN).patch_one({"id": "patch-preserve"}, ProjectPatch(title="New Title"))
+        await _repo(ADMIN).update_one({"id": "patch-preserve"}, ProjectPatch(title="New Title"))
         found = await Project.find_one(Project.id == "patch-preserve")
         assert found.authors == original.authors
 
     async def test_not_found_raises(self, db):
         with pytest.raises(NotFoundError):
-            await _repo(ADMIN).patch_one({"id": "no-such-id"}, ProjectPatch(title="Won't work"))
+            await _repo(ADMIN).update_one({"id": "no-such-id"}, ProjectPatch(title="Won't work"))
 
     async def test_empty_patch_returns_existing(self, db):
         await _insert("patch-empty")
-        result = await _repo(ADMIN).patch_one({"id": "patch-empty"}, ProjectPatch())
+        result = await _repo(ADMIN).update_one({"id": "patch-empty"}, ProjectPatch())
         assert result.id == "patch-empty"
 
 
@@ -366,7 +366,7 @@ class TestDeleteProject:
     async def test_deleted_project_not_in_default_query(self, db):
         await _insert("del-me", is_public=True, is_approved=True)
         await _repo(ADMIN).delete_one({"id": "del-me"})
-        page = await _repo(ADMIN).get_many(filter=_noop_filter(), pagination=CursorParams(), fields=None)
+        page = await _repo(ADMIN).read_many(filter=_noop_filter(), pagination=CursorParams(), fields=None)
         assert "del-me" not in {p.id for p in page.items}
 
     async def test_delete_nonexistent_throws_error(self, db):

--- a/mpcontribs-api/tests/integration/db/test_projects_repository.py
+++ b/mpcontribs-api/tests/integration/db/test_projects_repository.py
@@ -1,11 +1,9 @@
 import pytest
 
 from mpcontribs_api.authz import User
-from mpcontribs_api.domains.projects.models import Column, Project, ProjectIn, ProjectOut, ProjectPatch, Stats
-from mpcontribs_api.domains.consumers.models import ConsumerSettings
+from mpcontribs_api.domains.projects.models import Project, ProjectIn, ProjectOut, ProjectPatch
 from mpcontribs_api.domains.projects.repository import MongoDbProjectRepository
-from mpcontribs_api.exceptions import ConflictError, NotFoundError, PermissionError, ValidationError
-from mpcontribs_api.exceptions import PermissionError as AppPermissionError
+from mpcontribs_api.exceptions import ConflictError, NotFoundError
 from mpcontribs_api.pagination import CursorParams
 
 # All tests in this module share the session event loop so they can reuse the
@@ -20,16 +18,15 @@ pytestmark = [pytest.mark.db, pytest.mark.asyncio(loop_scope="session")]
 
 ADMIN = User(username="google:admin@example.com", groups=frozenset({"admin"}))
 ALICE = User(username="google:alice@example.com", groups=frozenset({"mp-team"}))
+BOB = User(username="google:bob@example.com", groups=frozenset())
 ANON = User()
 
+ALICE_EMAIL = "google:alice@example.com"
+BOB_EMAIL = "google:bob@example.com"
 
-def _repo(user: User, limits: ConsumerSettings | None = None) -> MongoDbProjectRepository:
-    return MongoDbProjectRepository(user, limits)
 
-
-def _cols(n: int) -> list[dict[str, str]]:
-    """n column definitions (coerced into Column by ProjectIn/ProjectPatch)."""
-    return [{"path": f"data.col_{i}"} for i in range(n)]
+def _repo(user: User) -> MongoDbProjectRepository:
+    return MongoDbProjectRepository(user)
 
 
 def _project_in(id: str, **overrides) -> ProjectIn:
@@ -38,24 +35,25 @@ def _project_in(id: str, **overrides) -> ProjectIn:
         "title": id[:30],
         "authors": "Test Author",
         "description": "Test description",
-        "owner": "google:alice@example.com",
+        "owner": ALICE_EMAIL,
     }
     defaults.update(overrides)
     return ProjectIn(**defaults)
 
 
 async def _insert(id: str, **overrides) -> Project:
-    """Seed a project via the repository's insert path.
+    """Seed a project via the repository's mechanical insert path (admin, no policy)."""
+    return await _repo(ADMIN).insert_one(id, _project_in(id, **overrides))
 
-    ``ProjectIn`` carries ``is_public`` / ``is_approved`` (the scope tests seed specific states
-    through overrides); the id comes from the path, and stats/columns keep their server defaults.
-    """
-    project_in = _project_in(id, **overrides)
-    return await _repo(ADMIN).insert_one(id, project_in)
+
+def _noop_filter():
+    from mpcontribs_api.domains.projects.models import ProjectFilter
+
+    return ProjectFilter()
 
 
 # ---------------------------------------------------------------------------
-# insert_one
+# insert_one  (mechanical: id-stamp + dup-reject, no policy)
 # ---------------------------------------------------------------------------
 
 
@@ -80,7 +78,7 @@ class TestInsertProject:
 
 
 # ---------------------------------------------------------------------------
-# Authorization scoping  (_build_scope)
+# Authorization scoping  (read visibility via ReadScope)
 # ---------------------------------------------------------------------------
 
 
@@ -104,8 +102,8 @@ class TestAuthorizationScope:
         assert "anon-pub-unapproved" not in ids
 
     async def test_authenticated_sees_own_and_public(self, db):
-        await _insert("auth-alice-priv", owner="google:alice@example.com", is_public=False)
-        await _insert("auth-bob-priv", owner="google:bob@example.com", is_public=False)
+        await _insert("auth-alice-priv", owner=ALICE_EMAIL, is_public=False)
+        await _insert("auth-bob-priv", owner=BOB_EMAIL, is_public=False)
         await _insert("auth-pub", is_public=True, is_approved=True)
         page = await _repo(ALICE).get_many(filter=_noop_filter(), pagination=CursorParams(), fields=None)
         ids = {p.id for p in page.items}
@@ -113,11 +111,12 @@ class TestAuthorizationScope:
         assert "auth-pub" in ids
         assert "auth-bob-priv" not in ids
 
-
-def _noop_filter():
-    from mpcontribs_api.domains.projects.models import ProjectFilter
-
-    return ProjectFilter()
+    async def test_group_member_sees_granted_private_project(self, db):
+        # A bare project role (the project id) grants visibility of an otherwise-private project.
+        member = User(username="google:carol@example.com", groups=frozenset({"scope-granted"}))
+        await _insert("scope-granted", owner=ALICE_EMAIL, is_public=False)
+        page = await _repo(member).get_many(filter=_noop_filter(), pagination=CursorParams(), fields=None)
+        assert "scope-granted" in {p.id for p in page.items}
 
 
 # ---------------------------------------------------------------------------
@@ -275,28 +274,26 @@ class TestFieldProjection:
 
 class TestPagination:
     async def test_limit_is_respected(self, db):
-        # Distinct owners: pagination is orthogonal to the per-owner project cap, so keep every
-        # project under its own owner rather than tripping max_projects.
         for i in range(5):
-            await _insert(f"pag-limit-{i:02d}", owner=f"google:pager{i}@example.com", is_public=True, is_approved=True)
+            await _insert(f"pag-limit-{i:02d}", is_public=True, is_approved=True)
         page = await _repo(ADMIN).get_many(filter=_noop_filter(), pagination=CursorParams(limit=3), fields=None)
         assert len(page.items) == 3
 
     async def test_next_cursor_set_when_more_items(self, db):
         for i in range(4):
-            await _insert(f"pag-cursor-{i:02d}", owner=f"google:pager{i}@example.com", is_public=True, is_approved=True)
+            await _insert(f"pag-cursor-{i:02d}", is_public=True, is_approved=True)
         page = await _repo(ADMIN).get_many(filter=_noop_filter(), pagination=CursorParams(limit=2), fields=None)
         assert page.next_cursor is not None
 
     async def test_next_cursor_none_on_last_page(self, db):
         for i in range(3):
-            await _insert(f"pag-last-{i:02d}", owner=f"google:pager{i}@example.com", is_public=True, is_approved=True)
+            await _insert(f"pag-last-{i:02d}", is_public=True, is_approved=True)
         page = await _repo(ADMIN).get_many(filter=_noop_filter(), pagination=CursorParams(limit=10), fields=None)
         assert page.next_cursor is None
 
     async def test_cursor_fetches_next_page(self, db):
         for i in range(4):
-            await _insert(f"pag-next-{i:02d}", owner=f"google:pager{i}@example.com", is_public=True, is_approved=True)
+            await _insert(f"pag-next-{i:02d}", is_public=True, is_approved=True)
         page1 = await _repo(ADMIN).get_many(filter=_noop_filter(), pagination=CursorParams(limit=2), fields=None)
         assert page1.next_cursor is not None
         page2 = await _repo(ADMIN).get_many(
@@ -308,7 +305,7 @@ class TestPagination:
 
     async def test_all_items_covered_across_pages(self, db):
         for i in range(5):
-            await _insert(f"pag-all-{i:02d}", owner=f"google:pager{i}@example.com", is_public=True, is_approved=True)
+            await _insert(f"pag-all-{i:02d}", is_public=True, is_approved=True)
         all_ids: set[str] = set()
         cursor = None
         while True:
@@ -323,30 +320,27 @@ class TestPagination:
 
 
 # ---------------------------------------------------------------------------
-# patch_one
+# patch_one  (base mechanics: scoped $set; policy lives in the service)
 # ---------------------------------------------------------------------------
 
 
 class TestPatchProject:
     async def test_updates_single_field(self, db):
         await _insert("patch-me")
-        patch = ProjectPatch(title="Updated Title")
-        await _repo(ADMIN).patch_one({"id": "patch-me"}, patch)
+        await _repo(ADMIN).patch_one({"id": "patch-me"}, ProjectPatch(title="Updated Title"))
         found = await Project.find_one(Project.id == "patch-me")
         assert found.title == "Updated Title"
 
     async def test_unset_fields_not_overwritten(self, db):
         await _insert("patch-preserve")
         original = await Project.find_one(Project.id == "patch-preserve")
-        patch = ProjectPatch(title="New Title")
-        await _repo(ADMIN).patch_one({"id": "patch-preserve"}, patch)
+        await _repo(ADMIN).patch_one({"id": "patch-preserve"}, ProjectPatch(title="New Title"))
         found = await Project.find_one(Project.id == "patch-preserve")
         assert found.authors == original.authors
 
     async def test_not_found_raises(self, db):
-        patch = ProjectPatch(title="Won't work")
         with pytest.raises(NotFoundError):
-            await _repo(ADMIN).patch_one({"id": "no-such-id"}, patch)
+            await _repo(ADMIN).patch_one({"id": "no-such-id"}, ProjectPatch(title="Won't work"))
 
     async def test_empty_patch_returns_existing(self, db):
         await _insert("patch-empty")
@@ -355,7 +349,7 @@ class TestPatchProject:
 
 
 # ---------------------------------------------------------------------------
-# delete_one  (soft-delete via DocumentWithSoftDelete)
+# delete_one  (base mechanics: scoped delete; owner-or-admin gate lives in the service)
 # ---------------------------------------------------------------------------
 
 
@@ -364,324 +358,48 @@ class TestDeleteProject:
         await _insert("del-me", is_public=True, is_approved=True)
         await _repo(ADMIN).delete_one({"id": "del-me"})
         page = await _repo(ADMIN).get_many(filter=_noop_filter(), pagination=CursorParams(), fields=None)
-        ids = {p.id for p in page.items}
-        assert "del-me" not in ids
+        assert "del-me" not in {p.id for p in page.items}
 
     async def test_delete_nonexistent_throws_error(self, db):
-        # delete_one does find_one().delete() — Error if not found
         with pytest.raises(NotFoundError, match="not found"):
             await _repo(ADMIN).delete_one({"id": "ghost-id"})
 
-    async def test_owner_can_delete_own_project(self, db):
-        await _insert("del-own", owner="google:alice@example.com")
-        await _repo(ALICE).delete_one({"id": "del-own"})
-        assert await Project.find_one(Project.id == "del-own") is None
-
-    async def test_admin_can_delete_any_project(self, db):
-        await _insert("del-admin", owner="google:alice@example.com")
-        await _repo(ADMIN).delete_one({"id": "del-admin"})
-        assert await Project.find_one(Project.id == "del-admin") is None
-
-    async def test_group_member_non_owner_cannot_delete(self, db):
-        # A user whose group contains the project slug can *see* it, but only the owner may delete.
-        member = User(username="google:carol@example.com", groups=frozenset({"del-grp"}))
-        await _insert("del-grp", owner="google:alice@example.com")
-        with pytest.raises(PermissionError):
-            await _repo(member).delete_one({"id": "del-grp"})
-        assert await Project.find_one(Project.id == "del-grp") is not None
-
-    async def test_visible_public_non_owner_cannot_delete(self, db):
-        # BOB can see the public+approved project but does not own it → 403, not a silent success.
-        await _insert("del-pub", owner="google:alice@example.com", is_public=True, is_approved=True)
-        with pytest.raises(PermissionError):
-            await _repo(BOB).delete_one({"id": "del-pub"})
-        assert await Project.find_one(Project.id == "del-pub") is not None
-
-    async def test_out_of_scope_delete_not_found(self, db):
-        # BOB cannot see Alice's private project → 404 (existence is not leaked as a 403).
-        await _insert("del-hidden", owner="google:alice@example.com", is_public=False)
-        with pytest.raises(NotFoundError):
-            await _repo(BOB).delete_one({"id": "del-hidden"})
-        assert await Project.find_one(Project.id == "del-hidden") is not None
-
 
 # ---------------------------------------------------------------------------
-# upsert_one
+# Toolbox query/persistence primitives the service composes
 # ---------------------------------------------------------------------------
 
 
-class TestUpsertProject:
-    async def test_upsert_creates_new_project(self, db):
-        data = _project_in("upsert-new")
-        await _repo(ADMIN).upsert_one({"id": "upsert-new"}, data=data)
-        found = await Project.find_one(Project.id == "upsert-new")
+class TestToolboxPrimitives:
+    async def test_count_for_owner_counts_only_that_owner(self, db):
+        await _insert("cbo-a", owner=ALICE_EMAIL)
+        await _insert("cbo-b", owner=ALICE_EMAIL)
+        await _insert("cbo-c", owner=BOB_EMAIL)
+        assert await _repo(ADMIN).count_for_owner(ALICE_EMAIL) == 2
+        assert await _repo(ADMIN).count_for_owner(BOB_EMAIL) == 1
+
+    async def test_count_for_owner_is_unscoped(self, db):
+        # The count is a property of the owner, independent of who asks — even a caller who cannot
+        # see the private projects sees the true total.
+        await _insert("cbo-priv-1", owner=ALICE_EMAIL, is_public=False)
+        await _insert("cbo-priv-2", owner=ALICE_EMAIL, is_public=False)
+        assert await _repo(BOB).count_for_owner(ALICE_EMAIL) == 2
+
+    async def test_find_by_id_unscoped_ignores_visibility(self, db):
+        await _insert("fbi-hidden", owner=ALICE_EMAIL, is_public=False)
+        # BOB cannot *see* it via scope, but the unscoped existence lookup still resolves it.
+        found = await _repo(BOB).find_by_id_unscoped("fbi-hidden")
         assert found is not None
+        assert found.id == "fbi-hidden"
 
-    async def test_upsert_updates_existing_project(self, db):
-        await _insert("upsert-existing")
-        data = _project_in("upsert-existing", title="Replaced Title")
-        await _repo(ADMIN).upsert_one({"id": "upsert-existing"}, data=data)
-        found = await Project.find_one(Project.id == "upsert-existing")
-        assert found.title == "Replaced Title"
+    async def test_find_by_id_unscoped_returns_none_when_absent(self, db):
+        assert await _repo(ADMIN).find_by_id_unscoped("fbi-missing") is None
 
-    async def test_upsert_uses_path_id_not_body_id(self, db):
-        data = _project_in("body-id")
-        await _repo(ADMIN).upsert_one({"id": "path-id"}, data=data)
-        found = await Project.find_one(Project.id == "path-id")
-        assert found is not None
-
-
-# ---------------------------------------------------------------------------
-# upsert_one — authorization (owner-or-admin)
-# ---------------------------------------------------------------------------
-
-BOB = User(username="google:bob@example.com", groups=frozenset())
-
-
-class TestUpsertProjectAuthorization:
-    async def test_owner_can_overwrite_own_project(self, db):
-        await _insert("auth-own", owner="google:alice@example.com")
-        data = _project_in("auth-own", owner="google:alice@example.com", title="Owner Edit")
-        await _repo(ALICE).upsert_one({"id": "auth-own"}, data=data)
-        found = await Project.find_one(Project.id == "auth-own")
-        assert found.title == "Owner Edit"
-
-    async def test_admin_can_overwrite_any_project(self, db):
-        await _insert("auth-admin", owner="google:alice@example.com")
-        data = _project_in("auth-admin", owner="google:alice@example.com", title="Admin Edit")
-        await _repo(ADMIN).upsert_one({"id": "auth-admin"}, data=data)
-        found = await Project.find_one(Project.id == "auth-admin")
-        assert found.title == "Admin Edit"
-
-    async def test_non_owner_cannot_overwrite(self, db):
-        await _insert("auth-other", owner="google:alice@example.com", title="Original")
-        data = _project_in("auth-other", owner="google:alice@example.com", title="Hijacked")
-        from mpcontribs_api.exceptions import PermissionError as AppPermissionError
-
-        with pytest.raises(AppPermissionError):
-            await _repo(BOB).upsert_one({"id": "auth-other"}, data=data)
-        found = await Project.find_one(Project.id == "auth-other")
-        assert found.title == "Original"
-
-    async def test_new_project_sets_owner_to_caller(self, db):
-        # Body carries a foreign owner; the authenticated caller's identity must win on insert.
-        data = _project_in("auth-newowner", owner="google:alice@example.com")
-        await _repo(BOB).upsert_one({"id": "auth-newowner"}, data=data)
-        found = await Project.find_one(Project.id == "auth-newowner")
-        assert found.owner == "google:bob@example.com"
-
-    async def test_update_preserves_original_owner(self, db):
-        await _insert("auth-preserve", owner="google:alice@example.com")
-        # Alice tries to reassign ownership via the body; owner must stay hers.
-        data = _project_in("auth-preserve", owner="google:bob@example.com", title="Edit")
-        await _repo(ALICE).upsert_one({"id": "auth-preserve"}, data=data)
-        found = await Project.find_one(Project.id == "auth-preserve")
-        assert found.owner == "google:alice@example.com"
-
-
-# ---------------------------------------------------------------------------
-# is_approved is admin-only (via PATCH — ProjectIn cannot carry it)
-# ---------------------------------------------------------------------------
-
-
-class TestApprovalIsAdminOnly:
-    async def test_non_admin_cannot_patch_is_approved(self, db):
-        await _insert("appr-patch", owner="google:alice@example.com")
-        with pytest.raises(PermissionError):
-            await _repo(ALICE).patch_one({"id": "appr-patch"}, ProjectPatch(is_approved=True))
-        found = await Project.find_one(Project.id == "appr-patch")
-        assert found.is_approved is False
-
-    async def test_admin_can_patch_is_approved(self, db):
-        await _insert("appr-patch-admin", owner="google:alice@example.com")
-        await _repo(ADMIN).patch_one({"id": "appr-patch-admin"}, ProjectPatch(is_approved=True))
-        found = await Project.find_one(Project.id == "appr-patch-admin")
-        assert found.is_approved is True
-
-
-# ---------------------------------------------------------------------------
-# a project cannot be public unless approved (enforced on PATCH)
-# ---------------------------------------------------------------------------
-
-
-class TestPublicRequiresApproved:
-    async def test_patch_public_on_unapproved_rejected(self, db):
-        await _insert("pub-unappr", owner="google:alice@example.com", is_approved=False)
-        with pytest.raises(ValidationError, match="approved"):
-            await _repo(ADMIN).patch_one({"id": "pub-unappr"}, ProjectPatch(is_public=True))
-        found = await Project.find_one(Project.id == "pub-unappr")
-        assert found.is_public is False
-
-    async def test_patch_public_and_approved_together_succeeds(self, db):
-        await _insert("pub-both", owner="google:alice@example.com", is_approved=False)
-        await _repo(ADMIN).patch_one(
-            {"id": "pub-both"}, ProjectPatch(is_public=True, is_approved=True)
-        )
-        found = await Project.find_one(Project.id == "pub-both")
-        assert found.is_public is True
-        assert found.is_approved is True
-
-    async def test_patch_public_on_approved_succeeds(self, db):
-        await _insert("pub-approved", owner="google:alice@example.com", is_approved=True)
-        await _repo(ADMIN).patch_one({"id": "pub-approved"}, ProjectPatch(is_public=True))
-        found = await Project.find_one(Project.id == "pub-approved")
-        assert found.is_public is True
-
-
-# ---------------------------------------------------------------------------
-# upsert (PUT) cannot set server-managed fields; it preserves them on update
-# ---------------------------------------------------------------------------
-
-
-class TestUpsertServerManagedFields:
-    async def test_new_project_is_private_and_unapproved(self, db):
-        # ProjectIn has no is_public/is_approved, so a new PUT project starts safe by default.
-        await _repo(BOB).upsert_one({"id": "srv-new"}, data=_project_in("srv-new"))
-        found = await Project.find_one(Project.id == "srv-new")
-        assert found.is_public is False
-        assert found.is_approved is False
-
-    async def test_admin_upsert_cannot_approve_via_body(self, db):
-        # Approval is PATCH-only even for an admin; a PUT can never approve a project.
-        await _repo(ADMIN).upsert_one({"id": "srv-admin-new"}, data=_project_in("srv-admin-new"))
-        found = await Project.find_one(Project.id == "srv-admin-new")
-        assert found.is_approved is False
-
-    async def test_update_preserves_public_and_approved(self, db):
-        # A full-replace PUT by the owner must not wipe server-managed publication/approval.
-        await _insert("srv-preserve", owner="google:alice@example.com", is_public=True, is_approved=True)
-        data = _project_in("srv-preserve", owner="google:alice@example.com", title="Renamed Title")
-        await _repo(ALICE).upsert_one({"id": "srv-preserve"}, data=data)
-        found = await Project.find_one(Project.id == "srv-preserve")
-        assert found.title == "Renamed Title"  # content fields still update
-        assert found.is_public is True
-        assert found.is_approved is True
-
-    async def test_update_preserves_stats(self, db):
-        await _insert("srv-stats", owner="google:alice@example.com", stats=Stats(contributions=7))
-        await _repo(ALICE).upsert_one({"id": "srv-stats"}, data=_project_in("srv-stats"))
-        found = await Project.find_one(Project.id == "srv-stats")
-        assert found.stats.contributions == 7
-# Server-owned fields: stats / columns are derived, is_approved is admin-only
-# ---------------------------------------------------------------------------
-
-
-class TestServerOwnedFields:
-    async def test_upsert_update_preserves_stats_and_columns(self, db):
-        await _insert("srv-preserve")
-        # A server-computed rollup already lives on the stored document.
-        stored = await Project.find_one(Project.id == "srv-preserve")
-        stored.stats = Stats(columns=2, contributions=5, tables=1, structures=0, attachments=0, size=42.0)
-        stored.columns = [Column(path="data.band_gap", min=0.0, max=1.0, unit="eV")]
-        await stored.save()
-        # A full overwrite must not clobber them.
-        await _repo(ADMIN).upsert_one({"id": "srv-preserve"}, _project_in("srv-preserve", title="Edited"))
-        found = await Project.find_one(Project.id == "srv-preserve")
-        assert found.title == "Edited"
-        assert found.stats.contributions == 5
-        assert [c.path for c in found.columns] == ["data.band_gap"]
-
-    async def test_upsert_new_starts_with_empty_stats(self, db):
-        await _repo(ALICE).upsert_one({"id": "srv-new-empty"}, _project_in("srv-new-empty"))
-        found = await Project.find_one(Project.id == "srv-new-empty")
-        assert found.stats == Stats()
-        assert found.columns == []
-
-    async def test_non_admin_cannot_approve_new_project_via_upsert(self, db):
-        data = _project_in("srv-approve-new", is_approved=True)
-        await _repo(ALICE).upsert_one({"id": "srv-approve-new"}, data)
-        found = await Project.find_one(Project.id == "srv-approve-new")
-        assert found.is_approved is False
-
-    async def test_admin_can_approve_new_project_via_upsert(self, db):
-        data = _project_in("srv-approve-admin", is_approved=True)
-        await _repo(ADMIN).upsert_one({"id": "srv-approve-admin"}, data)
-        found = await Project.find_one(Project.id == "srv-approve-admin")
-        assert found.is_approved is True
-
-    async def test_non_admin_cannot_change_approval_via_upsert(self, db):
-        await _insert("srv-approve-existing", owner="google:alice@example.com", is_approved=True)
-        # The owner (non-admin) overwrites and tries to un-approve; approval must stick.
-        data = _project_in("srv-approve-existing", owner="google:alice@example.com", is_approved=False)
-        await _repo(ALICE).upsert_one({"id": "srv-approve-existing"}, data)
-        found = await Project.find_one(Project.id == "srv-approve-existing")
-        assert found.is_approved is True
-
-    async def test_non_admin_cannot_approve_via_patch(self, db):
-        await _insert("srv-patch-approve", owner="google:alice@example.com")
-        with pytest.raises(AppPermissionError):
-            await _repo(ALICE).patch_one({"id": "srv-patch-approve"}, update=ProjectPatch(is_approved=True))
-        found = await Project.find_one(Project.id == "srv-patch-approve")
-        assert found.is_approved is False
-
-    async def test_admin_can_approve_via_patch(self, db):
-        await _insert("srv-patch-admin", owner="google:alice@example.com")
-        await _repo(ADMIN).patch_one({"id": "srv-patch-admin"}, update=ProjectPatch(is_approved=True))
-        found = await Project.find_one(Project.id == "srv-patch-admin")
-        assert found.is_approved is True
-
-    async def test_non_admin_plain_patch_is_allowed(self, db):
-        await _insert("srv-patch-plain", owner="google:alice@example.com")
-        await _repo(ALICE).patch_one({"id": "srv-patch-plain"}, update=ProjectPatch(title="New Title"))
-        found = await Project.find_one(Project.id == "srv-patch-plain")
-        assert found.title == "New Title"
-# Per-user project-count quota (max_projects)
-# ---------------------------------------------------------------------------
-
-
-ALICE_EMAIL = "google:alice@example.com"
-
-
-class TestProjectCountQuota:
-    async def test_insert_can_reach_exactly_cap(self, db, monkeypatch):
-        # The cap is inclusive: a user may own up to (not fewer than) max_projects.
-        from mpcontribs_api.config import get_settings
-
-        monkeypatch.setattr(get_settings().consumer, "max_projects", 2)
-        await _insert("cap-1", owner=ALICE_EMAIL)
-        await _insert("cap-2", owner=ALICE_EMAIL)
-        assert await Project.find(Project.owner == ALICE_EMAIL).count() == 2
-
-    async def test_insert_over_cap_rejected(self, db, monkeypatch):
-        from mpcontribs_api.config import get_settings
-        from mpcontribs_api.exceptions import PermissionError as AppPermissionError
-
-        monkeypatch.setattr(get_settings().consumer, "max_projects", 2)
-        await _insert("cap-a", owner=ALICE_EMAIL)
-        await _insert("cap-b", owner=ALICE_EMAIL)
-        with pytest.raises(AppPermissionError):
-            await _insert("cap-c", owner=ALICE_EMAIL)
-
-    async def test_upsert_new_project_over_cap_rejected(self, db, monkeypatch):
-        # A brand-new project via upsert is counted against the caller's cap.
-        from mpcontribs_api.config import get_settings
-        from mpcontribs_api.exceptions import PermissionError as AppPermissionError
-
-        monkeypatch.setattr(get_settings().consumer, "max_projects", 1)
-        await _insert("owned-1", owner=ALICE_EMAIL)
-        data = _project_in("new-proj", owner=ALICE_EMAIL)
-        with pytest.raises(AppPermissionError):
-            await _repo(ALICE).upsert_one({"id": "new-proj"}, data)
-
-    async def test_upsert_existing_project_allowed_at_cap(self, db, monkeypatch):
-        # Regression: updating a project you already own must never be blocked by the cap, even
-        # when you are exactly at it. Only *new* projects count against the quota.
-        from mpcontribs_api.config import get_settings
-
-        monkeypatch.setattr(get_settings().consumer, "max_projects", 1)
-        await _insert("owned-only", owner=ALICE_EMAIL)
-        data = _project_in("owned-only", owner=ALICE_EMAIL, title="Updated Title")
-        result = await _repo(ALICE).upsert_one({"id": "owned-only"}, data)
-        assert result.title == "Updated Title"
-
-    async def test_injected_consumer_override_lowers_cap(self, db):
-        # A per-consumer override resolves to a ConsumerSettings injected into the repo; the cap it
-        # carries is enforced without touching global config. Here the override tightens the cap to 1.
-        repo = _repo(ALICE, ConsumerSettings(max_projects=1))
-        await repo.insert_one("override-1", _project_in("override-1", owner=ALICE_EMAIL))
-        from mpcontribs_api.exceptions import PermissionError as AppPermissionError
-
-        with pytest.raises(AppPermissionError):
-            await repo.insert_one("override-2", _project_in("override-2", owner=ALICE_EMAIL))
-
-
+    async def test_save_inserts_then_replaces(self, db):
+        doc = Project.from_input_model(_project_in("save-doc", title="First"), id="save-doc")
+        await _repo(ADMIN).save(doc)
+        assert (await Project.find_one(Project.id == "save-doc")).title == "First"
+        # Saving the same id again replaces in place (upsert semantics).
+        doc.title = "Second"
+        await _repo(ADMIN).save(doc)
+        assert (await Project.find_one(Project.id == "save-doc")).title == "Second"

--- a/mpcontribs-api/tests/integration/db/test_projects_repository.py
+++ b/mpcontribs-api/tests/integration/db/test_projects_repository.py
@@ -420,3 +420,40 @@ class TestToolboxPrimitives:
         doc.title = "Second"
         await _repo(ADMIN).upsert_one(doc)
         assert (await Project.find_one(Project.id == "save-doc")).title == "Second"
+
+
+# ---------------------------------------------------------------------------
+# existing_ids — batched existence check for a list of project ids (scoped or global)
+# ---------------------------------------------------------------------------
+
+
+class TestExistingIds:
+    async def test_returns_only_ids_that_exist(self, db):
+        await _insert("ex-1", is_public=True, is_approved=True)
+        await _insert("ex-2", is_public=True, is_approved=True)
+        found = await _repo(ADMIN).existing_ids(["ex-1", "ex-2", "ex-missing"], scoped=True)
+        assert found == {"ex-1", "ex-2"}
+
+    async def test_empty_input_returns_empty_set_without_query(self, db):
+        assert await _repo(ADMIN).existing_ids([], scoped=True) == set()
+        assert await _repo(ADMIN).existing_ids([], scoped=False) == set()
+
+    async def test_scoped_hides_invisible_projects(self, db):
+        # scoped=True: Bob may see the public project but not Alice's private one, so only the visible
+        # id comes back even though both exist — existence is reported through the caller's read scope.
+        await _insert("ex-pub", owner=ALICE_EMAIL, is_public=True, is_approved=True)
+        await _insert("ex-priv", owner=ALICE_EMAIL, is_public=False)
+        found = await _repo(BOB).existing_ids(["ex-pub", "ex-priv"], scoped=True)
+        assert found == {"ex-pub"}
+
+    async def test_unscoped_sees_every_existing_id(self, db):
+        # scoped=False: a global existence check (e.g. duplicate-id detection) spans every project
+        # regardless of the caller's scope — Bob sees the private id exists even though he cannot read it.
+        await _insert("ex-g-pub", owner=ALICE_EMAIL, is_public=True, is_approved=True)
+        await _insert("ex-g-priv", owner=ALICE_EMAIL, is_public=False)
+        found = await _repo(BOB).existing_ids(["ex-g-pub", "ex-g-priv", "ex-g-missing"], scoped=False)
+        assert found == {"ex-g-pub", "ex-g-priv"}
+
+    async def test_owner_sees_own_private_project_when_scoped(self, db):
+        await _insert("ex-own", owner=ALICE_EMAIL, is_public=False)
+        assert await _repo(ALICE).existing_ids(["ex-own"], scoped=True) == {"ex-own"}

--- a/mpcontribs-api/tests/integration/db/test_projects_repository.py
+++ b/mpcontribs-api/tests/integration/db/test_projects_repository.py
@@ -45,10 +45,10 @@ async def _insert(id: str, **overrides) -> Project:
     """Seed a project via the repository's mechanical write path (admin, no policy).
 
     The repository is document-in: the service builds the stored ``Project`` (here via
-    ``from_input_model``) and hands it to ``save``, which inserts-or-replaces by ``_id``.
+    ``from_input_model``) and hands it to ``upsert_one``, which inserts-or-replaces by ``_id``.
     """
     document = Project.from_input_model(_project_in(id, **overrides), id=id)
-    return await _repo(ADMIN).save(document)
+    return await _repo(ADMIN).upsert_one(document)
 
 
 def _noop_filter():
@@ -58,7 +58,7 @@ def _noop_filter():
 
 
 # ---------------------------------------------------------------------------
-# save  (mechanical insert-or-replace by _id, no policy)
+# upsert_one  (mechanical insert-or-replace by _id, no policy)
 # ---------------------------------------------------------------------------
 
 
@@ -406,9 +406,9 @@ class TestToolboxPrimitives:
 
     async def test_save_inserts_then_replaces(self, db):
         doc = Project.from_input_model(_project_in("save-doc", title="First"), id="save-doc")
-        await _repo(ADMIN).save(doc)
+        await _repo(ADMIN).upsert_one(doc)
         assert (await Project.find_one(Project.id == "save-doc")).title == "First"
         # Saving the same id again replaces in place (upsert semantics).
         doc.title = "Second"
-        await _repo(ADMIN).save(doc)
+        await _repo(ADMIN).upsert_one(doc)
         assert (await Project.find_one(Project.id == "save-doc")).title == "Second"

--- a/mpcontribs-api/tests/integration/db/test_projects_repository.py
+++ b/mpcontribs-api/tests/integration/db/test_projects_repository.py
@@ -3,7 +3,7 @@ import pytest
 from mpcontribs_api.authz import User
 from mpcontribs_api.domains.projects.models import Project, ProjectIn, ProjectOut, ProjectPatch
 from mpcontribs_api.domains.projects.repository import MongoDbProjectRepository
-from mpcontribs_api.exceptions import ConflictError, NotFoundError
+from mpcontribs_api.exceptions import NotFoundError
 from mpcontribs_api.pagination import CursorParams
 
 # All tests in this module share the session event loop so they can reuse the
@@ -42,8 +42,13 @@ def _project_in(id: str, **overrides) -> ProjectIn:
 
 
 async def _insert(id: str, **overrides) -> Project:
-    """Seed a project via the repository's mechanical insert path (admin, no policy)."""
-    return await _repo(ADMIN).insert_one(id, _project_in(id, **overrides))
+    """Seed a project via the repository's mechanical write path (admin, no policy).
+
+    The repository is document-in: the service builds the stored ``Project`` (here via
+    ``from_input_model``) and hands it to ``save``, which inserts-or-replaces by ``_id``.
+    """
+    document = Project.from_input_model(_project_in(id, **overrides), id=id)
+    return await _repo(ADMIN).save(document)
 
 
 def _noop_filter():
@@ -53,7 +58,7 @@ def _noop_filter():
 
 
 # ---------------------------------------------------------------------------
-# insert_one  (mechanical: id-stamp + dup-reject, no policy)
+# save  (mechanical insert-or-replace by _id, no policy)
 # ---------------------------------------------------------------------------
 
 
@@ -64,10 +69,14 @@ class TestInsertProject:
         assert found is not None
         assert found.id == "ins-basic"
 
-    async def test_duplicate_id_raises_conflict(self, db):
-        await _insert("ins-dup")
-        with pytest.raises(ConflictError):
-            await _insert("ins-dup")
+    async def test_save_replaces_existing_id(self, db):
+        # save is upsert-by-_id, so re-saving the same id replaces rather than conflicts. Duplicate
+        # rejection for the create path is a service concern (ProjectService.upsert_one), not the repo.
+        await _insert("ins-dup", title="first")
+        await _insert("ins-dup", title="second")
+        found = await Project.find_one(Project.id == "ins-dup")
+        assert found is not None
+        assert found.title == "second"
 
     async def test_insert_defaults_private_and_unapproved(self, db):
         # ProjectIn carries no is_public/is_approved, so an inserted project is private and unapproved.

--- a/mpcontribs-api/tests/integration/db/test_projects_repository.py
+++ b/mpcontribs-api/tests/integration/db/test_projects_repository.py
@@ -78,7 +78,7 @@ class TestInsertProject:
 
 
 # ---------------------------------------------------------------------------
-# Authorization scoping  (read visibility via ReadScope)
+# Authorization scoping  (read visibility via the repo's declared Scope)
 # ---------------------------------------------------------------------------
 
 

--- a/mpcontribs-api/tests/integration/db/test_projects_repository.py
+++ b/mpcontribs-api/tests/integration/db/test_projects_repository.py
@@ -380,19 +380,27 @@ class TestDeleteProject:
 
 
 class TestToolboxPrimitives:
-    async def test_count_for_owner_counts_only_that_owner(self, db):
+    async def test_count_matching_counts_only_that_owner(self, db):
         await _insert("cbo-a", owner=ALICE_EMAIL)
         await _insert("cbo-b", owner=ALICE_EMAIL)
         await _insert("cbo-c", owner=BOB_EMAIL)
-        assert await _repo(ADMIN).count_for_owner(ALICE_EMAIL) == 2
-        assert await _repo(ADMIN).count_for_owner(BOB_EMAIL) == 1
+        assert await _repo(ADMIN).count_matching({"owner": ALICE_EMAIL}, scoped=False) == 2
+        assert await _repo(ADMIN).count_matching({"owner": BOB_EMAIL}, scoped=False) == 1
 
-    async def test_count_for_owner_is_unscoped(self, db):
-        # The count is a property of the owner, independent of who asks — even a caller who cannot
-        # see the private projects sees the true total.
+    async def test_count_matching_unscoped_sees_the_true_total(self, db):
+        # scoped=False makes the count a property of the owner, independent of who asks — even a
+        # caller who cannot see the private projects sees the true total.
         await _insert("cbo-priv-1", owner=ALICE_EMAIL, is_public=False)
         await _insert("cbo-priv-2", owner=ALICE_EMAIL, is_public=False)
-        assert await _repo(BOB).count_for_owner(ALICE_EMAIL) == 2
+        assert await _repo(BOB).count_matching({"owner": ALICE_EMAIL}, scoped=False) == 2
+
+    async def test_count_matching_scoped_hides_invisible_docs(self, db):
+        # scoped=True merges the caller's read scope: Bob cannot see Alice's private projects, so a
+        # scoped count of them is zero even though the unscoped total is two.
+        await _insert("cbo-sc-1", owner=ALICE_EMAIL, is_public=False)
+        await _insert("cbo-sc-2", owner=ALICE_EMAIL, is_public=False)
+        assert await _repo(BOB).count_matching({"owner": ALICE_EMAIL}, scoped=True) == 0
+        assert await _repo(ALICE).count_matching({"owner": ALICE_EMAIL}, scoped=True) == 2
 
     async def test_find_by_id_unscoped_ignores_visibility(self, db):
         await _insert("fbi-hidden", owner=ALICE_EMAIL, is_public=False)

--- a/mpcontribs-api/tests/integration/db/test_projects_service.py
+++ b/mpcontribs-api/tests/integration/db/test_projects_service.py
@@ -2,7 +2,7 @@ import pytest
 
 from mpcontribs_api.authz import User
 from mpcontribs_api.domains.consumers.models import ConsumerSettings
-from mpcontribs_api.domains.initiatives.repository import InitiativeRepository
+from mpcontribs_api.domains.initiatives.repository import MongoDbInitiativeRepository
 from mpcontribs_api.domains.projects.models import Column, Project, ProjectIn, ProjectPatch, Stats
 from mpcontribs_api.domains.projects.repository import MongoDbProjectRepository
 from mpcontribs_api.domains.projects.service import ProjectService
@@ -28,7 +28,7 @@ def _service(user: User, limits: ConsumerSettings | None = None) -> ProjectServi
     return ProjectService(
         user=user,
         projects=MongoDbProjectRepository(user),
-        initiatives=InitiativeRepository(user),
+        initiatives=MongoDbInitiativeRepository(user),
         limits=limits,
     )
 

--- a/mpcontribs-api/tests/integration/db/test_projects_service.py
+++ b/mpcontribs-api/tests/integration/db/test_projects_service.py
@@ -90,6 +90,48 @@ class TestDeleteAuthorization:
 
 
 # ---------------------------------------------------------------------------
+# patch_one — owner-or-admin, 403 vs 404 (mirrors delete_one)
+# ---------------------------------------------------------------------------
+
+
+class TestPatchAuthorization:
+    async def test_owner_can_patch_own_project(self, db):
+        await _insert("svc-patch-own", owner=ALICE_EMAIL)
+        updated = await _service(ALICE).patch_one({"id": "svc-patch-own"}, ProjectPatch(title="By Owner"))
+        assert updated.title == "By Owner"
+
+    async def test_admin_can_patch_any_project(self, db):
+        await _insert("svc-patch-admin", owner=ALICE_EMAIL)
+        updated = await _service(ADMIN).patch_one({"id": "svc-patch-admin"}, ProjectPatch(title="By Admin"))
+        assert updated.title == "By Admin"
+
+    async def test_group_member_non_owner_cannot_patch(self, db):
+        # A user whose group grants a role on the project can *see* it, but only the owner may patch.
+        member = User(username="google:carol@example.com", groups=frozenset({"svc-patch-grp"}))
+        await _insert("svc-patch-grp", owner=ALICE_EMAIL)
+        with pytest.raises(AppPermissionError):
+            await _service(member).patch_one({"id": "svc-patch-grp"}, ProjectPatch(title="Hijacked"))
+        doc = await Project.find_one(Project.id == "svc-patch-grp")
+        assert doc is not None and doc.title == "svc-patch-grp"[:30]
+
+    async def test_visible_public_non_owner_cannot_patch(self, db):
+        # BOB can see the public+approved project but does not own it → 403, and it is left unchanged.
+        await _insert("svc-patch-pub", owner=ALICE_EMAIL, is_public=True, is_approved=True)
+        with pytest.raises(AppPermissionError):
+            await _service(BOB).patch_one({"id": "svc-patch-pub"}, ProjectPatch(owner=BOB_EMAIL))
+        doc = await Project.find_one(Project.id == "svc-patch-pub")
+        assert doc is not None and doc.owner == ALICE_EMAIL
+
+    async def test_out_of_scope_patch_not_found(self, db):
+        # BOB cannot see Alice's private project → 404 (existence is not leaked as a 403).
+        await _insert("svc-patch-hidden", owner=ALICE_EMAIL, is_public=False)
+        with pytest.raises(NotFoundError):
+            await _service(BOB).patch_one({"id": "svc-patch-hidden"}, ProjectPatch(title="Hijacked"))
+        doc = await Project.find_one(Project.id == "svc-patch-hidden")
+        assert doc is not None and doc.title == "svc-patch-hidden"[:30]
+
+
+# ---------------------------------------------------------------------------
 # upsert_one — create / update / path-id
 # ---------------------------------------------------------------------------
 

--- a/mpcontribs-api/tests/integration/db/test_projects_service.py
+++ b/mpcontribs-api/tests/integration/db/test_projects_service.py
@@ -1,0 +1,307 @@
+import pytest
+
+from mpcontribs_api.authz import User
+from mpcontribs_api.domains.consumers.models import ConsumerSettings
+from mpcontribs_api.domains.initiatives.repository import InitiativeRepository
+from mpcontribs_api.domains.projects.models import Column, Project, ProjectIn, ProjectPatch, Stats
+from mpcontribs_api.domains.projects.repository import MongoDbProjectRepository
+from mpcontribs_api.domains.projects.service import ProjectService
+from mpcontribs_api.exceptions import PermissionError as AppPermissionError
+from mpcontribs_api.exceptions import NotFoundError, ValidationError
+
+pytestmark = [pytest.mark.db, pytest.mark.asyncio(loop_scope="session")]
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+ADMIN = User(username="google:admin@example.com", groups=frozenset({"admin"}))
+ALICE = User(username="google:alice@example.com", groups=frozenset({"mp-team"}))
+BOB = User(username="google:bob@example.com", groups=frozenset())
+
+ALICE_EMAIL = "google:alice@example.com"
+BOB_EMAIL = "google:bob@example.com"
+
+
+def _service(user: User, limits: ConsumerSettings | None = None) -> ProjectService:
+    return ProjectService(
+        user=user,
+        projects=MongoDbProjectRepository(user),
+        initiatives=InitiativeRepository(user),
+        limits=limits,
+    )
+
+
+def _project_in(id: str, **overrides) -> ProjectIn:
+    defaults = {
+        "title": id[:30],
+        "authors": "Test Author",
+        "description": "Test description",
+        "owner": ALICE_EMAIL,
+    }
+    defaults.update(overrides)
+    return ProjectIn(**defaults)
+
+
+async def _insert(id: str, **overrides) -> Project:
+    """Seed a project directly through the repository's mechanical insert (admin, no policy)."""
+    return await MongoDbProjectRepository(ADMIN).insert_one(id, _project_in(id, **overrides))
+
+
+# ---------------------------------------------------------------------------
+# delete_one — owner-or-admin, 403 vs 404
+# ---------------------------------------------------------------------------
+
+
+class TestDeleteAuthorization:
+    async def test_owner_can_delete_own_project(self, db):
+        await _insert("svc-del-own", owner=ALICE_EMAIL)
+        await _service(ALICE).delete_one({"id": "svc-del-own"})
+        assert await Project.find_one(Project.id == "svc-del-own") is None
+
+    async def test_admin_can_delete_any_project(self, db):
+        await _insert("svc-del-admin", owner=ALICE_EMAIL)
+        await _service(ADMIN).delete_one({"id": "svc-del-admin"})
+        assert await Project.find_one(Project.id == "svc-del-admin") is None
+
+    async def test_group_member_non_owner_cannot_delete(self, db):
+        # A user whose group contains the project id can *see* it, but only the owner may delete.
+        member = User(username="google:carol@example.com", groups=frozenset({"svc-del-grp"}))
+        await _insert("svc-del-grp", owner=ALICE_EMAIL)
+        with pytest.raises(AppPermissionError):
+            await _service(member).delete_one({"id": "svc-del-grp"})
+        assert await Project.find_one(Project.id == "svc-del-grp") is not None
+
+    async def test_visible_public_non_owner_cannot_delete(self, db):
+        # BOB can see the public+approved project but does not own it → 403, not a silent success.
+        await _insert("svc-del-pub", owner=ALICE_EMAIL, is_public=True, is_approved=True)
+        with pytest.raises(AppPermissionError):
+            await _service(BOB).delete_one({"id": "svc-del-pub"})
+        assert await Project.find_one(Project.id == "svc-del-pub") is not None
+
+    async def test_out_of_scope_delete_not_found(self, db):
+        # BOB cannot see Alice's private project → 404 (existence is not leaked as a 403).
+        await _insert("svc-del-hidden", owner=ALICE_EMAIL, is_public=False)
+        with pytest.raises(NotFoundError):
+            await _service(BOB).delete_one({"id": "svc-del-hidden"})
+        assert await Project.find_one(Project.id == "svc-del-hidden") is not None
+
+
+# ---------------------------------------------------------------------------
+# upsert_one — create / update / path-id
+# ---------------------------------------------------------------------------
+
+
+class TestUpsert:
+    async def test_upsert_creates_new_project(self, db):
+        await _service(ADMIN).upsert_one({"id": "svc-upsert-new"}, data=_project_in("svc-upsert-new"))
+        assert await Project.find_one(Project.id == "svc-upsert-new") is not None
+
+    async def test_upsert_updates_existing_project(self, db):
+        await _insert("svc-upsert-existing")
+        await _service(ADMIN).upsert_one(
+            {"id": "svc-upsert-existing"}, data=_project_in("svc-upsert-existing", title="Replaced Title")
+        )
+        found = await Project.find_one(Project.id == "svc-upsert-existing")
+        assert found.title == "Replaced Title"
+
+    async def test_upsert_uses_path_id_not_body_id(self, db):
+        await _service(ADMIN).upsert_one({"id": "svc-path-id"}, data=_project_in("svc-body-id"))
+        assert await Project.find_one(Project.id == "svc-path-id") is not None
+
+
+# ---------------------------------------------------------------------------
+# upsert_one — authorization (owner-or-admin), owner forcing
+# ---------------------------------------------------------------------------
+
+
+class TestUpsertAuthorization:
+    async def test_owner_can_overwrite_own_project(self, db):
+        await _insert("svc-auth-own", owner=ALICE_EMAIL)
+        await _service(ALICE).upsert_one(
+            {"id": "svc-auth-own"}, data=_project_in("svc-auth-own", owner=ALICE_EMAIL, title="Owner Edit")
+        )
+        found = await Project.find_one(Project.id == "svc-auth-own")
+        assert found.title == "Owner Edit"
+
+    async def test_admin_can_overwrite_any_project(self, db):
+        await _insert("svc-auth-admin", owner=ALICE_EMAIL)
+        await _service(ADMIN).upsert_one(
+            {"id": "svc-auth-admin"}, data=_project_in("svc-auth-admin", owner=ALICE_EMAIL, title="Admin Edit")
+        )
+        found = await Project.find_one(Project.id == "svc-auth-admin")
+        assert found.title == "Admin Edit"
+
+    async def test_non_owner_cannot_overwrite(self, db):
+        await _insert("svc-auth-other", owner=ALICE_EMAIL, title="Original")
+        with pytest.raises(AppPermissionError):
+            await _service(BOB).upsert_one(
+                {"id": "svc-auth-other"}, data=_project_in("svc-auth-other", owner=ALICE_EMAIL, title="Hijacked")
+            )
+        found = await Project.find_one(Project.id == "svc-auth-other")
+        assert found.title == "Original"
+
+    async def test_new_project_sets_owner_to_caller(self, db):
+        # Body carries a foreign owner; the authenticated caller's identity must win on insert.
+        await _service(BOB).upsert_one({"id": "svc-auth-newowner"}, data=_project_in("svc-auth-newowner", owner=ALICE_EMAIL))
+        found = await Project.find_one(Project.id == "svc-auth-newowner")
+        assert found.owner == BOB_EMAIL
+
+    async def test_update_preserves_original_owner(self, db):
+        await _insert("svc-auth-preserve", owner=ALICE_EMAIL)
+        # Alice tries to reassign ownership via the body; owner must stay hers.
+        await _service(ALICE).upsert_one(
+            {"id": "svc-auth-preserve"}, data=_project_in("svc-auth-preserve", owner=BOB_EMAIL, title="Edit")
+        )
+        found = await Project.find_one(Project.id == "svc-auth-preserve")
+        assert found.owner == ALICE_EMAIL
+
+    async def test_anonymous_cannot_upsert(self, db):
+        with pytest.raises(AppPermissionError):
+            await _service(User()).upsert_one({"id": "svc-anon"}, data=_project_in("svc-anon"))
+
+
+# ---------------------------------------------------------------------------
+# is_approved is admin-only (via PATCH)
+# ---------------------------------------------------------------------------
+
+
+class TestApprovalIsAdminOnly:
+    async def test_non_admin_cannot_patch_is_approved(self, db):
+        await _insert("svc-appr-patch", owner=ALICE_EMAIL)
+        with pytest.raises(AppPermissionError):
+            await _service(ALICE).patch_one({"id": "svc-appr-patch"}, ProjectPatch(is_approved=True))
+        found = await Project.find_one(Project.id == "svc-appr-patch")
+        assert found.is_approved is False
+
+    async def test_admin_can_patch_is_approved(self, db):
+        await _insert("svc-appr-admin", owner=ALICE_EMAIL)
+        await _service(ADMIN).patch_one({"id": "svc-appr-admin"}, ProjectPatch(is_approved=True))
+        found = await Project.find_one(Project.id == "svc-appr-admin")
+        assert found.is_approved is True
+
+    async def test_non_admin_plain_patch_is_allowed(self, db):
+        await _insert("svc-patch-plain", owner=ALICE_EMAIL)
+        await _service(ALICE).patch_one({"id": "svc-patch-plain"}, ProjectPatch(title="New Title"))
+        found = await Project.find_one(Project.id == "svc-patch-plain")
+        assert found.title == "New Title"
+
+    async def test_patch_missing_project_raises_not_found(self, db):
+        with pytest.raises(NotFoundError):
+            await _service(ADMIN).patch_one({"id": "svc-patch-ghost"}, ProjectPatch(title="x"))
+
+
+# ---------------------------------------------------------------------------
+# a project cannot be public unless approved (enforced on PATCH and PUT)
+# ---------------------------------------------------------------------------
+
+
+class TestPublicRequiresApproved:
+    async def test_patch_public_on_unapproved_rejected(self, db):
+        await _insert("svc-pub-unappr", owner=ALICE_EMAIL, is_approved=False)
+        with pytest.raises(ValidationError, match="approved"):
+            await _service(ADMIN).patch_one({"id": "svc-pub-unappr"}, ProjectPatch(is_public=True))
+        found = await Project.find_one(Project.id == "svc-pub-unappr")
+        assert found.is_public is False
+
+    async def test_patch_public_and_approved_together_succeeds(self, db):
+        await _insert("svc-pub-both", owner=ALICE_EMAIL, is_approved=False)
+        await _service(ADMIN).patch_one({"id": "svc-pub-both"}, ProjectPatch(is_public=True, is_approved=True))
+        found = await Project.find_one(Project.id == "svc-pub-both")
+        assert found.is_public is True
+        assert found.is_approved is True
+
+    async def test_patch_public_on_approved_succeeds(self, db):
+        await _insert("svc-pub-approved", owner=ALICE_EMAIL, is_approved=True)
+        await _service(ADMIN).patch_one({"id": "svc-pub-approved"}, ProjectPatch(is_public=True))
+        found = await Project.find_one(Project.id == "svc-pub-approved")
+        assert found.is_public is True
+
+
+# ---------------------------------------------------------------------------
+# upsert (PUT) cannot set server-managed fields; it preserves them on update
+# ---------------------------------------------------------------------------
+
+
+class TestServerManagedFields:
+    async def test_new_project_is_private_and_unapproved(self, db):
+        await _service(BOB).upsert_one({"id": "svc-srv-new"}, data=_project_in("svc-srv-new"))
+        found = await Project.find_one(Project.id == "svc-srv-new")
+        assert found.is_public is False
+        assert found.is_approved is False
+
+    async def test_admin_plain_upsert_leaves_unapproved(self, db):
+        # A plain PUT (no is_approved in the body) creates an unapproved project even for an admin.
+        await _service(ADMIN).upsert_one({"id": "svc-srv-admin-new"}, data=_project_in("svc-srv-admin-new"))
+        found = await Project.find_one(Project.id == "svc-srv-admin-new")
+        assert found.is_approved is False
+
+    async def test_non_admin_cannot_approve_new_project_via_upsert(self, db):
+        await _service(ALICE).upsert_one(
+            {"id": "svc-srv-approve-new"}, data=_project_in("svc-srv-approve-new", is_approved=True)
+        )
+        found = await Project.find_one(Project.id == "svc-srv-approve-new")
+        assert found.is_approved is False
+
+    async def test_non_admin_cannot_change_approval_via_upsert(self, db):
+        await _insert("svc-srv-approve-existing", owner=ALICE_EMAIL, is_approved=True)
+        # The owner (non-admin) overwrites and tries to un-approve; approval must stick.
+        await _service(ALICE).upsert_one(
+            {"id": "svc-srv-approve-existing"},
+            data=_project_in("svc-srv-approve-existing", owner=ALICE_EMAIL, is_approved=False),
+        )
+        found = await Project.find_one(Project.id == "svc-srv-approve-existing")
+        assert found.is_approved is True
+
+    async def test_update_preserves_stats_and_columns(self, db):
+        await _insert("svc-srv-preserve", owner=ALICE_EMAIL)
+        stored = await Project.find_one(Project.id == "svc-srv-preserve")
+        stored.stats = Stats(columns=2, contributions=5, tables=1, structures=0, attachments=0, size=42.0)
+        stored.columns = [Column(path="data.band_gap", min=0.0, max=1.0, unit="eV")]
+        await stored.save()
+        # A full overwrite must not clobber the server-owned rollups.
+        await _service(ADMIN).upsert_one({"id": "svc-srv-preserve"}, _project_in("svc-srv-preserve", title="Edited"))
+        found = await Project.find_one(Project.id == "svc-srv-preserve")
+        assert found.title == "Edited"
+        assert found.stats.contributions == 5
+        assert [c.path for c in found.columns] == ["data.band_gap"]
+
+    async def test_new_starts_with_empty_stats(self, db):
+        await _service(ALICE).upsert_one({"id": "svc-srv-new-empty"}, _project_in("svc-srv-new-empty"))
+        found = await Project.find_one(Project.id == "svc-srv-new-empty")
+        assert found.stats == Stats()
+        assert found.columns == []
+
+
+# ---------------------------------------------------------------------------
+# Per-user project-count quota (max_projects)
+# ---------------------------------------------------------------------------
+
+
+class TestProjectCountQuota:
+    async def test_upsert_new_project_over_cap_rejected(self, db, monkeypatch):
+        from mpcontribs_api.config import get_settings
+
+        monkeypatch.setattr(get_settings().consumer, "max_projects", 1)
+        await _insert("svc-owned-1", owner=ALICE_EMAIL)
+        with pytest.raises(AppPermissionError):
+            await _service(ALICE).upsert_one({"id": "svc-new-proj"}, _project_in("svc-new-proj", owner=ALICE_EMAIL))
+
+    async def test_upsert_existing_project_allowed_at_cap(self, db, monkeypatch):
+        # Updating a project you already own must never be blocked by the cap. Only new ones count.
+        from mpcontribs_api.config import get_settings
+
+        monkeypatch.setattr(get_settings().consumer, "max_projects", 1)
+        await _insert("svc-owned-only", owner=ALICE_EMAIL)
+        result = await _service(ALICE).upsert_one(
+            {"id": "svc-owned-only"}, _project_in("svc-owned-only", owner=ALICE_EMAIL, title="Updated Title")
+        )
+        assert result.title == "Updated Title"
+
+    async def test_injected_consumer_override_lowers_cap(self, db):
+        # A per-consumer override injected into the service tightens the cap to 1, without touching config.
+        await _insert("svc-override-1", owner=ALICE_EMAIL)
+        service = _service(ALICE, limits=ConsumerSettings(max_projects=1))
+        with pytest.raises(AppPermissionError):
+            await service.upsert_one({"id": "svc-override-2"}, _project_in("svc-override-2", owner=ALICE_EMAIL))

--- a/mpcontribs-api/tests/integration/db/test_projects_service.py
+++ b/mpcontribs-api/tests/integration/db/test_projects_service.py
@@ -91,19 +91,19 @@ class TestDeleteAuthorization:
 
 
 # ---------------------------------------------------------------------------
-# patch_one — owner-or-admin, 403 vs 404 (mirrors delete_one)
+# update_one — owner-or-admin, 403 vs 404 (mirrors delete_one)
 # ---------------------------------------------------------------------------
 
 
 class TestPatchAuthorization:
     async def test_owner_can_patch_own_project(self, db):
         await _insert("svc-patch-own", owner=ALICE_EMAIL)
-        updated = await _service(ALICE).patch_one({"id": "svc-patch-own"}, ProjectPatch(title="By Owner"))
+        updated = await _service(ALICE).update_one({"id": "svc-patch-own"}, ProjectPatch(title="By Owner"))
         assert updated.title == "By Owner"
 
     async def test_admin_can_patch_any_project(self, db):
         await _insert("svc-patch-admin", owner=ALICE_EMAIL)
-        updated = await _service(ADMIN).patch_one({"id": "svc-patch-admin"}, ProjectPatch(title="By Admin"))
+        updated = await _service(ADMIN).update_one({"id": "svc-patch-admin"}, ProjectPatch(title="By Admin"))
         assert updated.title == "By Admin"
 
     async def test_group_member_non_owner_cannot_patch(self, db):
@@ -111,7 +111,7 @@ class TestPatchAuthorization:
         member = User(username="google:carol@example.com", groups=frozenset({"svc-patch-grp"}))
         await _insert("svc-patch-grp", owner=ALICE_EMAIL)
         with pytest.raises(AppPermissionError):
-            await _service(member).patch_one({"id": "svc-patch-grp"}, ProjectPatch(title="Hijacked"))
+            await _service(member).update_one({"id": "svc-patch-grp"}, ProjectPatch(title="Hijacked"))
         doc = await Project.find_one(Project.id == "svc-patch-grp")
         assert doc is not None and doc.title == "svc-patch-grp"[:30]
 
@@ -119,7 +119,7 @@ class TestPatchAuthorization:
         # BOB can see the public+approved project but does not own it → 403, and it is left unchanged.
         await _insert("svc-patch-pub", owner=ALICE_EMAIL, is_public=True, is_approved=True)
         with pytest.raises(AppPermissionError):
-            await _service(BOB).patch_one({"id": "svc-patch-pub"}, ProjectPatch(owner=BOB_EMAIL))
+            await _service(BOB).update_one({"id": "svc-patch-pub"}, ProjectPatch(owner=BOB_EMAIL))
         doc = await Project.find_one(Project.id == "svc-patch-pub")
         assert doc is not None and doc.owner == ALICE_EMAIL
 
@@ -127,7 +127,7 @@ class TestPatchAuthorization:
         # BOB cannot see Alice's private project → 404 (existence is not leaked as a 403).
         await _insert("svc-patch-hidden", owner=ALICE_EMAIL, is_public=False)
         with pytest.raises(NotFoundError):
-            await _service(BOB).patch_one({"id": "svc-patch-hidden"}, ProjectPatch(title="Hijacked"))
+            await _service(BOB).update_one({"id": "svc-patch-hidden"}, ProjectPatch(title="Hijacked"))
         doc = await Project.find_one(Project.id == "svc-patch-hidden")
         assert doc is not None and doc.title == "svc-patch-hidden"[:30]
 
@@ -215,25 +215,25 @@ class TestApprovalIsAdminOnly:
     async def test_non_admin_cannot_patch_is_approved(self, db):
         await _insert("svc-appr-patch", owner=ALICE_EMAIL)
         with pytest.raises(AppPermissionError):
-            await _service(ALICE).patch_one({"id": "svc-appr-patch"}, ProjectPatch(is_approved=True))
+            await _service(ALICE).update_one({"id": "svc-appr-patch"}, ProjectPatch(is_approved=True))
         found = await Project.find_one(Project.id == "svc-appr-patch")
         assert found.is_approved is False
 
     async def test_admin_can_patch_is_approved(self, db):
         await _insert("svc-appr-admin", owner=ALICE_EMAIL)
-        await _service(ADMIN).patch_one({"id": "svc-appr-admin"}, ProjectPatch(is_approved=True))
+        await _service(ADMIN).update_one({"id": "svc-appr-admin"}, ProjectPatch(is_approved=True))
         found = await Project.find_one(Project.id == "svc-appr-admin")
         assert found.is_approved is True
 
     async def test_non_admin_plain_patch_is_allowed(self, db):
         await _insert("svc-patch-plain", owner=ALICE_EMAIL)
-        await _service(ALICE).patch_one({"id": "svc-patch-plain"}, ProjectPatch(title="New Title"))
+        await _service(ALICE).update_one({"id": "svc-patch-plain"}, ProjectPatch(title="New Title"))
         found = await Project.find_one(Project.id == "svc-patch-plain")
         assert found.title == "New Title"
 
     async def test_patch_missing_project_raises_not_found(self, db):
         with pytest.raises(NotFoundError):
-            await _service(ADMIN).patch_one({"id": "svc-patch-ghost"}, ProjectPatch(title="xyz"))
+            await _service(ADMIN).update_one({"id": "svc-patch-ghost"}, ProjectPatch(title="xyz"))
 
 
 # ---------------------------------------------------------------------------
@@ -245,20 +245,20 @@ class TestPublicRequiresApproved:
     async def test_patch_public_on_unapproved_rejected(self, db):
         await _insert("svc-pub-unappr", owner=ALICE_EMAIL, is_approved=False)
         with pytest.raises(ValidationError, match="approved"):
-            await _service(ADMIN).patch_one({"id": "svc-pub-unappr"}, ProjectPatch(is_public=True))
+            await _service(ADMIN).update_one({"id": "svc-pub-unappr"}, ProjectPatch(is_public=True))
         found = await Project.find_one(Project.id == "svc-pub-unappr")
         assert found.is_public is False
 
     async def test_patch_public_and_approved_together_succeeds(self, db):
         await _insert("svc-pub-both", owner=ALICE_EMAIL, is_approved=False)
-        await _service(ADMIN).patch_one({"id": "svc-pub-both"}, ProjectPatch(is_public=True, is_approved=True))
+        await _service(ADMIN).update_one({"id": "svc-pub-both"}, ProjectPatch(is_public=True, is_approved=True))
         found = await Project.find_one(Project.id == "svc-pub-both")
         assert found.is_public is True
         assert found.is_approved is True
 
     async def test_patch_public_on_approved_succeeds(self, db):
         await _insert("svc-pub-approved", owner=ALICE_EMAIL, is_approved=True)
-        await _service(ADMIN).patch_one({"id": "svc-pub-approved"}, ProjectPatch(is_public=True))
+        await _service(ADMIN).update_one({"id": "svc-pub-approved"}, ProjectPatch(is_public=True))
         found = await Project.find_one(Project.id == "svc-pub-approved")
         assert found.is_public is True
 
@@ -362,21 +362,21 @@ class TestReadScope:
         # public+approved one; Alice's private project must not leak into his listing.
         await _insert("scope-pub", owner=ALICE_EMAIL, is_public=True, is_approved=True)
         await _insert("scope-priv", owner=ALICE_EMAIL, is_public=False)
-        page = await _service(BOB).get_many(filter=ProjectFilter(), pagination=CursorParams(), fields=None)
+        page = await _service(BOB).read_many(filter=ProjectFilter(), pagination=CursorParams(), fields=None)
         ids = {p.id for p in page.items}
         assert "scope-pub" in ids
         assert "scope-priv" not in ids
 
     async def test_get_one_private_unowned_returns_none(self, db):
         await _insert("scope-one-priv", owner=ALICE_EMAIL, is_public=False)
-        assert await _service(BOB).get_one({"id": "scope-one-priv"}, fields=None) is None
+        assert await _service(BOB).read_one({"id": "scope-one-priv"}, fields=None) is None
 
     async def test_get_one_public_visible_to_non_owner(self, db):
         await _insert("scope-one-pub", owner=ALICE_EMAIL, is_public=True, is_approved=True)
-        found = await _service(BOB).get_one({"id": "scope-one-pub"}, fields=None)
+        found = await _service(BOB).read_one({"id": "scope-one-pub"}, fields=None)
         assert found is not None and found.id == "scope-one-pub"
 
     async def test_owner_sees_own_private_project(self, db):
         await _insert("scope-own-priv", owner=ALICE_EMAIL, is_public=False)
-        found = await _service(ALICE).get_one({"id": "scope-own-priv"}, fields=None)
+        found = await _service(ALICE).read_one({"id": "scope-own-priv"}, fields=None)
         assert found is not None and found.id == "scope-own-priv"

--- a/mpcontribs-api/tests/integration/db/test_projects_service.py
+++ b/mpcontribs-api/tests/integration/db/test_projects_service.py
@@ -46,7 +46,8 @@ def _project_in(id: str, **overrides) -> ProjectIn:
 
 async def _insert(id: str, **overrides) -> Project:
     """Seed a project directly through the repository's mechanical insert (admin, no policy)."""
-    return await MongoDbProjectRepository(ADMIN).insert_one(id, _project_in(id, **overrides))
+    document = Project.from_input_model(_project_in(id, **overrides), id=id)
+    return await MongoDbProjectRepository(ADMIN).insert_one(document)
 
 
 # ---------------------------------------------------------------------------
@@ -189,7 +190,7 @@ class TestApprovalIsAdminOnly:
 
     async def test_patch_missing_project_raises_not_found(self, db):
         with pytest.raises(NotFoundError):
-            await _service(ADMIN).patch_one({"id": "svc-patch-ghost"}, ProjectPatch(title="x"))
+            await _service(ADMIN).patch_one({"id": "svc-patch-ghost"}, ProjectPatch(title="xyz"))
 
 
 # ---------------------------------------------------------------------------

--- a/mpcontribs-api/tests/integration/db/test_projects_service.py
+++ b/mpcontribs-api/tests/integration/db/test_projects_service.py
@@ -3,11 +3,12 @@ import pytest
 from mpcontribs_api.authz import User
 from mpcontribs_api.domains.consumers.models import ConsumerSettings
 from mpcontribs_api.domains.initiatives.repository import MongoDbInitiativeRepository
-from mpcontribs_api.domains.projects.models import Column, Project, ProjectIn, ProjectPatch, Stats
+from mpcontribs_api.domains.projects.models import Column, Project, ProjectFilter, ProjectIn, ProjectPatch, Stats
 from mpcontribs_api.domains.projects.repository import MongoDbProjectRepository
 from mpcontribs_api.domains.projects.service import ProjectService
 from mpcontribs_api.exceptions import PermissionError as AppPermissionError
 from mpcontribs_api.exceptions import NotFoundError, ValidationError
+from mpcontribs_api.pagination import CursorParams
 
 pytestmark = [pytest.mark.db, pytest.mark.asyncio(loop_scope="session")]
 
@@ -348,3 +349,34 @@ class TestProjectCountQuota:
         service = _service(ALICE, limits=ConsumerSettings(max_projects=1))
         with pytest.raises(AppPermissionError):
             await service.upsert_one({"id": "svc-override-2"}, _project_in("svc-override-2", owner=ALICE_EMAIL))
+
+
+# ---------------------------------------------------------------------------
+# Read scope — GET "" and GET /{id} filter by user visibility
+# ---------------------------------------------------------------------------
+
+
+class TestReadScope:
+    async def test_get_many_hides_private_unowned(self, db):
+        # Alice owns one public+approved project and one private one. Bob (no roles) sees only the
+        # public+approved one; Alice's private project must not leak into his listing.
+        await _insert("scope-pub", owner=ALICE_EMAIL, is_public=True, is_approved=True)
+        await _insert("scope-priv", owner=ALICE_EMAIL, is_public=False)
+        page = await _service(BOB).get_many(filter=ProjectFilter(), pagination=CursorParams(), fields=None)
+        ids = {p.id for p in page.items}
+        assert "scope-pub" in ids
+        assert "scope-priv" not in ids
+
+    async def test_get_one_private_unowned_returns_none(self, db):
+        await _insert("scope-one-priv", owner=ALICE_EMAIL, is_public=False)
+        assert await _service(BOB).get_one({"id": "scope-one-priv"}, fields=None) is None
+
+    async def test_get_one_public_visible_to_non_owner(self, db):
+        await _insert("scope-one-pub", owner=ALICE_EMAIL, is_public=True, is_approved=True)
+        found = await _service(BOB).get_one({"id": "scope-one-pub"}, fields=None)
+        assert found is not None and found.id == "scope-one-pub"
+
+    async def test_owner_sees_own_private_project(self, db):
+        await _insert("scope-own-priv", owner=ALICE_EMAIL, is_public=False)
+        found = await _service(ALICE).get_one({"id": "scope-own-priv"}, fields=None)
+        assert found is not None and found.id == "scope-own-priv"

--- a/mpcontribs-api/tests/integration/db/test_stats_recompute.py
+++ b/mpcontribs-api/tests/integration/db/test_stats_recompute.py
@@ -67,7 +67,7 @@ async def _make_project() -> Project:
         description="Recompute lifecycle fixture",
         owner="google:admin@example.com",
     )
-    return await MongoDbProjectRepository(ADMIN).insert_one(PID, project_in)
+    return await MongoDbProjectRepository(ADMIN).save(Project.from_input_model(project_in, id=PID))
 
 
 def _structure(charge: float | None) -> StructureIn:

--- a/mpcontribs-api/tests/integration/db/test_stats_recompute.py
+++ b/mpcontribs-api/tests/integration/db/test_stats_recompute.py
@@ -67,7 +67,7 @@ async def _make_project() -> Project:
         description="Recompute lifecycle fixture",
         owner="google:admin@example.com",
     )
-    return await MongoDbProjectRepository(ADMIN).save(Project.from_input_model(project_in, id=PID))
+    return await MongoDbProjectRepository(ADMIN).upsert_one(Project.from_input_model(project_in, id=PID))
 
 
 def _structure(charge: float | None) -> StructureIn:

--- a/mpcontribs-api/tests/integration/test_component_routes.py
+++ b/mpcontribs-api/tests/integration/test_component_routes.py
@@ -64,37 +64,37 @@ SAMPLE_TABLE = TableOut(name="bandgaps", md5="b" * 32)
 
 class TestStructuresList:
     def test_empty_page_returns_200(self, client, structure_service):
-        structure_service.get_many.return_value = Page(items=[], next_cursor=None)
+        structure_service.read_many.return_value = Page(items=[], next_cursor=None)
         assert client.get("/api/v1/structures").status_code == 200
 
     def test_page_shape(self, client, structure_service):
-        structure_service.get_many.return_value = Page(items=[SAMPLE_STRUCTURE], next_cursor="c")
+        structure_service.read_many.return_value = Page(items=[SAMPLE_STRUCTURE], next_cursor="c")
         body = client.get("/api/v1/structures").json()
         assert "items" in body
         assert body["next_cursor"] == "c"
 
     def test_service_called_with_pagination(self, client, structure_service):
-        structure_service.get_many.return_value = Page(items=[], next_cursor=None)
+        structure_service.read_many.return_value = Page(items=[], next_cursor=None)
         client.get("/api/v1/structures?limit=5")
-        kwargs = structure_service.get_many.call_args.kwargs
+        kwargs = structure_service.read_many.call_args.kwargs
         assert kwargs["pagination"].limit == 5
 
     def test_invalid_fields_returns_422(self, client, structure_service):
-        structure_service.get_many.return_value = Page(items=[], next_cursor=None)
+        structure_service.read_many.return_value = Page(items=[], next_cursor=None)
         assert client.get("/api/v1/structures?_fields=not_a_field").status_code == 422
 
     def test_valid_fields_forwarded(self, client, structure_service):
-        structure_service.get_many.return_value = Page(items=[], next_cursor=None)
+        structure_service.read_many.return_value = Page(items=[], next_cursor=None)
         client.get("/api/v1/structures?_fields=name")
         # parse_fields always includes the id identity field.
-        assert structure_service.get_many.call_args.kwargs["fields"] == frozenset({"id", "name"})
+        assert structure_service.read_many.call_args.kwargs["fields"] == frozenset({"id", "name"})
 
     def test_content_fields_are_selectable(self, client, structure_service):
         # Regression for #4: structure content must be reachable via _fields (on the Out model).
-        structure_service.get_many.return_value = Page(items=[], next_cursor=None)
+        structure_service.read_many.return_value = Page(items=[], next_cursor=None)
         r = client.get("/api/v1/structures?_fields=lattice&_fields=sites&_fields=charge&_fields=cif")
         assert r.status_code == 200
-        assert structure_service.get_many.call_args.kwargs["fields"] == frozenset(
+        assert structure_service.read_many.call_args.kwargs["fields"] == frozenset(
             {"id", "lattice", "sites", "charge", "cif"}
         )
 
@@ -127,7 +127,7 @@ class TestStructuresInsert:
 
 class TestStructuresByIdRouting:
     def test_get_by_id_conventional_path(self, client, structure_service):
-        structure_service.get_one.return_value = SAMPLE_STRUCTURE
+        structure_service.read_one.return_value = SAMPLE_STRUCTURE
         assert client.get(f"/api/v1/structures/{PydanticObjectId()}").status_code == 200
 
     def test_delete_by_id_conventional_path(self, client, structure_service):
@@ -135,7 +135,7 @@ class TestStructuresByIdRouting:
         assert client.delete(f"/api/v1/structures/{PydanticObjectId()}").status_code == 200
 
     def test_patch_by_id_conventional_path(self, client, structure_service):
-        structure_service.patch_one.return_value = SAMPLE_STRUCTURE
+        structure_service.update_one.return_value = SAMPLE_STRUCTURE
         r = client.patch(f"/api/v1/structures/{PydanticObjectId()}", json={"name": "renamed"})
         assert r.status_code == 200
 
@@ -151,19 +151,19 @@ class TestStructuresByIdRouting:
 
 class TestTablesList:
     def test_empty_page_returns_200(self, client, table_service):
-        table_service.get_many.return_value = Page(items=[], next_cursor=None)
+        table_service.read_many.return_value = Page(items=[], next_cursor=None)
         assert client.get("/api/v1/tables").status_code == 200
 
     def test_page_shape(self, client, table_service):
-        table_service.get_many.return_value = Page(items=[SAMPLE_TABLE], next_cursor=None)
+        table_service.read_many.return_value = Page(items=[SAMPLE_TABLE], next_cursor=None)
         assert "items" in client.get("/api/v1/tables").json()
 
     def test_invalid_fields_returns_422(self, client, table_service):
-        table_service.get_many.return_value = Page(items=[], next_cursor=None)
+        table_service.read_many.return_value = Page(items=[], next_cursor=None)
         assert client.get("/api/v1/tables?_fields=nope").status_code == 422
 
     def test_default_fields_accepted(self, client, table_service):
-        table_service.get_many.return_value = Page(items=[], next_cursor=None)
+        table_service.read_many.return_value = Page(items=[], next_cursor=None)
         assert client.get("/api/v1/tables").status_code == 200
 
 
@@ -186,7 +186,7 @@ class TestTablesInsert:
 
 class TestTablesByIdRouting:
     def test_get_by_id_conventional_path(self, client, table_service):
-        table_service.get_one.return_value = SAMPLE_TABLE
+        table_service.read_one.return_value = SAMPLE_TABLE
         assert client.get(f"/api/v1/tables/{PydanticObjectId()}").status_code == 200
 
     def test_delete_by_id_conventional_path(self, client, table_service):
@@ -194,7 +194,7 @@ class TestTablesByIdRouting:
         assert client.delete(f"/api/v1/tables/{PydanticObjectId()}").status_code == 200
 
     def test_patch_by_id_conventional_path(self, client, table_service):
-        table_service.patch_one.return_value = SAMPLE_TABLE
+        table_service.update_one.return_value = SAMPLE_TABLE
         r = client.patch(f"/api/v1/tables/{PydanticObjectId()}", json={"name": "x"})
         assert r.status_code == 200
 
@@ -206,15 +206,15 @@ class TestTablesByIdRouting:
 
 class TestAttachmentsRouterWiring:
     def test_list_calls_attachment_service(self, client, attachment_service):
-        attachment_service.get_many.return_value = Page(items=[], next_cursor=None)
+        attachment_service.read_many.return_value = Page(items=[], next_cursor=None)
         r = client.get("/api/v1/attachments")
         assert r.status_code == 200
-        attachment_service.get_many.assert_awaited_once()
+        attachment_service.read_many.assert_awaited_once()
 
     def test_get_by_id_calls_attachment_service(self, client, attachment_service):
-        attachment_service.get_one.return_value = None
+        attachment_service.read_one.return_value = None
         client.get(f"/api/v1/attachments/{PydanticObjectId()}")
-        attachment_service.get_one.assert_awaited_once()
+        attachment_service.read_one.assert_awaited_once()
 
     def test_delete_by_id_calls_attachment_service(self, client, attachment_service):
         attachment_service.delete_one.return_value = ComponentDeleteResponse(num_deleted=1)
@@ -315,7 +315,7 @@ class TestComponentMutationsRequireAuth:
     def test_structure_patch_by_id_anon_401(self, client, structure_service):
         r = client.patch(f"/api/v1/structures/{PydanticObjectId()}", json={"name": "x"}, headers=FORCE_ANON_HEADERS)
         assert r.status_code == 401
-        structure_service.patch_one.assert_not_called()
+        structure_service.update_one.assert_not_called()
 
     def test_tables_delete_anon_401(self, client, table_service):
         r = client.delete("/api/v1/tables", headers=FORCE_ANON_HEADERS)
@@ -335,7 +335,7 @@ class TestComponentMutationsRequireAuth:
     def test_attachment_patch_by_id_anon_401(self, client, attachment_service):
         r = client.patch(f"/api/v1/attachments/{PydanticObjectId()}", json={"name": "x"}, headers=FORCE_ANON_HEADERS)
         assert r.status_code == 401
-        attachment_service.patch_one.assert_not_called()
+        attachment_service.update_one.assert_not_called()
 
     def test_tables_post_anon_401(self, client, table_service):
         # POST is guarded by require_writer, which rejects an anonymous caller with 401 (before the
@@ -352,10 +352,10 @@ class TestComponentMutationsRequireAuth:
     def test_table_patch_by_id_anon_401(self, client, table_service):
         r = client.patch(f"/api/v1/tables/{PydanticObjectId()}", json={"name": "x"}, headers=FORCE_ANON_HEADERS)
         assert r.status_code == 401
-        table_service.patch_one.assert_not_called()
+        table_service.update_one.assert_not_called()
 
     def test_structures_get_still_open_to_anon(self, client, structure_service):
-        structure_service.get_many.return_value = Page(items=[], next_cursor=None)
+        structure_service.read_many.return_value = Page(items=[], next_cursor=None)
         r = client.get("/api/v1/structures", headers=FORCE_ANON_HEADERS)
         assert r.status_code == 200
 

--- a/mpcontribs-api/tests/integration/test_component_routes.py
+++ b/mpcontribs-api/tests/integration/test_component_routes.py
@@ -327,6 +327,33 @@ class TestComponentMutationsRequireAuth:
         assert r.status_code == 401
         attachment_service.delete_one.assert_not_called()
 
+    def test_attachment_batch_delete_anon_401(self, client, attachment_service):
+        r = client.delete("/api/v1/attachments", headers=FORCE_ANON_HEADERS)
+        assert r.status_code == 401
+        attachment_service.delete_many.assert_not_called()
+
+    def test_attachment_patch_by_id_anon_401(self, client, attachment_service):
+        r = client.patch(f"/api/v1/attachments/{PydanticObjectId()}", json={"name": "x"}, headers=FORCE_ANON_HEADERS)
+        assert r.status_code == 401
+        attachment_service.patch_one.assert_not_called()
+
+    def test_tables_post_anon_401(self, client, table_service):
+        # POST is guarded by require_writer, which rejects an anonymous caller with 401 (before the
+        # non-writer 403 path is even reached).
+        r = client.post("/api/v1/tables", json=[], headers=FORCE_ANON_HEADERS)
+        assert r.status_code == 401
+        table_service.insert_many.assert_not_called()
+
+    def test_table_delete_by_id_anon_401(self, client, table_service):
+        r = client.delete(f"/api/v1/tables/{PydanticObjectId()}", headers=FORCE_ANON_HEADERS)
+        assert r.status_code == 401
+        table_service.delete_one.assert_not_called()
+
+    def test_table_patch_by_id_anon_401(self, client, table_service):
+        r = client.patch(f"/api/v1/tables/{PydanticObjectId()}", json={"name": "x"}, headers=FORCE_ANON_HEADERS)
+        assert r.status_code == 401
+        table_service.patch_one.assert_not_called()
+
     def test_structures_get_still_open_to_anon(self, client, structure_service):
         structure_service.get_many.return_value = Page(items=[], next_cursor=None)
         r = client.get("/api/v1/structures", headers=FORCE_ANON_HEADERS)

--- a/mpcontribs-api/tests/integration/test_consumers.py
+++ b/mpcontribs-api/tests/integration/test_consumers.py
@@ -38,11 +38,11 @@ def _requests(client):
     and admin.
     """
     return [
-        ("get_many", lambda h: client.get("/api/v1/admin/consumers", headers=h)),
-        ("get_one", lambda h: client.get("/api/v1/admin/consumers/507f1f77bcf86cd799439011", headers=h)),
+        ("read_many", lambda h: client.get("/api/v1/admin/consumers", headers=h)),
+        ("read_one", lambda h: client.get("/api/v1/admin/consumers/507f1f77bcf86cd799439011", headers=h)),
         ("insert_one", lambda h: client.post("/api/v1/admin/consumers", json={"consumer_id": "c-new"}, headers=h)),
         (
-            "patch_one",
+            "update_one",
             lambda h: client.patch(
                 "/api/v1/admin/consumers/507f1f77bcf86cd799439011",
                 json={"settings": {"max_projects": 5}},
@@ -59,7 +59,7 @@ def _requests(client):
 
 
 class TestConsumerRoutesRequireAdmin:
-    @pytest.mark.parametrize("label", ["get_many", "get_one", "insert_one", "patch_one", "delete_one"])
+    @pytest.mark.parametrize("label", ["read_many", "read_one", "insert_one", "update_one", "delete_one"])
     def test_anonymous_rejected_401(self, client, consumer_service, label):
         request = dict(_requests(client))[label]
         r = request(ANON_HEADERS)
@@ -67,7 +67,7 @@ class TestConsumerRoutesRequireAdmin:
         assert r.json()["error"]["code"] == "authentication_error"
         getattr(consumer_service, label).assert_not_called()
 
-    @pytest.mark.parametrize("label", ["get_many", "get_one", "insert_one", "patch_one", "delete_one"])
+    @pytest.mark.parametrize("label", ["read_many", "read_one", "insert_one", "update_one", "delete_one"])
     def test_authenticated_non_admin_rejected_403(self, client, consumer_service, label):
         # AUTHED_HEADERS is an authenticated, non-admin caller (alice / mp-team).
         request = dict(_requests(client))[label]
@@ -83,13 +83,13 @@ class TestConsumerRoutesRequireAdmin:
 
 class TestConsumerRoutesAdminAllowed:
     def test_admin_get_many_returns_200(self, client, consumer_service):
-        consumer_service.get_many.return_value = Page(items=[SAMPLE_CONSUMER], next_cursor=None)
+        consumer_service.read_many.return_value = Page(items=[SAMPLE_CONSUMER], next_cursor=None)
         r = client.get("/api/v1/admin/consumers", headers=ADMIN_HEADERS)
         assert r.status_code == 200
-        consumer_service.get_many.assert_called_once()
+        consumer_service.read_many.assert_called_once()
 
     def test_admin_get_one_returns_200(self, client, consumer_service):
-        consumer_service.get_one.return_value = SAMPLE_CONSUMER
+        consumer_service.read_one.return_value = SAMPLE_CONSUMER
         r = client.get("/api/v1/admin/consumers/507f1f77bcf86cd799439011", headers=ADMIN_HEADERS)
         assert r.status_code == 200
 
@@ -100,14 +100,14 @@ class TestConsumerRoutesAdminAllowed:
         consumer_service.insert_one.assert_called_once()
 
     def test_admin_patch_returns_200(self, client, consumer_service):
-        consumer_service.patch_one.return_value = SAMPLE_CONSUMER
+        consumer_service.update_one.return_value = SAMPLE_CONSUMER
         r = client.patch(
             "/api/v1/admin/consumers/507f1f77bcf86cd799439011",
             json={"settings": {"max_projects": 5}},
             headers=ADMIN_HEADERS,
         )
         assert r.status_code == 200
-        consumer_service.patch_one.assert_called_once()
+        consumer_service.update_one.assert_called_once()
 
     def test_admin_delete_returns_204(self, client, consumer_service):
         consumer_service.delete_one.return_value = None

--- a/mpcontribs-api/tests/integration/test_consumers.py
+++ b/mpcontribs-api/tests/integration/test_consumers.py
@@ -1,0 +1,116 @@
+from unittest.mock import AsyncMock
+
+import pytest
+
+from mpcontribs_api.domains.consumers.dependencies import get_consumer_service
+from mpcontribs_api.domains.consumers.models import ConsumerOut, ConsumerSettings
+from mpcontribs_api.pagination import Page
+from tests.integration.conftest import ADMIN_HEADERS, ANON_HEADERS, AUTHED_HEADERS
+
+# ---------------------------------------------------------------------------
+# The consumer-override routes are admin-only: the whole router carries
+# ``dependencies=[Depends(require_admin)]``. These tests guard that wiring — an
+# anonymous caller gets 401, an authenticated non-admin gets 403 — and confirm
+# the admin path reaches the (mocked) service. The service is mocked because the
+# guard runs *before* the service dependency resolves.
+# ---------------------------------------------------------------------------
+
+SAMPLE_CONSUMER = ConsumerOut(
+    id="507f1f77bcf86cd799439011",
+    consumer_id="test-consumer-id",
+    settings=ConsumerSettings(max_projects=3, max_unapproved_contributions_per_project=10, max_columns=20),
+)
+
+
+@pytest.fixture
+def consumer_service(test_app):
+    """Override the service every consumer route depends on with an async mock."""
+    service = AsyncMock()
+    test_app.dependency_overrides[get_consumer_service] = lambda: service
+    yield service
+    test_app.dependency_overrides.pop(get_consumer_service, None)
+
+
+def _requests(client):
+    """Every (label, callable) mutating/reading request under the consumers router.
+
+    Each callable takes the request headers so the same set can be replayed as anon, non-admin,
+    and admin.
+    """
+    return [
+        ("get_many", lambda h: client.get("/api/v1/admin/consumers", headers=h)),
+        ("get_one", lambda h: client.get("/api/v1/admin/consumers/507f1f77bcf86cd799439011", headers=h)),
+        ("insert_one", lambda h: client.post("/api/v1/admin/consumers", json={"consumer_id": "c-new"}, headers=h)),
+        (
+            "patch_one",
+            lambda h: client.patch(
+                "/api/v1/admin/consumers/507f1f77bcf86cd799439011",
+                json={"settings": {"max_projects": 5}},
+                headers=h,
+            ),
+        ),
+        ("delete_one", lambda h: client.delete("/api/v1/admin/consumers/507f1f77bcf86cd799439011", headers=h)),
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Admin-only guard: anonymous -> 401, authenticated non-admin -> 403
+# ---------------------------------------------------------------------------
+
+
+class TestConsumerRoutesRequireAdmin:
+    @pytest.mark.parametrize("label", ["get_many", "get_one", "insert_one", "patch_one", "delete_one"])
+    def test_anonymous_rejected_401(self, client, consumer_service, label):
+        request = dict(_requests(client))[label]
+        r = request(ANON_HEADERS)
+        assert r.status_code == 401
+        assert r.json()["error"]["code"] == "authentication_error"
+        getattr(consumer_service, label).assert_not_called()
+
+    @pytest.mark.parametrize("label", ["get_many", "get_one", "insert_one", "patch_one", "delete_one"])
+    def test_authenticated_non_admin_rejected_403(self, client, consumer_service, label):
+        # AUTHED_HEADERS is an authenticated, non-admin caller (alice / mp-team).
+        request = dict(_requests(client))[label]
+        r = request(AUTHED_HEADERS)
+        assert r.status_code == 403
+        getattr(consumer_service, label).assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Admin path reaches the service (happy-path wiring)
+# ---------------------------------------------------------------------------
+
+
+class TestConsumerRoutesAdminAllowed:
+    def test_admin_get_many_returns_200(self, client, consumer_service):
+        consumer_service.get_many.return_value = Page(items=[SAMPLE_CONSUMER], next_cursor=None)
+        r = client.get("/api/v1/admin/consumers", headers=ADMIN_HEADERS)
+        assert r.status_code == 200
+        consumer_service.get_many.assert_called_once()
+
+    def test_admin_get_one_returns_200(self, client, consumer_service):
+        consumer_service.get_one.return_value = SAMPLE_CONSUMER
+        r = client.get("/api/v1/admin/consumers/507f1f77bcf86cd799439011", headers=ADMIN_HEADERS)
+        assert r.status_code == 200
+
+    def test_admin_insert_returns_201(self, client, consumer_service):
+        consumer_service.insert_one.return_value = SAMPLE_CONSUMER
+        r = client.post("/api/v1/admin/consumers", json={"consumer_id": "test-consumer-id"}, headers=ADMIN_HEADERS)
+        assert r.status_code == 201
+        consumer_service.insert_one.assert_called_once()
+
+    def test_admin_patch_returns_200(self, client, consumer_service):
+        consumer_service.patch_one.return_value = SAMPLE_CONSUMER
+        r = client.patch(
+            "/api/v1/admin/consumers/507f1f77bcf86cd799439011",
+            json={"settings": {"max_projects": 5}},
+            headers=ADMIN_HEADERS,
+        )
+        assert r.status_code == 200
+        consumer_service.patch_one.assert_called_once()
+
+    def test_admin_delete_returns_204(self, client, consumer_service):
+        consumer_service.delete_one.return_value = None
+        r = client.delete("/api/v1/admin/consumers/507f1f77bcf86cd799439011", headers=ADMIN_HEADERS)
+        assert r.status_code == 204
+        consumer_service.delete_one.assert_called_once()

--- a/mpcontribs-api/tests/integration/test_contributions.py
+++ b/mpcontribs-api/tests/integration/test_contributions.py
@@ -1,21 +1,22 @@
 import pytest
 
 from mpcontribs_api.domains._shared.models import DeleteResponse
-from mpcontribs_api.domains.contributions.dependencies import get_scoped_contributions
+from mpcontribs_api.domains.contributions.dependencies import get_contribution_service
 from mpcontribs_api.domains.contributions.models import ContributionOut
 from mpcontribs_api.pagination import Page
 from tests.integration.conftest import ANON_HEADERS, AUTHED_HEADERS
 
 # ---------------------------------------------------------------------------
-# Fixture: inject mock repo for each test
+# Fixture: inject a mock ContributionService for each test. The routes depend
+# only on the service (which owns the repository), so the service is the seam.
 # ---------------------------------------------------------------------------
 
 
 @pytest.fixture
-def contribution_repo(test_app, mock_contribution_repo):
-    test_app.dependency_overrides[get_scoped_contributions] = lambda: mock_contribution_repo
-    yield mock_contribution_repo
-    test_app.dependency_overrides.pop(get_scoped_contributions, None)
+def contribution_service(test_app, mock_contribution_service):
+    test_app.dependency_overrides[get_contribution_service] = lambda: mock_contribution_service
+    yield mock_contribution_service
+    test_app.dependency_overrides.pop(get_contribution_service, None)
 
 
 SAMPLE_CONTRIBUTION = ContributionOut(
@@ -34,49 +35,49 @@ SAMPLE_CONTRIBUTION = ContributionOut(
 
 
 class TestListContributions:
-    def test_empty_page_returns_200(self, client, contribution_repo):
-        contribution_repo.get_many.return_value = Page(items=[], next_cursor=None)
+    def test_empty_page_returns_200(self, client, contribution_service):
+        contribution_service.get_many.return_value = Page(items=[], next_cursor=None)
         r = client.get("/api/v1/contributions", headers=AUTHED_HEADERS)
         assert r.status_code == 200
 
-    def test_response_has_page_shape(self, client, contribution_repo):
-        contribution_repo.get_many.return_value = Page(items=[], next_cursor=None)
+    def test_response_has_page_shape(self, client, contribution_service):
+        contribution_service.get_many.return_value = Page(items=[], next_cursor=None)
         body = client.get("/api/v1/contributions", headers=AUTHED_HEADERS).json()
         assert "items" in body
         assert "next_cursor" in body
 
-    def test_items_in_response(self, client, contribution_repo):
-        contribution_repo.get_many.return_value = Page(items=[SAMPLE_CONTRIBUTION], next_cursor=None)
+    def test_items_in_response(self, client, contribution_service):
+        contribution_service.get_many.return_value = Page(items=[SAMPLE_CONTRIBUTION], next_cursor=None)
         body = client.get("/api/v1/contributions", headers=AUTHED_HEADERS).json()
         assert len(body["items"]) == 1
 
-    def test_repo_called_with_pagination(self, client, contribution_repo):
-        contribution_repo.get_many.return_value = Page(items=[], next_cursor=None)
+    def test_repo_called_with_pagination(self, client, contribution_service):
+        contribution_service.get_many.return_value = Page(items=[], next_cursor=None)
         client.get("/api/v1/contributions", params={"limit": 10}, headers=AUTHED_HEADERS)
-        _, kwargs = contribution_repo.get_many.call_args
+        _, kwargs = contribution_service.get_many.call_args
         assert kwargs["pagination"].limit == 10
 
-    def test_fields_forwarded(self, client, contribution_repo):
-        contribution_repo.get_many.return_value = Page(items=[], next_cursor=None)
+    def test_fields_forwarded(self, client, contribution_service):
+        contribution_service.get_many.return_value = Page(items=[], next_cursor=None)
         client.get("/api/v1/contributions", params={"_fields": ["formula"]}, headers=AUTHED_HEADERS)
-        _, kwargs = contribution_repo.get_many.call_args
+        _, kwargs = contribution_service.get_many.call_args
         assert kwargs["fields"] is not None
         assert "formula" in kwargs["fields"]
 
-    def test_invalid_fields_returns_422(self, client, contribution_repo):
-        contribution_repo.get_many.return_value = Page(items=[], next_cursor=None)
+    def test_invalid_fields_returns_422(self, client, contribution_service):
+        contribution_service.get_many.return_value = Page(items=[], next_cursor=None)
         r = client.get("/api/v1/contributions", params={"_fields": "bad_field"}, headers=AUTHED_HEADERS)
         assert r.status_code == 422
 
-    def test_anonymous_can_list(self, client, contribution_repo):
-        contribution_repo.get_many.return_value = Page(items=[], next_cursor=None)
+    def test_anonymous_can_list(self, client, contribution_service):
+        contribution_service.get_many.return_value = Page(items=[], next_cursor=None)
         r = client.get("/api/v1/contributions", headers=ANON_HEADERS)
         assert r.status_code == 200
 
-    def test_filter_param_forwarded_to_repo(self, client, contribution_repo):
-        contribution_repo.get_many.return_value = Page(items=[], next_cursor=None)
+    def test_filter_param_forwarded_to_repo(self, client, contribution_service):
+        contribution_service.get_many.return_value = Page(items=[], next_cursor=None)
         client.get("/api/v1/contributions", params={"formula": "Fe2O3"}, headers=AUTHED_HEADERS)
-        contribution_repo.get_many.assert_called_once()
+        contribution_service.get_many.assert_called_once()
 
 
 # ---------------------------------------------------------------------------
@@ -85,20 +86,20 @@ class TestListContributions:
 
 
 class TestDeleteContributions:
-    def test_batch_delete_returns_200(self, client, contribution_repo):
-        contribution_repo.delete_many.return_value = DeleteResponse(num_deleted=0)
+    def test_batch_delete_returns_200(self, client, contribution_service):
+        contribution_service.delete_many.return_value = DeleteResponse(num_deleted=0)
         r = client.delete("/api/v1/contributions", headers=AUTHED_HEADERS)
         assert r.status_code == 200
 
-    def test_repo_delete_called(self, client, contribution_repo):
-        contribution_repo.delete_many.return_value = None
+    def test_repo_delete_called(self, client, contribution_service):
+        contribution_service.delete_many.return_value = None
         client.delete("/api/v1/contributions", headers=AUTHED_HEADERS)
-        contribution_repo.delete_many.assert_called_once()
+        contribution_service.delete_many.assert_called_once()
 
-    def test_filter_forwarded_to_repo(self, client, contribution_repo):
-        contribution_repo.delete_many.return_value = None
+    def test_filter_forwarded_to_repo(self, client, contribution_service):
+        contribution_service.delete_many.return_value = None
         client.delete("/api/v1/contributions", params={"is_public": "true"}, headers=AUTHED_HEADERS)
-        _, kwargs = contribution_repo.delete_many.call_args
+        _, kwargs = contribution_service.delete_many.call_args
         assert kwargs["filter"] is not None
 
 
@@ -110,15 +111,15 @@ class TestDeleteContributions:
 class TestStubEndpoints:
     """These endpoints are stubs in the repo but the routes must be wired."""
 
-    def test_post_contributions_route_exists(self, client, contribution_repo):
-        contribution_repo.insert_many.return_value = None
+    def test_post_contributions_route_exists(self, client, contribution_service):
+        contribution_service.insert_many.return_value = None
         r = client.post("/api/v1/contributions", json=[], headers=AUTHED_HEADERS)
         # Should reach the route (not 404/405) even if the handler is a stub
         assert r.status_code != 404
         assert r.status_code != 405
 
-    def test_put_contributions_route_exists(self, client, contribution_repo):
-        contribution_repo.upsert_many.return_value = None
+    def test_put_contributions_route_exists(self, client, contribution_service):
+        contribution_service.upsert_many.return_value = None
         r = client.put("/api/v1/contributions", json=[], headers=AUTHED_HEADERS)
         assert r.status_code != 404
         assert r.status_code != 405

--- a/mpcontribs-api/tests/integration/test_contributions.py
+++ b/mpcontribs-api/tests/integration/test_contributions.py
@@ -36,48 +36,48 @@ SAMPLE_CONTRIBUTION = ContributionOut(
 
 class TestListContributions:
     def test_empty_page_returns_200(self, client, contribution_service):
-        contribution_service.get_many.return_value = Page(items=[], next_cursor=None)
+        contribution_service.read_many.return_value = Page(items=[], next_cursor=None)
         r = client.get("/api/v1/contributions", headers=AUTHED_HEADERS)
         assert r.status_code == 200
 
     def test_response_has_page_shape(self, client, contribution_service):
-        contribution_service.get_many.return_value = Page(items=[], next_cursor=None)
+        contribution_service.read_many.return_value = Page(items=[], next_cursor=None)
         body = client.get("/api/v1/contributions", headers=AUTHED_HEADERS).json()
         assert "items" in body
         assert "next_cursor" in body
 
     def test_items_in_response(self, client, contribution_service):
-        contribution_service.get_many.return_value = Page(items=[SAMPLE_CONTRIBUTION], next_cursor=None)
+        contribution_service.read_many.return_value = Page(items=[SAMPLE_CONTRIBUTION], next_cursor=None)
         body = client.get("/api/v1/contributions", headers=AUTHED_HEADERS).json()
         assert len(body["items"]) == 1
 
     def test_repo_called_with_pagination(self, client, contribution_service):
-        contribution_service.get_many.return_value = Page(items=[], next_cursor=None)
+        contribution_service.read_many.return_value = Page(items=[], next_cursor=None)
         client.get("/api/v1/contributions", params={"limit": 10}, headers=AUTHED_HEADERS)
-        _, kwargs = contribution_service.get_many.call_args
+        _, kwargs = contribution_service.read_many.call_args
         assert kwargs["pagination"].limit == 10
 
     def test_fields_forwarded(self, client, contribution_service):
-        contribution_service.get_many.return_value = Page(items=[], next_cursor=None)
+        contribution_service.read_many.return_value = Page(items=[], next_cursor=None)
         client.get("/api/v1/contributions", params={"_fields": ["formula"]}, headers=AUTHED_HEADERS)
-        _, kwargs = contribution_service.get_many.call_args
+        _, kwargs = contribution_service.read_many.call_args
         assert kwargs["fields"] is not None
         assert "formula" in kwargs["fields"]
 
     def test_invalid_fields_returns_422(self, client, contribution_service):
-        contribution_service.get_many.return_value = Page(items=[], next_cursor=None)
+        contribution_service.read_many.return_value = Page(items=[], next_cursor=None)
         r = client.get("/api/v1/contributions", params={"_fields": "bad_field"}, headers=AUTHED_HEADERS)
         assert r.status_code == 422
 
     def test_anonymous_can_list(self, client, contribution_service):
-        contribution_service.get_many.return_value = Page(items=[], next_cursor=None)
+        contribution_service.read_many.return_value = Page(items=[], next_cursor=None)
         r = client.get("/api/v1/contributions", headers=ANON_HEADERS)
         assert r.status_code == 200
 
     def test_filter_param_forwarded_to_repo(self, client, contribution_service):
-        contribution_service.get_many.return_value = Page(items=[], next_cursor=None)
+        contribution_service.read_many.return_value = Page(items=[], next_cursor=None)
         client.get("/api/v1/contributions", params={"formula": "Fe2O3"}, headers=AUTHED_HEADERS)
-        contribution_service.get_many.assert_called_once()
+        contribution_service.read_many.assert_called_once()
 
 
 # ---------------------------------------------------------------------------

--- a/mpcontribs-api/tests/integration/test_contributions_routes.py
+++ b/mpcontribs-api/tests/integration/test_contributions_routes.py
@@ -128,11 +128,11 @@ class TestContributionByIdRouting:
     """RED: routes mount as /contributions{id} not /contributions/{id}."""
 
     def test_get_by_id_conventional_path(self, client, contribution_service):
-        contribution_service.get_one.return_value = SAMPLE_OUT
+        contribution_service.read_one.return_value = SAMPLE_OUT
         assert client.get(f"/api/v1/contributions/{PydanticObjectId()}").status_code == 200
 
     def test_patch_by_id_conventional_path(self, client, contribution_service):
-        contribution_service.patch_one.return_value = SAMPLE_OUT
+        contribution_service.update_one.return_value = SAMPLE_OUT
         r = client.patch(f"/api/v1/contributions/{PydanticObjectId()}", json={"formula": "H2O"})
         assert r.status_code == 200
 
@@ -242,7 +242,7 @@ class TestDownloadContributions:
 
 class TestBulkUpdateContributions:
     def test_publish_returns_200_and_summary(self, client, contribution_service):
-        contribution_service.patch_many.return_value = BulkUpdateSummary(matched=3, modified=2, projects=["mp-team"])
+        contribution_service.update_many.return_value = BulkUpdateSummary(matched=3, modified=2, projects=["mp-team"])
         r = client.patch("/api/v1/contributions", json={"is_public": True})
         assert r.status_code == 200
         assert r.json() == {"matched": 3, "modified": 2, "projects": ["mp-team"], "failed": []}
@@ -250,57 +250,57 @@ class TestBulkUpdateContributions:
     def test_forwards_update_and_filter(self, client, contribution_service):
         from mpcontribs_api.domains.contributions.models import ContributionFilter
 
-        contribution_service.patch_many.return_value = BulkUpdateSummary(matched=0, modified=0, projects=[])
+        contribution_service.update_many.return_value = BulkUpdateSummary(matched=0, modified=0, projects=[])
         client.patch("/api/v1/contributions?project=mp-team", json={"is_public": True})
-        contribution_service.patch_many.assert_awaited_once()
-        kwargs = contribution_service.patch_many.call_args.kwargs
+        contribution_service.update_many.assert_awaited_once()
+        kwargs = contribution_service.update_many.call_args.kwargs
         assert kwargs["update"].is_public is True
         assert isinstance(kwargs["filter"], ContributionFilter)
 
     def test_forwards_full_patch_body(self, client, contribution_service):
         # The bulk patch now accepts the same fields as the single-item patch (not just is_public).
-        contribution_service.patch_many.return_value = BulkUpdateSummary(matched=1, modified=1, projects=["mp-team"])
+        contribution_service.update_many.return_value = BulkUpdateSummary(matched=1, modified=1, projects=["mp-team"])
         r = client.patch("/api/v1/contributions", json={"formula": "Fe2O3", "data": {"y": 9.0}})
         assert r.status_code == 200
-        update = contribution_service.patch_many.call_args.kwargs["update"]
+        update = contribution_service.update_many.call_args.kwargs["update"]
         assert update.formula == "Fe2O3"
         assert update.data == {"y": 9.0}
 
     def test_empty_patch_is_accepted_as_noop(self, client, contribution_service):
         # An empty patch is a valid no-op (parity with the single-item patch), no longer a 422.
-        contribution_service.patch_many.return_value = BulkUpdateSummary(matched=0, modified=0, projects=[])
+        contribution_service.update_many.return_value = BulkUpdateSummary(matched=0, modified=0, projects=[])
         r = client.patch("/api/v1/contributions", json={})
         assert r.status_code == 200
-        contribution_service.patch_many.assert_awaited_once()
+        contribution_service.update_many.assert_awaited_once()
 
     def test_replace_data_query_param_forwarded(self, client, contribution_service):
         # ?replace_data=true opts a data patch out of the additive-merge default (whole-dict overwrite).
-        contribution_service.patch_many.return_value = BulkUpdateSummary(matched=0, modified=0, projects=[])
+        contribution_service.update_many.return_value = BulkUpdateSummary(matched=0, modified=0, projects=[])
         client.patch("/api/v1/contributions?replace_data=true", json={"data": {"y": 9.0}})
-        assert contribution_service.patch_many.call_args.kwargs["replace_data"] is True
+        assert contribution_service.update_many.call_args.kwargs["replace_data"] is True
 
     def test_replace_data_defaults_to_false(self, client, contribution_service):
         # Omitting the flag keeps the additive-merge default.
-        contribution_service.patch_many.return_value = BulkUpdateSummary(matched=0, modified=0, projects=[])
+        contribution_service.update_many.return_value = BulkUpdateSummary(matched=0, modified=0, projects=[])
         client.patch("/api/v1/contributions", json={"data": {"y": 9.0}})
-        assert contribution_service.patch_many.call_args.kwargs["replace_data"] is False
+        assert contribution_service.update_many.call_args.kwargs["replace_data"] is False
 
     def test_patch_by_id_forwards_is_public(self, client, contribution_service):
         # The single-contribution publish path: {"is_public": true} reaches the service patch.
-        contribution_service.patch_one.return_value = SAMPLE_OUT
+        contribution_service.update_one.return_value = SAMPLE_OUT
         r = client.patch(f"/api/v1/contributions/{PydanticObjectId()}", json={"is_public": True})
         assert r.status_code == 200
-        update = contribution_service.patch_one.call_args.kwargs["update"]
+        update = contribution_service.update_one.call_args.kwargs["update"]
         assert update.is_public is True
 
     def test_patch_by_id_forwards_replace_data(self, client, contribution_service):
         # The single-item path exposes the same overwrite opt-out as the bulk path.
-        contribution_service.patch_one.return_value = SAMPLE_OUT
+        contribution_service.update_one.return_value = SAMPLE_OUT
         r = client.patch(
             f"/api/v1/contributions/{PydanticObjectId()}?replace_data=true", json={"data": {"y": 9.0}}
         )
         assert r.status_code == 200
-        assert contribution_service.patch_one.call_args.kwargs["replace_data"] is True
+        assert contribution_service.update_one.call_args.kwargs["replace_data"] is True
 
 
 class TestContributionMutationsRequireAuth:
@@ -323,7 +323,7 @@ class TestContributionMutationsRequireAuth:
     def test_patch_collection_anon_401(self, client, contribution_service):
         r = client.patch("/api/v1/contributions", json={"is_public": True}, headers=FORCE_ANON_HEADERS)
         assert r.status_code == 401
-        contribution_service.patch_many.assert_not_called()
+        contribution_service.update_many.assert_not_called()
 
     def test_delete_by_id_anon_401(self, client, contribution_service):
         r = client.delete(f"/api/v1/contributions/{PydanticObjectId()}", headers=FORCE_ANON_HEADERS)
@@ -343,11 +343,11 @@ class TestContributionMutationsRequireAuth:
             f"/api/v1/contributions/{PydanticObjectId()}", json={"formula": "H2O"}, headers=FORCE_ANON_HEADERS
         )
         assert r.status_code == 401
-        contribution_service.patch_one.assert_not_called()
+        contribution_service.update_one.assert_not_called()
 
     def test_get_collection_still_open_to_anon(self, client, contribution_service):
         from mpcontribs_api.pagination import Page
 
-        contribution_service.get_many.return_value = Page(items=[], next_cursor=None)
+        contribution_service.read_many.return_value = Page(items=[], next_cursor=None)
         r = client.get("/api/v1/contributions", headers=FORCE_ANON_HEADERS)
         assert r.status_code == 200

--- a/mpcontribs-api/tests/integration/test_contributions_routes.py
+++ b/mpcontribs-api/tests/integration/test_contributions_routes.py
@@ -2,10 +2,7 @@ import pytest
 from beanie import PydanticObjectId
 
 from mpcontribs_api.domains._shared.bulk import BulkDeleteSummary, BulkUpdateSummary, BulkWriteSummary
-from mpcontribs_api.domains.contributions.dependencies import (
-    get_contribution_service,
-    get_scoped_contributions,
-)
+from mpcontribs_api.domains.contributions.dependencies import get_contribution_service
 from mpcontribs_api.domains.contributions.models import ContributionOut
 from mpcontribs_api.exceptions import NotFoundError
 from tests.integration.conftest import AUTHED_HEADERS, FORCE_ANON_HEADERS
@@ -24,13 +21,6 @@ def _authenticate(client):
     explicitly by TestContributionMutationsRequireAuth via FORCE_ANON_HEADERS.
     """
     client.headers.update(AUTHED_HEADERS)
-
-
-@pytest.fixture
-def contribution_repo(test_app, mock_contribution_repo):
-    test_app.dependency_overrides[get_scoped_contributions] = lambda: mock_contribution_repo
-    yield mock_contribution_repo
-    test_app.dependency_overrides.pop(get_scoped_contributions, None)
 
 
 @pytest.fixture
@@ -155,8 +145,8 @@ class TestContributionByIdRouting:
         contribution_service.delete_one.return_value = BulkDeleteSummary(num_deleted=1, num_children_deleted=0)
         assert client.delete(f"/api/v1/contributions/{PydanticObjectId()}").status_code == 200
 
-    def test_download_route_conventional_path(self, client, contribution_repo):
-        contribution_repo.download_contributions.return_value = iter([b"x"])
+    def test_download_route_conventional_path(self, client, contribution_service):
+        contribution_service.download.return_value = iter([b"x"])
         assert client.get("/api/v1/contributions/download/gz").status_code == 200
 
 
@@ -186,60 +176,60 @@ class TestDeleteContributionByIdWiring:
 
 
 class TestDownloadContributions:
-    def test_default_format_jsonl_returns_200(self, client, contribution_repo):
+    def test_default_format_jsonl_returns_200(self, client, contribution_service):
         # The contributions route gives `format` a default of JSONL, so it works
         # with the param omitted (component routes require it — see test_component_routes).
-        contribution_repo.download_contributions.return_value = iter([b"x"])
+        contribution_service.download.return_value = iter([b"x"])
         assert client.get("/api/v1/contributions/download/gz").status_code == 200
 
-    def test_csv_format_returns_200(self, client, contribution_repo):
-        contribution_repo.download_contributions.return_value = iter([b"x"])
+    def test_csv_format_returns_200(self, client, contribution_service):
+        contribution_service.download.return_value = iter([b"x"])
         assert client.get("/api/v1/contributions/download/gz?format=csv").status_code == 200
 
-    def test_body_is_streamed_bytes(self, client, contribution_repo):
-        contribution_repo.download_contributions.return_value = iter([b"abc", b"def"])
+    def test_body_is_streamed_bytes(self, client, contribution_service):
+        contribution_service.download.return_value = iter([b"abc", b"def"])
         assert client.get("/api/v1/contributions/download/gz").content == b"abcdef"
 
-    def test_invalid_short_mime_returns_422(self, client, contribution_repo):
-        contribution_repo.download_contributions.return_value = iter([b"x"])
+    def test_invalid_short_mime_returns_422(self, client, contribution_service):
+        contribution_service.download.return_value = iter([b"x"])
         # Only 'gz' is a valid ShortMimeFormat.
         assert client.get("/api/v1/contributions/download/zip").status_code == 422
 
-    def test_invalid_format_returns_422(self, client, contribution_repo):
-        contribution_repo.download_contributions.return_value = iter([b"x"])
+    def test_invalid_format_returns_422(self, client, contribution_service):
+        contribution_service.download.return_value = iter([b"x"])
         assert client.get("/api/v1/contributions/download/gz?format=xml").status_code == 422
 
-    def test_format_forwarded_to_repo(self, client, contribution_repo):
-        contribution_repo.download_contributions.return_value = iter([b"x"])
+    def test_format_forwarded_to_repo(self, client, contribution_service):
+        contribution_service.download.return_value = iter([b"x"])
         client.get("/api/v1/contributions/download/gz?format=csv")
-        assert contribution_repo.download_contributions.call_args.kwargs["format"] == "csv"
+        assert contribution_service.download.call_args.kwargs["format"] == "csv"
 
-    def test_fields_parsed_and_forwarded(self, client, contribution_repo):
-        contribution_repo.download_contributions.return_value = iter([b"x"])
+    def test_fields_parsed_and_forwarded(self, client, contribution_service):
+        contribution_service.download.return_value = iter([b"x"])
         client.get("/api/v1/contributions/download/gz?_fields=project")
-        forwarded = contribution_repo.download_contributions.call_args.kwargs["fields"]
+        forwarded = contribution_service.download.call_args.kwargs["fields"]
         assert "project" in forwarded
 
-    def test_invalid_fields_returns_422(self, client, contribution_repo):
-        contribution_repo.download_contributions.return_value = iter([b"x"])
+    def test_invalid_fields_returns_422(self, client, contribution_service):
+        contribution_service.download.return_value = iter([b"x"])
         assert client.get("/api/v1/contributions/download/gz?_fields=not_a_field").status_code == 422
 
-    def test_filename_names_the_contributions_resource(self, client, contribution_repo):
+    def test_filename_names_the_contributions_resource(self, client, contribution_service):
         """The attachment filename references the contributions resource."""
-        contribution_repo.download_contributions.return_value = iter([b"x"])
+        contribution_service.download.return_value = iter([b"x"])
         cd = client.get("/api/v1/contributions/download/gz").headers["content-disposition"]
         assert "contributions" in cd
 
-    def test_csv_filename_uses_csv_extension(self, client, contribution_repo):
+    def test_csv_filename_uses_csv_extension(self, client, contribution_service):
         """A CSV download is named *.csv.gz, matching the requested format."""
-        contribution_repo.download_contributions.return_value = iter([b"x"])
+        contribution_service.download.return_value = iter([b"x"])
         cd = client.get("/api/v1/contributions/download/gz?format=csv").headers["content-disposition"]
         assert ".csv.gz" in cd
 
-    def test_repo_error_surfaces_as_uniform_json(self, client, contribution_repo):
+    def test_repo_error_surfaces_as_uniform_json(self, client, contribution_service):
         # An AppError raised while the repo builds the download surfaces through the
         # registered exception handler as the uniform error envelope (not a 500 traceback).
-        contribution_repo.download_contributions.side_effect = NotFoundError("nothing to download")
+        contribution_service.download.side_effect = NotFoundError("nothing to download")
         r = client.get("/api/v1/contributions/download/gz")
         assert r.status_code == 404
         assert r.json()["error"]["code"] == "not_found"
@@ -325,10 +315,10 @@ class TestContributionMutationsRequireAuth:
         assert r.status_code == 401
         contribution_service.upsert_many.assert_not_called()
 
-    def test_delete_collection_anon_401(self, client, contribution_repo):
+    def test_delete_collection_anon_401(self, client, contribution_service):
         r = client.delete("/api/v1/contributions", headers=FORCE_ANON_HEADERS)
         assert r.status_code == 401
-        contribution_repo.delete_many.assert_not_called()
+        contribution_service.delete_many.assert_not_called()
 
     def test_patch_collection_anon_401(self, client, contribution_service):
         r = client.patch("/api/v1/contributions", json={"is_public": True}, headers=FORCE_ANON_HEADERS)
@@ -355,9 +345,9 @@ class TestContributionMutationsRequireAuth:
         assert r.status_code == 401
         contribution_service.patch_one.assert_not_called()
 
-    def test_get_collection_still_open_to_anon(self, client, contribution_repo):
+    def test_get_collection_still_open_to_anon(self, client, contribution_service):
         from mpcontribs_api.pagination import Page
 
-        contribution_repo.get_many.return_value = Page(items=[], next_cursor=None)
+        contribution_service.get_many.return_value = Page(items=[], next_cursor=None)
         r = client.get("/api/v1/contributions", headers=FORCE_ANON_HEADERS)
         assert r.status_code == 200

--- a/mpcontribs-api/tests/integration/test_initiatives.py
+++ b/mpcontribs-api/tests/integration/test_initiatives.py
@@ -73,12 +73,12 @@ class TestInsert:
 
 class TestGet:
     def test_list_returns_200(self, client, initiative_service):
-        initiative_service.get_many.return_value = Page(items=[], next_cursor=None)
+        initiative_service.read_many.return_value = Page(items=[], next_cursor=None)
         r = client.get("/api/v1/initiatives", headers=AUTHED_HEADERS)
         assert r.status_code == 200
 
     def test_get_by_slug_returns_200(self, client, initiative_service):
-        initiative_service.get_one.return_value = _stored()
+        initiative_service.read_one.return_value = _stored()
         r = client.get("/api/v1/initiatives/battery-genome", headers=AUTHED_HEADERS)
         assert r.status_code == 200
         assert r.json()["slug"] == "battery-genome"
@@ -91,7 +91,7 @@ class TestGet:
 
 class TestPatch:
     def test_patch_returns_200(self, client, initiative_service):
-        initiative_service.patch_one.return_value = _stored(name="Renamed")
+        initiative_service.update_one.return_value = _stored(name="Renamed")
         r = client.patch(
             "/api/v1/initiatives/battery-genome",
             json={"name": "Renamed"},
@@ -109,7 +109,7 @@ class TestPatch:
         assert r.status_code == 401
 
     def test_not_found_propagates_404(self, client, initiative_service):
-        initiative_service.patch_one.side_effect = NotFoundError("nope")
+        initiative_service.update_one.side_effect = NotFoundError("nope")
         r = client.patch(
             "/api/v1/initiatives/missing",
             json={"name": "Renamed"},

--- a/mpcontribs-api/tests/integration/test_initiatives.py
+++ b/mpcontribs-api/tests/integration/test_initiatives.py
@@ -3,7 +3,7 @@ from unittest.mock import AsyncMock
 
 import pytest
 
-from mpcontribs_api.domains.initiatives.dependencies import get_initiative_repository
+from mpcontribs_api.domains.initiatives.dependencies import get_initiative_service
 from mpcontribs_api.exceptions import NotFoundError
 from mpcontribs_api.pagination import Page
 from tests.integration.conftest import AUTHED_HEADERS, FORCE_ANON_HEADERS
@@ -12,11 +12,11 @@ SAMPLE_OID = "6eb7cf5a86d9755df3a6c593"
 
 
 @pytest.fixture
-def initiative_repo(test_app):
-    repo = AsyncMock()
-    test_app.dependency_overrides[get_initiative_repository] = lambda: repo
-    yield repo
-    test_app.dependency_overrides.pop(get_initiative_repository, None)
+def initiative_service(test_app):
+    service = AsyncMock()
+    test_app.dependency_overrides[get_initiative_service] = lambda: service
+    yield service
+    test_app.dependency_overrides.pop(get_initiative_service, None)
 
 
 def _stored(**overrides):
@@ -39,8 +39,8 @@ def _stored(**overrides):
 
 
 class TestInsert:
-    def test_returns_201_and_echoes_id(self, client, initiative_repo):
-        initiative_repo.insert_one.return_value = _stored()
+    def test_returns_201_and_echoes_id(self, client, initiative_service):
+        initiative_service.insert_one.return_value = _stored()
         r = client.post(
             "/api/v1/initiatives",
             json={"slug": "battery-genome", "name": "Battery Genome"},
@@ -49,7 +49,7 @@ class TestInsert:
         assert r.status_code == 201
         assert r.json()["id"] == SAMPLE_OID
 
-    def test_anonymous_rejected_401(self, client, initiative_repo):
+    def test_anonymous_rejected_401(self, client, initiative_service):
         r = client.post(
             "/api/v1/initiatives",
             json={"slug": "battery-genome", "name": "Battery Genome"},
@@ -57,7 +57,7 @@ class TestInsert:
         )
         assert r.status_code == 401
 
-    def test_invalid_slug_returns_422(self, client, initiative_repo):
+    def test_invalid_slug_returns_422(self, client, initiative_service):
         r = client.post(
             "/api/v1/initiatives",
             json={"slug": "Not A Slug!", "name": "x"},
@@ -72,13 +72,13 @@ class TestInsert:
 
 
 class TestGet:
-    def test_list_returns_200(self, client, initiative_repo):
-        initiative_repo.get_many.return_value = Page(items=[], next_cursor=None)
+    def test_list_returns_200(self, client, initiative_service):
+        initiative_service.get_many.return_value = Page(items=[], next_cursor=None)
         r = client.get("/api/v1/initiatives", headers=AUTHED_HEADERS)
         assert r.status_code == 200
 
-    def test_get_by_slug_returns_200(self, client, initiative_repo):
-        initiative_repo.get_one.return_value = _stored()
+    def test_get_by_slug_returns_200(self, client, initiative_service):
+        initiative_service.get_one.return_value = _stored()
         r = client.get("/api/v1/initiatives/battery-genome", headers=AUTHED_HEADERS)
         assert r.status_code == 200
         assert r.json()["slug"] == "battery-genome"
@@ -90,8 +90,8 @@ class TestGet:
 
 
 class TestPatch:
-    def test_patch_returns_200(self, client, initiative_repo):
-        initiative_repo.patch_one.return_value = _stored(name="Renamed")
+    def test_patch_returns_200(self, client, initiative_service):
+        initiative_service.patch_one.return_value = _stored(name="Renamed")
         r = client.patch(
             "/api/v1/initiatives/battery-genome",
             json={"name": "Renamed"},
@@ -100,7 +100,7 @@ class TestPatch:
         assert r.status_code == 200
         assert r.json()["name"] == "Renamed"
 
-    def test_anonymous_rejected_401(self, client, initiative_repo):
+    def test_anonymous_rejected_401(self, client, initiative_service):
         r = client.patch(
             "/api/v1/initiatives/battery-genome",
             json={"name": "Renamed"},
@@ -108,8 +108,8 @@ class TestPatch:
         )
         assert r.status_code == 401
 
-    def test_not_found_propagates_404(self, client, initiative_repo):
-        initiative_repo.patch_one.side_effect = NotFoundError("nope")
+    def test_not_found_propagates_404(self, client, initiative_service):
+        initiative_service.patch_one.side_effect = NotFoundError("nope")
         r = client.patch(
             "/api/v1/initiatives/missing",
             json={"name": "Renamed"},
@@ -124,12 +124,12 @@ class TestPatch:
 
 
 class TestDelete:
-    def test_delete_returns_204(self, client, initiative_repo):
-        initiative_repo.delete_one.return_value = None
+    def test_delete_returns_204(self, client, initiative_service):
+        initiative_service.delete_one.return_value = None
         r = client.delete("/api/v1/initiatives/battery-genome", headers=AUTHED_HEADERS)
         assert r.status_code == 204
         assert r.content == b""
 
-    def test_anonymous_rejected_401(self, client, initiative_repo):
+    def test_anonymous_rejected_401(self, client, initiative_service):
         r = client.delete("/api/v1/initiatives/battery-genome", headers=FORCE_ANON_HEADERS)
         assert r.status_code == 401

--- a/mpcontribs-api/tests/integration/test_project_groups.py
+++ b/mpcontribs-api/tests/integration/test_project_groups.py
@@ -99,7 +99,7 @@ class TestProjectGroupMutationsRequireAuth:
     def test_anonymous_patch_item_returns_401(self, client, group_service):
         r = client.patch("/api/v1/project_groups/item", params=_Q, json={"description": "x"}, headers=ANON_HEADERS)
         assert r.status_code == 401
-        group_service.patch_one.assert_not_called()
+        group_service.update_one.assert_not_called()
 
     def test_anonymous_delete_item_returns_401(self, client, group_service):
         r = client.delete("/api/v1/project_groups/item", params=_Q, headers=ANON_HEADERS)

--- a/mpcontribs-api/tests/integration/test_project_groups.py
+++ b/mpcontribs-api/tests/integration/test_project_groups.py
@@ -4,7 +4,7 @@ from unittest.mock import AsyncMock
 import pytest
 
 from mpcontribs_api.domains.project_groups.dependencies import get_project_group_service
-from tests.integration.conftest import AUTHED_HEADERS
+from tests.integration.conftest import ANON_HEADERS, AUTHED_HEADERS
 
 # A valid 24-char hex ObjectId string (ProjectGroupOut.id is a PydanticObjectId).
 SAMPLE_OID = "6eb7cf5a86d9755df3a6c593"
@@ -74,3 +74,61 @@ class TestInsertProjectGroupResponse:
         assert body["name"] == "echo-group"
         assert body["owner"] == "google:alice@example.com"
         assert body["is_public"] is True
+
+
+# ---------------------------------------------------------------------------
+# Authentication enforcement: every mutating route requires an authenticated
+# user (each carries ``dependencies=[Depends(require_user)]``). An anonymous
+# caller must be rejected with 401 before the service is ever touched.
+# ---------------------------------------------------------------------------
+
+_Q = {"name": "my-group", "owner": "google:alice@example.com"}
+_REFS = {"project_ids": ["mp-x"]}
+
+
+class TestProjectGroupMutationsRequireAuth:
+    def test_anonymous_post_returns_401(self, client, group_service):
+        r = client.post(
+            "/api/v1/project_groups",
+            json={"name": "g", "owner": "google:alice@example.com", "description": "d", "projects": []},
+            headers=ANON_HEADERS,
+        )
+        assert r.status_code == 401
+        group_service.insert_one.assert_not_called()
+
+    def test_anonymous_patch_item_returns_401(self, client, group_service):
+        r = client.patch("/api/v1/project_groups/item", params=_Q, json={"description": "x"}, headers=ANON_HEADERS)
+        assert r.status_code == 401
+        group_service.patch_one.assert_not_called()
+
+    def test_anonymous_delete_item_returns_401(self, client, group_service):
+        r = client.delete("/api/v1/project_groups/item", params=_Q, headers=ANON_HEADERS)
+        assert r.status_code == 401
+        group_service.delete_one.assert_not_called()
+
+    def test_anonymous_bulk_delete_returns_401(self, client, group_service):
+        r = client.delete("/api/v1/project_groups", params={"owner": "google:alice@example.com"}, headers=ANON_HEADERS)
+        assert r.status_code == 401
+        group_service.delete_many.assert_not_called()
+
+    def test_anonymous_add_projects_by_identifiers_returns_401(self, client, group_service):
+        r = client.post("/api/v1/project_groups/item/projects", params=_Q, json=_REFS, headers=ANON_HEADERS)
+        assert r.status_code == 401
+        group_service.add_projects.assert_not_called()
+
+    def test_anonymous_delete_projects_by_identifiers_returns_401(self, client, group_service):
+        r = client.request(
+            "DELETE", "/api/v1/project_groups/item/projects", params=_Q, json=_REFS, headers=ANON_HEADERS
+        )
+        assert r.status_code == 401
+        group_service.delete_projects.assert_not_called()
+
+    def test_anonymous_add_projects_by_id_returns_401(self, client, group_service):
+        r = client.post("/api/v1/project_groups/gid/projects", json=_REFS, headers=ANON_HEADERS)
+        assert r.status_code == 401
+        group_service.add_projects.assert_not_called()
+
+    def test_anonymous_delete_projects_by_id_returns_401(self, client, group_service):
+        r = client.request("DELETE", "/api/v1/project_groups/gid/projects", json=_REFS, headers=ANON_HEADERS)
+        assert r.status_code == 401
+        group_service.delete_projects.assert_not_called()

--- a/mpcontribs-api/tests/integration/test_projects.py
+++ b/mpcontribs-api/tests/integration/test_projects.py
@@ -50,18 +50,18 @@ def project_service(test_app):
 
 class TestListProjects:
     def test_empty_page_returns_200(self, client, project_service):
-        project_service.get_many.return_value = Page(items=[], next_cursor=None)
+        project_service.read_many.return_value = Page(items=[], next_cursor=None)
         r = client.get("/api/v1/projects", headers=AUTHED_HEADERS)
         assert r.status_code == 200
 
     def test_response_has_items_and_cursor(self, client, project_service):
-        project_service.get_many.return_value = Page(items=[], next_cursor=None)
+        project_service.read_many.return_value = Page(items=[], next_cursor=None)
         body = client.get("/api/v1/projects", headers=AUTHED_HEADERS).json()
         assert "items" in body
         assert "next_cursor" in body
 
     def test_items_returned_in_response(self, client, project_service):
-        project_service.get_many.return_value = Page(items=[SAMPLE_PROJECT], next_cursor=None)
+        project_service.read_many.return_value = Page(items=[SAMPLE_PROJECT], next_cursor=None)
         body = client.get("/api/v1/projects", headers=AUTHED_HEADERS).json()
         assert len(body["items"]) == 1
 
@@ -69,29 +69,29 @@ class TestListProjects:
         from mpcontribs_api.pagination import encode_cursor
 
         cursor = encode_cursor("mp-sample")
-        project_service.get_many.return_value = Page(items=[SAMPLE_PROJECT], next_cursor=cursor)
+        project_service.read_many.return_value = Page(items=[SAMPLE_PROJECT], next_cursor=cursor)
         body = client.get("/api/v1/projects", headers=AUTHED_HEADERS).json()
         assert body["next_cursor"] == cursor
 
     def test_repo_get_project_called(self, client, project_service):
-        project_service.get_many.return_value = Page(items=[], next_cursor=None)
+        project_service.read_many.return_value = Page(items=[], next_cursor=None)
         client.get("/api/v1/projects", headers=AUTHED_HEADERS)
-        project_service.get_many.assert_called_once()
+        project_service.read_many.assert_called_once()
 
     def test_anonymous_user_reaches_route(self, client, project_service):
-        project_service.get_many.return_value = Page(items=[], next_cursor=None)
+        project_service.read_many.return_value = Page(items=[], next_cursor=None)
         r = client.get("/api/v1/projects", headers=ANON_HEADERS)
         assert r.status_code == 200
 
     def test_invalid_fields_param_returns_422(self, client, project_service):
-        project_service.get_many.return_value = Page(items=[], next_cursor=None)
+        project_service.read_many.return_value = Page(items=[], next_cursor=None)
         r = client.get("/api/v1/projects", params={"_fields": "nonexistent_field"}, headers=AUTHED_HEADERS)
         assert r.status_code == 422
 
     def test_limit_param_forwarded(self, client, project_service):
-        project_service.get_many.return_value = Page(items=[], next_cursor=None)
+        project_service.read_many.return_value = Page(items=[], next_cursor=None)
         client.get("/api/v1/projects", params={"limit": 5}, headers=AUTHED_HEADERS)
-        _, kwargs = project_service.get_many.call_args
+        _, kwargs = project_service.read_many.call_args
         assert kwargs["pagination"].limit == 5
 
     def test_limit_above_max_returns_422(self, client, project_service):
@@ -99,9 +99,9 @@ class TestListProjects:
         assert r.status_code == 422
 
     def test_valid_fields_param_forwarded(self, client, project_service):
-        project_service.get_many.return_value = Page(items=[], next_cursor=None)
+        project_service.read_many.return_value = Page(items=[], next_cursor=None)
         client.get("/api/v1/projects", params=[("_fields", "title"), ("_fields", "authors")], headers=AUTHED_HEADERS)
-        _, kwargs = project_service.get_many.call_args
+        _, kwargs = project_service.read_many.call_args
         assert kwargs["fields"] is not None
         assert "title" in kwargs["fields"]
 
@@ -114,30 +114,30 @@ class TestListProjects:
 class TestFieldSelectionSemantics:
     def test_omitted_fields_forwards_route_defaults(self, client, project_service):
         # No _fields query param -> the route's default_fields() (identity + summary columns).
-        project_service.get_many.return_value = Page(items=[], next_cursor=None)
+        project_service.read_many.return_value = Page(items=[], next_cursor=None)
         client.get("/api/v1/projects", headers=AUTHED_HEADERS)
-        _, kwargs = project_service.get_many.call_args
+        _, kwargs = project_service.read_many.call_args
         assert kwargs["fields"] == frozenset(ProjectOut.default_fields())
 
     def test_empty_fields_forwards_identity_only(self, client, project_service):
         # `?_fields=` (present but empty) -> only the identity field, the cheap "just ids" call.
-        project_service.get_many.return_value = Page(items=[], next_cursor=None)
+        project_service.read_many.return_value = Page(items=[], next_cursor=None)
         client.get("/api/v1/projects", params={"_fields": ""}, headers=AUTHED_HEADERS)
-        _, kwargs = project_service.get_many.call_args
+        _, kwargs = project_service.read_many.call_args
         assert kwargs["fields"] == frozenset({"id"})
 
     def test_all_sentinel_forwards_none(self, client, project_service):
         # `?_fields=_all` -> None, i.e. project every field.
-        project_service.get_many.return_value = Page(items=[], next_cursor=None)
+        project_service.read_many.return_value = Page(items=[], next_cursor=None)
         client.get("/api/v1/projects", params={"_fields": "_all"}, headers=AUTHED_HEADERS)
-        _, kwargs = project_service.get_many.call_args
+        _, kwargs = project_service.read_many.call_args
         assert kwargs["fields"] is None
 
     def test_empty_fields_detail_forwards_identity_only(self, client, project_service):
         # Same three-way rule on the detail route (now served through ProjectService).
-        project_service.get_one.return_value = SAMPLE_PROJECT
+        project_service.read_one.return_value = SAMPLE_PROJECT
         client.get("/api/v1/projects/mp-sample", params={"_fields": ""}, headers=AUTHED_HEADERS)
-        _, kwargs = project_service.get_one.call_args
+        _, kwargs = project_service.read_one.call_args
         assert kwargs["fields"] == frozenset({"id"})
 
 
@@ -148,42 +148,42 @@ class TestFieldSelectionSemantics:
 
 class TestGetProjectById:
     def test_found_returns_200(self, client, project_service):
-        project_service.get_one.return_value = SAMPLE_PROJECT
+        project_service.read_one.return_value = SAMPLE_PROJECT
         r = client.get("/api/v1/projects/mp-sample", headers=AUTHED_HEADERS)
         assert r.status_code == 200
 
     def test_response_contains_project_data(self, client, project_service):
-        project_service.get_one.return_value = SAMPLE_PROJECT
+        project_service.read_one.return_value = SAMPLE_PROJECT
         body = client.get("/api/v1/projects/mp-sample", headers=AUTHED_HEADERS).json()
         assert body["id"] == "mp-sample"
         assert body["title"] == "Sample Project"
 
     def test_not_found_returns_404(self, client, project_service):
-        project_service.get_one.side_effect = NotFoundError("project not found")
+        project_service.read_one.side_effect = NotFoundError("project not found")
         r = client.get("/api/v1/projects/nonexistent", headers=AUTHED_HEADERS)
         assert r.status_code == 404
 
     def test_not_found_error_code(self, client, project_service):
-        project_service.get_one.side_effect = NotFoundError("project not found")
+        project_service.read_one.side_effect = NotFoundError("project not found")
         body = client.get("/api/v1/projects/nonexistent", headers=AUTHED_HEADERS).json()
         assert body["error"]["code"] == "not_found"
 
     def test_id_forwarded_to_service(self, client, project_service):
-        project_service.get_one.return_value = SAMPLE_PROJECT
+        project_service.read_one.return_value = SAMPLE_PROJECT
         client.get("/api/v1/projects/my-specific-id", headers=AUTHED_HEADERS)
-        assert project_service.get_one.call_args.args[0] == {"id": "my-specific-id"}
+        assert project_service.read_one.call_args.args[0] == {"id": "my-specific-id"}
 
     def test_fields_param_forwarded(self, client, project_service):
-        project_service.get_one.return_value = SAMPLE_PROJECT
+        project_service.read_one.return_value = SAMPLE_PROJECT
         client.get("/api/v1/projects/mp-sample", params={"_fields": "title"}, headers=AUTHED_HEADERS)
-        _, kwargs = project_service.get_one.call_args
+        _, kwargs = project_service.read_one.call_args
         assert kwargs["fields"] is not None
         assert "title" in kwargs["fields"]
 
     def test_no_fields_param_uses_default_fields(self, client, project_service):
-        project_service.get_one.return_value = SAMPLE_PROJECT
+        project_service.read_one.return_value = SAMPLE_PROJECT
         client.get("/api/v1/projects/mp-sample", headers=AUTHED_HEADERS)
-        _, kwargs = project_service.get_one.call_args
+        _, kwargs = project_service.read_one.call_args
         assert kwargs["fields"] is not None
         assert "title" in kwargs["fields"]
 
@@ -195,7 +195,7 @@ class TestGetProjectById:
 
 class TestPatchProject:
     def test_valid_patch_returns_200(self, client, project_service):
-        project_service.patch_one.return_value = SAMPLE_PROJECT
+        project_service.update_one.return_value = SAMPLE_PROJECT
         r = client.patch(
             "/api/v1/projects/mp-sample",
             json={"title": "Updated Title"},
@@ -205,7 +205,7 @@ class TestPatchProject:
 
     def test_patch_response_is_project_out(self, client, project_service):
         updated = ProjectOut(id="mp-sample", title="Updated Title")
-        project_service.patch_one.return_value = updated
+        project_service.update_one.return_value = updated
         body = client.patch(
             "/api/v1/projects/mp-sample",
             json={"title": "Updated Title"},
@@ -214,7 +214,7 @@ class TestPatchProject:
         assert body["title"] == "Updated Title"
 
     def test_not_found_returns_404(self, client, project_service):
-        project_service.patch_one.side_effect = NotFoundError("not found")
+        project_service.update_one.side_effect = NotFoundError("not found")
         r = client.patch(
             "/api/v1/projects/missing",
             json={"title": "x" * 5},
@@ -231,13 +231,13 @@ class TestPatchProject:
         assert r.status_code == 422
 
     def test_id_and_update_forwarded_to_service(self, client, project_service):
-        project_service.patch_one.return_value = SAMPLE_PROJECT
+        project_service.update_one.return_value = SAMPLE_PROJECT
         client.patch(
             "/api/v1/projects/mp-sample",
             json={"title": "New Name"},
             headers=AUTHED_HEADERS,
         )
-        call = project_service.patch_one.call_args
+        call = project_service.update_one.call_args
         assert call.args[0] == {"id": "mp-sample"}
         assert call.kwargs["update"].title == "New Name"
 
@@ -325,7 +325,7 @@ class TestProjectMutationsRequireAuth:
     def test_anonymous_patch_returns_401(self, client, project_service):
         r = client.patch("/api/v1/projects/mp-sample", json={"title": "Updated Title"}, headers=ANON_HEADERS)
         assert r.status_code == 401
-        project_service.patch_one.assert_not_called()
+        project_service.update_one.assert_not_called()
 
     def test_anonymous_delete_returns_401(self, client, project_service):
         r = client.delete("/api/v1/projects/mp-sample", headers=ANON_HEADERS)

--- a/mpcontribs-api/tests/integration/test_projects.py
+++ b/mpcontribs-api/tests/integration/test_projects.py
@@ -2,7 +2,7 @@ from unittest.mock import AsyncMock
 
 import pytest
 
-from mpcontribs_api.domains.projects.dependencies import get_project_service, get_scoped_projects
+from mpcontribs_api.domains.projects.dependencies import get_project_service
 from mpcontribs_api.domains.projects.models import ProjectOut, Stats
 from mpcontribs_api.exceptions import ConflictError, NotFoundError
 from mpcontribs_api.pagination import Page
@@ -28,20 +28,15 @@ SAMPLE_PROJECT = ProjectOut.model_validate(
 
 
 # ---------------------------------------------------------------------------
-# Fixture: inject mock repo into the test_app for the duration of each test
+# Fixture: inject a mock ProjectService into the test_app for each test. The
+# routes depend only on the service, which owns the repository, so overriding
+# the service is the single seam these route tests need.
 # ---------------------------------------------------------------------------
 
 
 @pytest.fixture
-def project_repo(test_app, mock_project_repo):
-    test_app.dependency_overrides[get_scoped_projects] = lambda: mock_project_repo
-    yield mock_project_repo
-    test_app.dependency_overrides.pop(get_scoped_projects, None)
-
-
-@pytest.fixture
 def project_service(test_app):
-    """Override the assignment service the PATCH route depends on with an async mock."""
+    """Override the service every project route depends on with an async mock."""
     service = AsyncMock()
     test_app.dependency_overrides[get_project_service] = lambda: service
     yield service
@@ -54,59 +49,59 @@ def project_service(test_app):
 
 
 class TestListProjects:
-    def test_empty_page_returns_200(self, client, project_repo):
-        project_repo.get_many.return_value = Page(items=[], next_cursor=None)
+    def test_empty_page_returns_200(self, client, project_service):
+        project_service.get_many.return_value = Page(items=[], next_cursor=None)
         r = client.get("/api/v1/projects", headers=AUTHED_HEADERS)
         assert r.status_code == 200
 
-    def test_response_has_items_and_cursor(self, client, project_repo):
-        project_repo.get_many.return_value = Page(items=[], next_cursor=None)
+    def test_response_has_items_and_cursor(self, client, project_service):
+        project_service.get_many.return_value = Page(items=[], next_cursor=None)
         body = client.get("/api/v1/projects", headers=AUTHED_HEADERS).json()
         assert "items" in body
         assert "next_cursor" in body
 
-    def test_items_returned_in_response(self, client, project_repo):
-        project_repo.get_many.return_value = Page(items=[SAMPLE_PROJECT], next_cursor=None)
+    def test_items_returned_in_response(self, client, project_service):
+        project_service.get_many.return_value = Page(items=[SAMPLE_PROJECT], next_cursor=None)
         body = client.get("/api/v1/projects", headers=AUTHED_HEADERS).json()
         assert len(body["items"]) == 1
 
-    def test_next_cursor_set_when_more_pages(self, client, project_repo):
+    def test_next_cursor_set_when_more_pages(self, client, project_service):
         from mpcontribs_api.pagination import encode_cursor
 
         cursor = encode_cursor("mp-sample")
-        project_repo.get_many.return_value = Page(items=[SAMPLE_PROJECT], next_cursor=cursor)
+        project_service.get_many.return_value = Page(items=[SAMPLE_PROJECT], next_cursor=cursor)
         body = client.get("/api/v1/projects", headers=AUTHED_HEADERS).json()
         assert body["next_cursor"] == cursor
 
-    def test_repo_get_project_called(self, client, project_repo):
-        project_repo.get_many.return_value = Page(items=[], next_cursor=None)
+    def test_repo_get_project_called(self, client, project_service):
+        project_service.get_many.return_value = Page(items=[], next_cursor=None)
         client.get("/api/v1/projects", headers=AUTHED_HEADERS)
-        project_repo.get_many.assert_called_once()
+        project_service.get_many.assert_called_once()
 
-    def test_anonymous_user_reaches_route(self, client, project_repo):
-        project_repo.get_many.return_value = Page(items=[], next_cursor=None)
+    def test_anonymous_user_reaches_route(self, client, project_service):
+        project_service.get_many.return_value = Page(items=[], next_cursor=None)
         r = client.get("/api/v1/projects", headers=ANON_HEADERS)
         assert r.status_code == 200
 
-    def test_invalid_fields_param_returns_422(self, client, project_repo):
-        project_repo.get_many.return_value = Page(items=[], next_cursor=None)
+    def test_invalid_fields_param_returns_422(self, client, project_service):
+        project_service.get_many.return_value = Page(items=[], next_cursor=None)
         r = client.get("/api/v1/projects", params={"_fields": "nonexistent_field"}, headers=AUTHED_HEADERS)
         assert r.status_code == 422
 
-    def test_limit_param_forwarded(self, client, project_repo):
-        project_repo.get_many.return_value = Page(items=[], next_cursor=None)
+    def test_limit_param_forwarded(self, client, project_service):
+        project_service.get_many.return_value = Page(items=[], next_cursor=None)
         client.get("/api/v1/projects", params={"limit": 5}, headers=AUTHED_HEADERS)
-        _, kwargs = project_repo.get_many.call_args
+        _, kwargs = project_service.get_many.call_args
         assert kwargs["pagination"].limit == 5
 
-    def test_limit_above_max_returns_422(self, client, project_repo):
+    def test_limit_above_max_returns_422(self, client, project_service):
         r = client.get("/api/v1/projects", params={"limit": 999}, headers=AUTHED_HEADERS)
         assert r.status_code == 422
 
-    def test_valid_fields_param_forwarded(self, client, project_repo):
-        project_repo.get_many.return_value = Page(items=[], next_cursor=None)
+    def test_valid_fields_param_forwarded(self, client, project_service):
+        project_service.get_many.return_value = Page(items=[], next_cursor=None)
         client.get("/api/v1/projects", params=[("_fields", "title"), ("_fields", "authors")], headers=AUTHED_HEADERS)
-        _, kwargs = project_repo.get_many.call_args
+        _, kwargs = project_service.get_many.call_args
         assert kwargs["fields"] is not None
         assert "title" in kwargs["fields"]
 
@@ -117,25 +112,25 @@ class TestListProjects:
 
 
 class TestFieldSelectionSemantics:
-    def test_omitted_fields_forwards_route_defaults(self, client, project_repo):
+    def test_omitted_fields_forwards_route_defaults(self, client, project_service):
         # No _fields query param -> the route's default_fields() (identity + summary columns).
-        project_repo.get_many.return_value = Page(items=[], next_cursor=None)
+        project_service.get_many.return_value = Page(items=[], next_cursor=None)
         client.get("/api/v1/projects", headers=AUTHED_HEADERS)
-        _, kwargs = project_repo.get_many.call_args
+        _, kwargs = project_service.get_many.call_args
         assert kwargs["fields"] == frozenset(ProjectOut.default_fields())
 
-    def test_empty_fields_forwards_identity_only(self, client, project_repo):
+    def test_empty_fields_forwards_identity_only(self, client, project_service):
         # `?_fields=` (present but empty) -> only the identity field, the cheap "just ids" call.
-        project_repo.get_many.return_value = Page(items=[], next_cursor=None)
+        project_service.get_many.return_value = Page(items=[], next_cursor=None)
         client.get("/api/v1/projects", params={"_fields": ""}, headers=AUTHED_HEADERS)
-        _, kwargs = project_repo.get_many.call_args
+        _, kwargs = project_service.get_many.call_args
         assert kwargs["fields"] == frozenset({"id"})
 
-    def test_all_sentinel_forwards_none(self, client, project_repo):
+    def test_all_sentinel_forwards_none(self, client, project_service):
         # `?_fields=_all` -> None, i.e. project every field.
-        project_repo.get_many.return_value = Page(items=[], next_cursor=None)
+        project_service.get_many.return_value = Page(items=[], next_cursor=None)
         client.get("/api/v1/projects", params={"_fields": "_all"}, headers=AUTHED_HEADERS)
-        _, kwargs = project_repo.get_many.call_args
+        _, kwargs = project_service.get_many.call_args
         assert kwargs["fields"] is None
 
     def test_empty_fields_detail_forwards_identity_only(self, client, project_service):

--- a/mpcontribs-api/tests/unit/domains/test_component_service.py
+++ b/mpcontribs-api/tests/unit/domains/test_component_service.py
@@ -3,9 +3,10 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 from beanie import PydanticObjectId
 
+from mpcontribs_api.domains._shared.bulk import BulkFailure
 from mpcontribs_api.domains._shared.models import ComponentDeleteResponse, DeleteResponse
 from mpcontribs_api.domains._shared.service import ComponentService
-from mpcontribs_api.domains.attachments.models import AttachmentFilter
+from mpcontribs_api.domains.attachments.models import Attachment, AttachmentFilter
 from mpcontribs_api.exceptions import NotFoundError
 
 pytestmark = pytest.mark.asyncio
@@ -229,3 +230,35 @@ async def test_patch_by_id_reachable_patches():
 
     assert result == "patched"
     components.patch_one.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# insert_many — assembles a BulkWriteSummary from the repo's (successes, failures) tuple
+# ---------------------------------------------------------------------------
+
+
+async def test_insert_many_assembles_summary_sorted_by_index():
+    svc, components, _ = _make_service(candidate_ids=[], reachable=set(), referenced=set())
+    # spec=Attachment so the docs satisfy BulkWriteSummary's Component-typed ``succeeded`` field.
+    doc_a, doc_b = MagicMock(spec=Attachment), MagicMock(spec=Attachment)
+    failure = BulkFailure(index=1, error_code="conflict", message="dup")
+    # Repo reports successes out of order and one per-item failure; the service orders by input index.
+    components.insert_many = AsyncMock(return_value=([(2, doc_b), (0, doc_a)], [failure]))
+
+    summary = await svc.insert_many(components=["in0", "in1", "in2"])
+
+    assert summary.total == 3
+    assert summary.succeeded == [doc_a, doc_b]  # index 0 then index 2
+    assert [f.index for f in summary.failed] == [1]
+
+
+async def test_insert_many_all_succeed():
+    svc, components, _ = _make_service(candidate_ids=[], reachable=set(), referenced=set())
+    doc = MagicMock(spec=Attachment)
+    components.insert_many = AsyncMock(return_value=([(0, doc)], []))
+
+    summary = await svc.insert_many(components=["only"])
+
+    assert summary.total == 1
+    assert summary.succeeded == [doc]
+    assert summary.failed == []

--- a/mpcontribs-api/tests/unit/domains/test_component_service.py
+++ b/mpcontribs-api/tests/unit/domains/test_component_service.py
@@ -18,7 +18,7 @@ def _oid() -> PydanticObjectId:
 
 
 def _id_resolving_get_one() -> AsyncMock:
-    """A stand-in for the component repo's ``get_one``.
+    """A stand-in for the component repo's ``read_one``.
 
     The service resolves a component's ``_id`` by asking the repo (which coerces a string ``id`` to
     ``ObjectId`` internally), so the mock echoes a document whose ``id`` is the coerced identifier —
@@ -49,7 +49,7 @@ def _make_service(
     components.list_ids = AsyncMock(return_value=candidate_ids)
     components.delete_many = AsyncMock(side_effect=lambda filter: DeleteResponse(num_deleted=len(filter.id__in)))
     components.delete_one = AsyncMock(return_value=DeleteResponse(num_deleted=1))
-    components.get_one = _id_resolving_get_one()
+    components.read_one = _id_resolving_get_one()
 
     contributions = AsyncMock(name="contributions")
 
@@ -166,14 +166,14 @@ async def test_delete_by_id_reachable_and_unreferenced_deletes():
 
 
 # ---------------------------------------------------------------------------
-# Read gating: get_by_id / get_many / patch_by_id are reachability-scoped
+# Read gating: get_by_id / read_many / patch_by_id are reachability-scoped
 # ---------------------------------------------------------------------------
 
 
 def _make_read_service(*, reachable: set[PydanticObjectId]) -> tuple[ComponentService, AsyncMock, AsyncMock]:
     """ComponentService whose contribution repo reports `reachable` ids as in-scope."""
     components = AsyncMock(name="components")
-    components.get_one = _id_resolving_get_one()
+    components.read_one = _id_resolving_get_one()
 
     contributions = AsyncMock(name="contributions")
 
@@ -194,34 +194,34 @@ async def test_get_by_id_unreachable_returns_none():
     oid = _oid()
     svc, components, _ = _make_read_service(reachable=set())
 
-    result = await svc.get_one({"id": str(oid)}, fields=None)
+    result = await svc.read_one({"id": str(oid)}, fields=None)
 
     assert result is None
-    components.get_one.assert_awaited_once()
+    components.read_one.assert_awaited_once()
 
 
 async def test_get_by_id_reachable_fetches_component():
     oid = _oid()
     svc, components, _ = _make_read_service(reachable={oid})
 
-    result = await svc.get_one({"id": str(oid)}, fields=None)
+    result = await svc.read_one({"id": str(oid)}, fields=None)
 
     # Resolved (id lookup) then fetched (full projection): the reachable component is returned.
     assert result is not None and result.id == oid
-    assert components.get_one.await_count == 2
+    assert components.read_one.await_count == 2
 
 
 async def test_get_many_restricts_to_reachable_ids():
     a, b = _oid(), _oid()
     svc, components, contributions = _make_read_service(reachable={a, b})
-    components.get_many = AsyncMock(return_value="page")
+    components.read_many = AsyncMock(return_value="page")
 
-    await svc.get_many(filter=AttachmentFilter(), pagination=None, fields=None)
+    await svc.read_many(filter=AttachmentFilter(), pagination=None, fields=None)
 
     contributions.referenced_component_ids.assert_awaited_once()
     assert contributions.referenced_component_ids.await_args.kwargs["scoped"] is True
     assert contributions.referenced_component_ids.await_args.args[1:] == ()
-    restrict = components.get_many.await_args.kwargs["restrict_ids"]
+    restrict = components.read_many.await_args.kwargs["restrict_ids"]
     assert set(restrict) == {a, b}
 
 
@@ -230,19 +230,19 @@ async def test_patch_by_id_unreachable_raises_not_found():
     svc, components, _ = _make_read_service(reachable=set())
 
     with pytest.raises(NotFoundError):
-        await svc.patch_one({"id": str(oid)}, update=MagicMock())
-    components.patch_one.assert_not_awaited()
+        await svc.update_one({"id": str(oid)}, update=MagicMock())
+    components.update_one.assert_not_awaited()
 
 
 async def test_patch_by_id_reachable_patches():
     oid = _oid()
     svc, components, _ = _make_read_service(reachable={oid})
-    components.patch_one = AsyncMock(return_value="patched")
+    components.update_one = AsyncMock(return_value="patched")
 
-    result = await svc.patch_one({"id": str(oid)}, update=MagicMock())
+    result = await svc.update_one({"id": str(oid)}, update=MagicMock())
 
     assert result == "patched"
-    components.patch_one.assert_awaited_once()
+    components.update_one.assert_awaited_once()
 
 
 # ---------------------------------------------------------------------------

--- a/mpcontribs-api/tests/unit/domains/test_component_service.py
+++ b/mpcontribs-api/tests/unit/domains/test_component_service.py
@@ -1,3 +1,4 @@
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -16,11 +17,21 @@ def _oid() -> PydanticObjectId:
     return PydanticObjectId()
 
 
-def _coerce_identifiers(identifiers: dict) -> dict:
-    """Stub for the repo's ObjectId-keyed ``coerce_identifiers`` (string id -> ObjectId)."""
-    if isinstance(identifiers.get("id"), str):
-        return {**identifiers, "id": PydanticObjectId(identifiers["id"])}
-    return identifiers
+def _id_resolving_get_one() -> AsyncMock:
+    """A stand-in for the component repo's ``get_one``.
+
+    The service resolves a component's ``_id`` by asking the repo (which coerces a string ``id`` to
+    ``ObjectId`` internally), so the mock echoes a document whose ``id`` is the coerced identifier —
+    letting the reachability check key off the real ``ObjectId``.
+    """
+
+    async def _get_one(identifiers, fields=None, **kwargs):
+        if "id" in identifiers:
+            raw = identifiers["id"]
+            return SimpleNamespace(id=PydanticObjectId(raw) if isinstance(raw, str) else raw)
+        return None
+
+    return AsyncMock(side_effect=_get_one)
 
 
 def _make_service(
@@ -38,7 +49,7 @@ def _make_service(
     components.list_ids = AsyncMock(return_value=candidate_ids)
     components.delete_many = AsyncMock(side_effect=lambda filter: DeleteResponse(num_deleted=len(filter.id__in)))
     components.delete_one = AsyncMock(return_value=DeleteResponse(num_deleted=1))
-    components.coerce_identifiers = MagicMock(side_effect=_coerce_identifiers)
+    components.get_one = _id_resolving_get_one()
 
     contributions = AsyncMock(name="contributions")
 
@@ -162,7 +173,7 @@ async def test_delete_by_id_reachable_and_unreferenced_deletes():
 def _make_read_service(*, reachable: set[PydanticObjectId]) -> tuple[ComponentService, AsyncMock, AsyncMock]:
     """ComponentService whose contribution repo reports `reachable` ids as in-scope."""
     components = AsyncMock(name="components")
-    components.coerce_identifiers = MagicMock(side_effect=_coerce_identifiers)
+    components.get_one = _id_resolving_get_one()
 
     contributions = AsyncMock(name="contributions")
 
@@ -177,25 +188,27 @@ def _make_read_service(*, reachable: set[PydanticObjectId]) -> tuple[ComponentSe
     return service, components, contributions
 
 
-async def test_get_by_id_unreachable_returns_none_without_fetch():
+async def test_get_by_id_unreachable_returns_none():
+    # The id is resolved through the repo, but an unreachable component still yields None (and the
+    # full-fields fetch is skipped once the reachability gate fails).
     oid = _oid()
     svc, components, _ = _make_read_service(reachable=set())
 
     result = await svc.get_one({"id": str(oid)}, fields=None)
 
     assert result is None
-    components.get_one.assert_not_awaited()
+    components.get_one.assert_awaited_once()
 
 
 async def test_get_by_id_reachable_fetches_component():
     oid = _oid()
     svc, components, _ = _make_read_service(reachable={oid})
-    components.get_one = AsyncMock(return_value="the-component")
 
     result = await svc.get_one({"id": str(oid)}, fields=None)
 
-    assert result == "the-component"
-    components.get_one.assert_awaited_once()
+    # Resolved (id lookup) then fetched (full projection): the reachable component is returned.
+    assert result is not None and result.id == oid
+    assert components.get_one.await_count == 2
 
 
 async def test_get_many_restricts_to_reachable_ids():

--- a/mpcontribs-api/tests/unit/domains/test_consumers_models.py
+++ b/mpcontribs-api/tests/unit/domains/test_consumers_models.py
@@ -31,7 +31,7 @@ class TestConsumerSettingsDefaults:
         assert settings.max_columns == get_settings().consumer.max_columns
 
     def test_only_explicit_field_is_marked_set(self):
-        # patch_one relies on exclude_unset to touch only the named limit, so a partial
+        # update_one relies on exclude_unset to touch only the named limit, so a partial
         # override must report exactly the fields the admin supplied.
         settings = ConsumerSettings(max_columns=5)
         assert settings.model_dump(exclude_unset=True) == {"max_columns": 5}

--- a/mpcontribs-api/tests/unit/domains/test_contribution_service.py
+++ b/mpcontribs-api/tests/unit/domains/test_contribution_service.py
@@ -264,6 +264,15 @@ def _fake_attachment() -> Attachment:
     return a
 
 
+def _components_result(*docs):
+    """Build a component repo ``insert_many`` result: ``(indexed_successes, failures)``, no failures.
+
+    The repository reports one ``(input_index, resolved_doc)`` pair per input; the transactional
+    caller keeps only the docs. Failures are exercised separately.
+    """
+    return [(index, doc) for index, doc in enumerate(docs)], []
+
+
 # ---------------------------------------------------------------------------
 # insert_many — pre-checks (cheap, no DB)
 # ---------------------------------------------------------------------------
@@ -662,8 +671,8 @@ class TestInsertContributionsTransactionPath:
     async def test_with_components_opens_session_per_contribution(self):
         svc, contrib_repo, struct_repo, table_repo, attach_repo, client = _make_service()
 
-        struct_repo.insert_many.return_value = [_fake_structure()]
-        table_repo.insert_many.return_value = []
+        struct_repo.insert_many.return_value = _components_result(_fake_structure())
+        table_repo.insert_many.return_value = _components_result()
         attach_repo.insert_many.return_value = []
 
         async def _insert(doc, session=None):
@@ -683,8 +692,8 @@ class TestInsertContributionsTransactionPath:
         client, session = _make_fake_client()
         svc, contrib_repo, struct_repo, table_repo, _, _ = _make_service(client=client)
 
-        struct_repo.insert_many.return_value = [_fake_structure()]
-        table_repo.insert_many.return_value = [_fake_table()]
+        struct_repo.insert_many.return_value = _components_result(_fake_structure())
+        table_repo.insert_many.return_value = _components_result(_fake_table())
 
         async def _insert(doc, session=None):
             return doc
@@ -704,8 +713,8 @@ class TestInsertContributionsTransactionPath:
     async def test_failure_on_second_of_three_yields_summary(self):
         svc, contrib_repo, struct_repo, table_repo, attach_repo, _ = _make_service()
 
-        struct_repo.insert_many.return_value = [_fake_structure()]
-        table_repo.insert_many.return_value = []
+        struct_repo.insert_many.return_value = _components_result(_fake_structure())
+        table_repo.insert_many.return_value = _components_result()
         attach_repo.insert_many.return_value = []
 
         async def _insert(doc, session=None):
@@ -733,9 +742,9 @@ class TestInsertContributionsTransactionPath:
         svc, contrib_repo, struct_repo, table_repo, attach_repo, _ = _make_service()
 
         struct_a, struct_b = _fake_structure(), _fake_structure()
-        struct_calls = iter([[struct_a], [struct_b]])
+        struct_calls = iter([_components_result(struct_a), _components_result(struct_b)])
         struct_repo.insert_many.side_effect = lambda *_args, **_kwargs: next(struct_calls)
-        table_repo.insert_many.return_value = []
+        table_repo.insert_many.return_value = _components_result()
         attach_repo.insert_many.return_value = []
 
         captured: list[Contribution] = []
@@ -760,8 +769,8 @@ class TestInsertContributionsTransactionPath:
         svc, contrib_repo, struct_repo, table_repo, attach_repo, client = _make_service()
 
         shared = _fake_structure()
-        struct_repo.insert_many.return_value = [shared]
-        table_repo.insert_many.return_value = []
+        struct_repo.insert_many.return_value = _components_result(shared)
+        table_repo.insert_many.return_value = _components_result()
         attach_repo.insert_many.return_value = []
 
         captured: list[Contribution] = []
@@ -803,8 +812,8 @@ class TestInsertContributionsMixedBatch:
     async def test_mixed_batch_routes_correctly(self):
         svc, contrib_repo, struct_repo, table_repo, attach_repo, client = _make_service()
 
-        struct_repo.insert_many.return_value = [_fake_structure()]
-        table_repo.insert_many.return_value = []
+        struct_repo.insert_many.return_value = _components_result(_fake_structure())
+        table_repo.insert_many.return_value = _components_result()
         attach_repo.insert_many.return_value = []
         contrib_repo.insert_many.return_value = None
 

--- a/mpcontribs-api/tests/unit/domains/test_contribution_service.py
+++ b/mpcontribs-api/tests/unit/domains/test_contribution_service.py
@@ -342,7 +342,7 @@ class TestInsertContributionsUnapprovedQuota:
         monkeypatch.setattr(get_settings().consumer, "max_unapproved_contributions_per_project", 2)
         contrib_repo = AsyncMock()
         contrib_repo.insert_many.return_value = None
-        contrib_repo.count_contributions_for_project.return_value = 5  # already over cap
+        contrib_repo.count_matching.return_value = 5  # already over cap
         svc, *_ = _make_service(contributions=contrib_repo, projects=_unapproved_projects_repo())
 
         summary = await svc.insert_many([_contrib_in(identifier=f"mp-{i}") for i in range(3)])
@@ -358,7 +358,7 @@ class TestInsertContributionsUnapprovedQuota:
         monkeypatch.setattr(get_settings().consumer, "max_unapproved_contributions_per_project", 5)
         contrib_repo = AsyncMock()
         contrib_repo.insert_many.return_value = None
-        contrib_repo.count_contributions_for_project.return_value = 3
+        contrib_repo.count_matching.return_value = 3
         svc, *_ = _make_service(contributions=contrib_repo, projects=_unapproved_projects_repo())
 
         summary = await svc.insert_many([_contrib_in(identifier=f"mp-{i}") for i in range(4)])
@@ -375,7 +375,7 @@ class TestInsertContributionsUnapprovedQuota:
         monkeypatch.setattr(get_settings().consumer, "max_unapproved_contributions_per_project", 3)
         contrib_repo = AsyncMock()
         contrib_repo.insert_many.return_value = None
-        contrib_repo.count_contributions_for_project.return_value = 2
+        contrib_repo.count_matching.return_value = 2
         svc, *_ = _make_service(contributions=contrib_repo, projects=_unapproved_projects_repo())
 
         summary = await svc.insert_many([_contrib_in(identifier=f"mp-{i}") for i in range(2)])
@@ -389,7 +389,7 @@ class TestInsertContributionsUnapprovedQuota:
         monkeypatch.setattr(get_settings().consumer, "max_unapproved_contributions_per_project", 3)
         contrib_repo = AsyncMock()
         contrib_repo.insert_many.return_value = None
-        contrib_repo.count_contributions_for_project.return_value = 3
+        contrib_repo.count_matching.return_value = 3
         svc, *_ = _make_service(contributions=contrib_repo, projects=_unapproved_projects_repo())
 
         summary = await svc.insert_many([_contrib_in(identifier=f"mp-{i}") for i in range(2)])
@@ -409,13 +409,13 @@ class TestInsertContributionsUnapprovedQuota:
         assert len(summary.succeeded) == 3
         assert summary.failed == []
         # Approved short-circuits before counting stored contributions
-        contrib_repo.count_contributions_for_project.assert_not_called()
+        contrib_repo.count_matching.assert_not_called()
 
     async def test_quota_evaluated_per_project(self, monkeypatch):
         monkeypatch.setattr(get_settings().consumer, "max_unapproved_contributions_per_project", 2)
         contrib_repo = AsyncMock()
         contrib_repo.insert_many.return_value = None
-        contrib_repo.count_contributions_for_project.return_value = 99  # only consulted for the unapproved one
+        contrib_repo.count_matching.return_value = 99  # only consulted for the unapproved one
         projects = _projects_repo_by_approval({"ok": True, "bad": False})
         svc, *_ = _make_service(contributions=contrib_repo, projects=projects)
 
@@ -435,7 +435,7 @@ class TestInsertContributionsUnapprovedQuota:
         monkeypatch.setattr(get_settings().consumer, "max_unapproved_contributions_per_project", 2)
         contrib_repo = AsyncMock()
         contrib_repo.insert_many.return_value = None
-        contrib_repo.count_contributions_for_project.return_value = 5
+        contrib_repo.count_matching.return_value = 5
         svc, *_ = _make_service(contributions=contrib_repo, projects=_unapproved_projects_repo())
 
         with patch.object(service_module.logger, "warning") as warn:
@@ -476,7 +476,7 @@ class TestUpsertContributionsUnapprovedQuota:
         monkeypatch.setattr(get_settings().consumer, "max_unapproved_contributions_per_project", 3)
         contrib_repo = AsyncMock()
         contrib_repo.upsert_one.return_value = MagicMock(spec=Contribution, project="proj")
-        contrib_repo.count_contributions_for_project.return_value = 2
+        contrib_repo.count_matching.return_value = 2
         svc, *_ = _make_service(contributions=contrib_repo, projects=_unapproved_projects_repo())
         # Set after _make_service, which stubs existing_identities to an empty set. 'a' already exists.
         contrib_repo.existing_identities.return_value = {
@@ -502,7 +502,7 @@ class TestUpsertContributionsUnapprovedQuota:
         monkeypatch.setattr(get_settings().consumer, "max_unapproved_contributions_per_project", 1)
         contrib_repo = AsyncMock()
         contrib_repo.upsert_one.return_value = MagicMock(spec=Contribution, project="proj")
-        contrib_repo.count_contributions_for_project.return_value = 99  # far over cap
+        contrib_repo.count_matching.return_value = 99  # far over cap
         svc, *_ = _make_service(contributions=contrib_repo, projects=_unapproved_projects_repo())
         # Every contribution in the batch is an existing document -> all are free updates.
         contrib_repo.existing_identities.return_value = {
@@ -528,7 +528,7 @@ class TestUpsertContributionsUnapprovedQuota:
 
         assert len(summary.succeeded) == 3
         assert summary.failed == []
-        contrib_repo.count_contributions_for_project.assert_not_called()
+        contrib_repo.count_matching.assert_not_called()
         contrib_repo.existing_identities.assert_not_called()
 
 
@@ -542,20 +542,20 @@ class TestUpsertContributionByIdQuota:
         monkeypatch.setattr(get_settings().consumer, "max_unapproved_contributions_per_project", 1)
         contrib_repo = AsyncMock()
         contrib_repo.get_one.return_value = MagicMock(spec=Contribution)  # id exists -> update
-        contrib_repo.count_contributions_for_project.return_value = 99
+        contrib_repo.count_matching.return_value = 99
         contrib_repo.upsert_one.return_value = MagicMock(spec=Contribution)
         svc, *_ = _make_service(contributions=contrib_repo, projects=_unapproved_projects_repo())
 
         await svc.upsert_one("someid", _contrib_in())
 
         contrib_repo.upsert_one.assert_called_once()
-        contrib_repo.count_contributions_for_project.assert_not_called()
+        contrib_repo.count_matching.assert_not_called()
 
     async def test_new_insert_over_cap_rejected(self, monkeypatch):
         monkeypatch.setattr(get_settings().consumer, "max_unapproved_contributions_per_project", 2)
         contrib_repo = AsyncMock()
         contrib_repo.get_one.return_value = None  # id absent -> would insert
-        contrib_repo.count_contributions_for_project.return_value = 5  # over cap
+        contrib_repo.count_matching.return_value = 5  # over cap
         svc, *_ = _make_service(contributions=contrib_repo, projects=_unapproved_projects_repo())
 
         with pytest.raises(PermissionError):
@@ -567,7 +567,7 @@ class TestUpsertContributionByIdQuota:
         monkeypatch.setattr(get_settings().consumer, "max_unapproved_contributions_per_project", 5)
         contrib_repo = AsyncMock()
         contrib_repo.get_one.return_value = None
-        contrib_repo.count_contributions_for_project.return_value = 1
+        contrib_repo.count_matching.return_value = 1
         contrib_repo.upsert_one.return_value = MagicMock(spec=Contribution)
         svc, *_ = _make_service(contributions=contrib_repo, projects=_unapproved_projects_repo())
 
@@ -580,7 +580,7 @@ class TestUpsertContributionByIdQuota:
         monkeypatch.setattr(get_settings().consumer, "max_unapproved_contributions_per_project", 2)
         contrib_repo = AsyncMock()
         contrib_repo.get_one.return_value = None
-        contrib_repo.count_contributions_for_project.return_value = 2
+        contrib_repo.count_matching.return_value = 2
         svc, *_ = _make_service(contributions=contrib_repo, projects=_unapproved_projects_repo())
 
         with pytest.raises(PermissionError):
@@ -598,7 +598,7 @@ class TestUpsertContributionByIdQuota:
         await svc.upsert_one("someid", _contrib_in())
 
         contrib_repo.upsert_one.assert_called_once()
-        contrib_repo.count_contributions_for_project.assert_not_called()
+        contrib_repo.count_matching.assert_not_called()
 
 
 # ---------------------------------------------------------------------------

--- a/mpcontribs-api/tests/unit/domains/test_contribution_service.py
+++ b/mpcontribs-api/tests/unit/domains/test_contribution_service.py
@@ -203,8 +203,8 @@ def _make_service(
     # class so the classmethod runs (an AsyncMock child would return a coroutine).
     contrib_repo.document_model = Contribution
     # ``coerce_identifiers`` is a *sync* repo method (see MongoDbRepository), but a bare AsyncMock
-    # would turn it into a coroutine factory: the service passes its result straight into get_one/
-    # patch_one without awaiting, leaking un-awaited coroutines. Make it a sync passthrough on every
+    # would turn it into a coroutine factory: the service passes its result straight into read_one/
+    # update_one without awaiting, leaking un-awaited coroutines. Make it a sync passthrough on every
     # repo so it behaves like the real thing (returns the identifiers dict unchanged).
     for repo in (contrib_repo, struct_repo, table_repo, attach_repo):
         repo.coerce_identifiers = MagicMock(side_effect=lambda identifiers: identifiers)
@@ -233,7 +233,7 @@ def _make_service(
 def _approved_projects_repo() -> AsyncMock:
     """A projects repo whose every project reads as approved (quota does not apply)."""
     repo = AsyncMock()
-    repo.get_one = AsyncMock(return_value=MagicMock(is_approved=True))
+    repo.read_one = AsyncMock(return_value=MagicMock(is_approved=True))
     repo.unique_columns_by_id.side_effect = lambda ids: {pid: None for pid in ids}
     return repo
 
@@ -241,7 +241,7 @@ def _approved_projects_repo() -> AsyncMock:
 def _unapproved_projects_repo() -> AsyncMock:
     """A projects repo whose every project reads as unapproved (quota applies)."""
     repo = AsyncMock()
-    repo.get_one = AsyncMock(return_value=MagicMock(is_approved=False))
+    repo.read_one = AsyncMock(return_value=MagicMock(is_approved=False))
     repo.unique_columns_by_id.side_effect = lambda ids: {pid: None for pid in ids}
     return repo
 
@@ -335,13 +335,13 @@ class TestInsertContributionsPreChecks:
 
 
 def _projects_repo_by_approval(approval: dict[str, bool]) -> AsyncMock:
-    """Projects repo whose ``get_one`` reports approval per project id from ``approval``."""
+    """Projects repo whose ``read_one`` reports approval per project id from ``approval``."""
     repo = AsyncMock()
 
     async def _get_one(identifiers, fields=None):
         return MagicMock(is_approved=approval[identifiers["id"]])
 
-    repo.get_one = AsyncMock(side_effect=_get_one)
+    repo.read_one = AsyncMock(side_effect=_get_one)
     repo.unique_columns_by_id.side_effect = lambda ids: {pid: None for pid in ids}
     return repo
 
@@ -550,7 +550,7 @@ class TestUpsertContributionByIdQuota:
     async def test_update_existing_allowed_even_over_cap(self, monkeypatch):
         monkeypatch.setattr(get_settings().consumer, "max_unapproved_contributions_per_project", 1)
         contrib_repo = AsyncMock()
-        contrib_repo.get_one.return_value = MagicMock(spec=Contribution)  # id exists -> update
+        contrib_repo.read_one.return_value = MagicMock(spec=Contribution)  # id exists -> update
         contrib_repo.count_matching.return_value = 99
         contrib_repo.upsert_one.return_value = MagicMock(spec=Contribution)
         svc, *_ = _make_service(contributions=contrib_repo, projects=_unapproved_projects_repo())
@@ -563,7 +563,7 @@ class TestUpsertContributionByIdQuota:
     async def test_new_insert_over_cap_rejected(self, monkeypatch):
         monkeypatch.setattr(get_settings().consumer, "max_unapproved_contributions_per_project", 2)
         contrib_repo = AsyncMock()
-        contrib_repo.get_one.return_value = None  # id absent -> would insert
+        contrib_repo.read_one.return_value = None  # id absent -> would insert
         contrib_repo.count_matching.return_value = 5  # over cap
         svc, *_ = _make_service(contributions=contrib_repo, projects=_unapproved_projects_repo())
 
@@ -575,7 +575,7 @@ class TestUpsertContributionByIdQuota:
     async def test_new_insert_under_cap_allowed(self, monkeypatch):
         monkeypatch.setattr(get_settings().consumer, "max_unapproved_contributions_per_project", 5)
         contrib_repo = AsyncMock()
-        contrib_repo.get_one.return_value = None
+        contrib_repo.read_one.return_value = None
         contrib_repo.count_matching.return_value = 1
         contrib_repo.upsert_one.return_value = MagicMock(spec=Contribution)
         svc, *_ = _make_service(contributions=contrib_repo, projects=_unapproved_projects_repo())
@@ -588,7 +588,7 @@ class TestUpsertContributionByIdQuota:
         # stored == cap: the project is full, so a brand-new document is rejected (no cap+1 slack).
         monkeypatch.setattr(get_settings().consumer, "max_unapproved_contributions_per_project", 2)
         contrib_repo = AsyncMock()
-        contrib_repo.get_one.return_value = None
+        contrib_repo.read_one.return_value = None
         contrib_repo.count_matching.return_value = 2
         svc, *_ = _make_service(contributions=contrib_repo, projects=_unapproved_projects_repo())
 
@@ -600,7 +600,7 @@ class TestUpsertContributionByIdQuota:
     async def test_new_insert_approved_project_unlimited(self, monkeypatch):
         monkeypatch.setattr(get_settings().consumer, "max_unapproved_contributions_per_project", 1)
         contrib_repo = AsyncMock()
-        contrib_repo.get_one.return_value = None
+        contrib_repo.read_one.return_value = None
         contrib_repo.upsert_one.return_value = MagicMock(spec=Contribution)
         svc, *_ = _make_service(contributions=contrib_repo, projects=_approved_projects_repo())
 
@@ -1218,7 +1218,7 @@ class TestWriteAuthorization:
         with pytest.raises(PermissionError, match="forbidden"):
             await svc.upsert_one("someid", _contrib_in(project="forbidden"))
 
-        contrib_repo.get_one.assert_not_called()
+        contrib_repo.read_one.assert_not_called()
         contrib_repo.upsert_one.assert_not_called()
 
     async def test_upsert_unauthorized_cannot_overwrite_public_contribution(self):
@@ -1226,7 +1226,7 @@ class TestWriteAuthorization:
         # repository read scope would admit a public row, authorization is enforced up front.
         svc, contrib_repo, *_ = _make_service(user=_member_user("allowed"))
         # An existing (readable) contribution must not lower the bar — authz still rejects the write.
-        contrib_repo.get_one.return_value = MagicMock(spec=Contribution)
+        contrib_repo.read_one.return_value = MagicMock(spec=Contribution)
 
         with pytest.raises(PermissionError, match="forbidden"):
             await svc.upsert_one("someid", _contrib_in(project="forbidden"))
@@ -1239,14 +1239,14 @@ class TestWriteAuthorization:
         with pytest.raises(PermissionError):
             await svc.upsert_one("someid", _contrib_in(project="any"))
 
-        contrib_repo.get_one.assert_not_called()
+        contrib_repo.read_one.assert_not_called()
         contrib_repo.upsert_one.assert_not_called()
 
     async def test_upsert_authorized_member_proceeds(self):
         # A member writing to their own project passes authorization; updating an existing row is
         # not gated by the quota, so the write goes through.
         contrib_repo = AsyncMock()
-        contrib_repo.get_one.return_value = MagicMock(spec=Contribution)  # exists -> update
+        contrib_repo.read_one.return_value = MagicMock(spec=Contribution)  # exists -> update
         contrib_repo.upsert_one.return_value = MagicMock(spec=Contribution)
         svc, *_ = _make_service(
             contributions=contrib_repo, projects=_unapproved_projects_repo(), user=_member_user("allowed")
@@ -1258,7 +1258,7 @@ class TestWriteAuthorization:
 
     async def test_upsert_admin_bypasses_authorization(self):
         contrib_repo = AsyncMock()
-        contrib_repo.get_one.return_value = MagicMock(spec=Contribution)
+        contrib_repo.read_one.return_value = MagicMock(spec=Contribution)
         contrib_repo.upsert_one.return_value = MagicMock(spec=Contribution)
         svc, *_ = _make_service(contributions=contrib_repo, projects=_approved_projects_repo())  # admin default
 
@@ -1310,7 +1310,7 @@ def _noop_filter() -> ContributionFilter:
 class TestDeleteContributionsEmpty:
     async def test_empty_match_returns_zero_summary(self):
         svc, contrib_repo, *_ = _make_service()
-        contrib_repo.get_many.return_value = _page([])
+        contrib_repo.read_many.return_value = _page([])
         contrib_repo.delete_many.return_value = _delete_result(0)
 
         summary = await svc.delete_many(_noop_filter())
@@ -1320,7 +1320,7 @@ class TestDeleteContributionsEmpty:
 
     async def test_empty_match_does_not_call_child_repos(self):
         svc, contrib_repo, struct_repo, table_repo, attach_repo, _ = _make_service()
-        contrib_repo.get_many.return_value = _page([])
+        contrib_repo.read_many.return_value = _page([])
         contrib_repo.delete_many.return_value = _delete_result(0)
 
         await svc.delete_many(_noop_filter())
@@ -1331,12 +1331,12 @@ class TestDeleteContributionsEmpty:
 
     async def test_empty_match_terminates_after_one_page(self):
         svc, contrib_repo, *_ = _make_service()
-        contrib_repo.get_many.return_value = _page([])
+        contrib_repo.read_many.return_value = _page([])
         contrib_repo.delete_many.return_value = _delete_result(0)
 
         await svc.delete_many(_noop_filter())
 
-        assert contrib_repo.get_many.await_count == 1
+        assert contrib_repo.read_many.await_count == 1
 
 
 class TestDeleteContributionsSinglePage:
@@ -1344,7 +1344,7 @@ class TestDeleteContributionsSinglePage:
         svc, contrib_repo, *_ = _make_service()
         docs = [_contrib_doc() for _ in range(3)]
         # First call returns the page; second returns empty so the loop ends.
-        contrib_repo.get_many.side_effect = [_page(docs), _page([])]
+        contrib_repo.read_many.side_effect = [_page(docs), _page([])]
         contrib_repo.delete_many.side_effect = [_delete_result(3), _delete_result(0)]
 
         summary = await svc.delete_many(_noop_filter())
@@ -1353,7 +1353,7 @@ class TestDeleteContributionsSinglePage:
 
     async def test_no_components_means_no_child_deletes(self):
         svc, contrib_repo, struct_repo, table_repo, attach_repo, _ = _make_service()
-        contrib_repo.get_many.side_effect = [_page([_contrib_doc()]), _page([])]
+        contrib_repo.read_many.side_effect = [_page([_contrib_doc()]), _page([])]
         contrib_repo.delete_many.side_effect = [_delete_result(1), _delete_result(0)]
 
         summary = await svc.delete_many(_noop_filter())
@@ -1369,7 +1369,7 @@ class TestDeleteContributionsSinglePage:
         svc, contrib_repo, struct_repo, table_repo, attach_repo, _ = _make_service()
 
         doc = _contrib_doc(structures=[_oid()], tables=[_oid()], attachments=[_oid()])
-        contrib_repo.get_many.side_effect = [_page([doc]), _page([])]
+        contrib_repo.read_many.side_effect = [_page([doc]), _page([])]
 
         def _make_child_recorder(name):
             async def _record(ids, *a, **k):
@@ -1401,7 +1401,7 @@ class TestDeleteContributionsSinglePage:
         svc, contrib_repo, struct_repo, *_ = _make_service()
         s1, s2 = _oid(), _oid()
         doc = _contrib_doc(structures=[s1, s2])
-        contrib_repo.get_many.side_effect = [_page([doc]), _page([])]
+        contrib_repo.read_many.side_effect = [_page([doc]), _page([])]
         struct_repo.delete_many.return_value = DeleteResponse(num_deleted=2)
         contrib_repo.delete_many.side_effect = [_delete_result(1), _delete_result(0)]
 
@@ -1413,7 +1413,7 @@ class TestDeleteContributionsSinglePage:
     async def test_child_counts_accumulated_across_types(self):
         svc, contrib_repo, struct_repo, table_repo, attach_repo, _ = _make_service()
         doc = _contrib_doc(structures=[_oid()], tables=[_oid(), _oid()], attachments=[_oid()])
-        contrib_repo.get_many.side_effect = [_page([doc]), _page([])]
+        contrib_repo.read_many.side_effect = [_page([doc]), _page([])]
         struct_repo.delete_many.return_value = DeleteResponse(num_deleted=1)
         table_repo.delete_many.return_value = DeleteResponse(num_deleted=2)
         attach_repo.delete_many.return_value = DeleteResponse(num_deleted=1)
@@ -1427,7 +1427,7 @@ class TestDeleteContributionsSinglePage:
         svc, contrib_repo, *_ = _make_service()
         ids = [_oid(), _oid()]
         docs = [_contrib_doc(id_=i) for i in ids]
-        contrib_repo.get_many.side_effect = [_page(docs), _page([])]
+        contrib_repo.read_many.side_effect = [_page(docs), _page([])]
         contrib_repo.delete_many.side_effect = [_delete_result(2), _delete_result(0)]
 
         await svc.delete_many(_noop_filter())
@@ -1439,7 +1439,7 @@ class TestDeleteContributionsSinglePage:
 class TestDeleteContributionsMultiPage:
     async def test_loops_until_page_empty(self):
         svc, contrib_repo, *_ = _make_service()
-        contrib_repo.get_many.side_effect = [
+        contrib_repo.read_many.side_effect = [
             _page([_contrib_doc() for _ in range(2)]),
             _page([_contrib_doc()]),
             _page([]),
@@ -1453,11 +1453,11 @@ class TestDeleteContributionsMultiPage:
         summary = await svc.delete_many(_noop_filter())
 
         assert summary.num_deleted == 3
-        assert contrib_repo.get_many.await_count == 3
+        assert contrib_repo.read_many.await_count == 3
 
     async def test_children_accumulate_across_pages(self):
         svc, contrib_repo, struct_repo, *_ = _make_service()
-        contrib_repo.get_many.side_effect = [
+        contrib_repo.read_many.side_effect = [
             _page([_contrib_doc(structures=[_oid()])]),
             _page([_contrib_doc(structures=[_oid()])]),
             _page([]),
@@ -1484,7 +1484,7 @@ class TestDeleteContributionsNoneComponents:
     async def test_none_component_fields_do_not_raise(self):
         svc, contrib_repo, struct_repo, table_repo, attach_repo, _ = _make_service()
         doc = SimpleNamespace(id=_oid(), project="proj", structures=None, tables=None, attachments=None)
-        contrib_repo.get_many.side_effect = [_page([doc]), _page([])]
+        contrib_repo.read_many.side_effect = [_page([doc]), _page([])]
         contrib_repo.delete_many.side_effect = [_delete_result(1), _delete_result(0)]
 
         summary = await svc.delete_many(_noop_filter())
@@ -1497,7 +1497,7 @@ class TestDeleteContributionsNoneComponents:
 
 
 # ---------------------------------------------------------------------------
-# patch_one — identifier hierarchy on the merged state
+# update_one — identifier hierarchy on the merged state
 # ---------------------------------------------------------------------------
 
 
@@ -1517,37 +1517,37 @@ class TestPatchIdentifierHierarchy:
     async def test_patch_material_id_onto_doc_without_formula_raises(self):
         svc, contrib_repo, *_ = _make_service()
         existing = _existing_doc(material_id=None, chemical_system_id="Fe-O", formula=None)
-        contrib_repo.get_one.return_value = existing
+        contrib_repo.read_one.return_value = existing
 
         with pytest.raises(ValidationError, match="formula is required when material_id"):
-            await svc.patch_one(str(existing.id), ContributionPatch(material_id="mp-1"))
+            await svc.update_one(str(existing.id), ContributionPatch(material_id="mp-1"))
 
         # Rejected before any write.
-        contrib_repo.patch_one.assert_not_called()
+        contrib_repo.update_one.assert_not_called()
 
     async def test_patch_material_id_when_existing_has_formula_ok(self):
         svc, contrib_repo, *_ = _make_service()
         existing = _existing_doc(material_id=None, chemical_system_id="Fe-O", formula="Fe2O3")
-        contrib_repo.get_one.return_value = existing
-        contrib_repo.patch_one.return_value = MagicMock(spec=Contribution)
+        contrib_repo.read_one.return_value = existing
+        contrib_repo.update_one.return_value = MagicMock(spec=Contribution)
 
-        await svc.patch_one(str(existing.id), ContributionPatch(material_id="mp-1"))
+        await svc.update_one(str(existing.id), ContributionPatch(material_id="mp-1"))
 
-        contrib_repo.patch_one.assert_called_once()
+        contrib_repo.update_one.assert_called_once()
 
     async def test_metadata_only_patch_skips_existing_read(self):
         svc, contrib_repo, *_ = _make_service()
-        contrib_repo.patch_one.return_value = MagicMock(spec=Contribution)
+        contrib_repo.update_one.return_value = MagicMock(spec=Contribution)
 
-        await svc.patch_one("some-id", ContributionPatch(is_public=True))
+        await svc.update_one("some-id", ContributionPatch(is_public=True))
 
         # No identity/unique inputs touched -> no re-read, straight to the plain patch.
-        contrib_repo.get_one.assert_not_called()
-        contrib_repo.patch_one.assert_called_once()
+        contrib_repo.read_one.assert_not_called()
+        contrib_repo.update_one.assert_called_once()
 
 
 # ---------------------------------------------------------------------------
-# patch_one — data merge vs replace + unique_value resolution
+# update_one — data merge vs replace + unique_value resolution
 # ---------------------------------------------------------------------------
 
 
@@ -1556,26 +1556,26 @@ class TestPatchDataMergeReplace:
         svc, contrib_repo, *_ = _make_service()
         existing = _existing_doc(material_id=None, chemical_system_id="Fe-O", formula="Fe2O3")
         existing.data = {"x": 1.0}
-        contrib_repo.get_one.return_value = existing
-        contrib_repo.patch_one.return_value = MagicMock(spec=Contribution)
+        contrib_repo.read_one.return_value = existing
+        contrib_repo.update_one.return_value = MagicMock(spec=Contribution)
 
-        await svc.patch_one(str(existing.id), ContributionPatch(data={"y": 9.0}))
+        await svc.update_one(str(existing.id), ContributionPatch(data={"y": 9.0}))
 
         # The repo performs the actual dotted-$set merge; the service just forwards replace_data=False.
-        assert contrib_repo.patch_one.call_args.kwargs["replace_data"] is False
+        assert contrib_repo.update_one.call_args.kwargs["replace_data"] is False
 
     async def test_replace_data_flag_forwarded_to_repo(self):
         svc, contrib_repo, *_ = _make_service()
         existing = _existing_doc(material_id=None, chemical_system_id="Fe-O", formula="Fe2O3")
         existing.data = {"x": 1.0}
-        contrib_repo.get_one.return_value = existing
-        contrib_repo.patch_one.return_value = MagicMock(spec=Contribution)
+        contrib_repo.read_one.return_value = existing
+        contrib_repo.update_one.return_value = MagicMock(spec=Contribution)
 
-        await svc.patch_one(
+        await svc.update_one(
             str(existing.id), ContributionPatch(data={"y": 9.0}), replace_data=True
         )
 
-        assert contrib_repo.patch_one.call_args.kwargs["replace_data"] is True
+        assert contrib_repo.update_one.call_args.kwargs["replace_data"] is True
 
     async def test_merge_resolves_unique_value_from_merged_state(self):
         # The unique_column value lives in the stored data and is NOT in the patch. A merge preserves
@@ -1583,13 +1583,13 @@ class TestPatchDataMergeReplace:
         svc, contrib_repo, *_ = _make_service(unique_column="sample_id")
         existing = _existing_doc(material_id=None, chemical_system_id="Fe-O", formula="Fe2O3")
         existing.data = {"sample_id": 42, "x": 1.0}
-        contrib_repo.get_one.return_value = existing
-        contrib_repo.patch_one.return_value = MagicMock(spec=Contribution)
+        contrib_repo.read_one.return_value = existing
+        contrib_repo.update_one.return_value = MagicMock(spec=Contribution)
 
-        await svc.patch_one(str(existing.id), ContributionPatch(data={"y": 9.0}))
+        await svc.update_one(str(existing.id), ContributionPatch(data={"y": 9.0}))
 
         # Resolved from {sample_id:42, x:1, y:9}, so the untouched unique_value survives the merge.
-        assert contrib_repo.patch_one.call_args.kwargs["unique_value"] == 42
+        assert contrib_repo.update_one.call_args.kwargs["unique_value"] == 42
 
     async def test_replace_resolves_unique_value_from_patch_data_only(self):
         # On replace the stored data is discarded, so a unique_column absent from the patch is a
@@ -1597,10 +1597,10 @@ class TestPatchDataMergeReplace:
         svc, contrib_repo, *_ = _make_service(unique_column="sample_id")
         existing = _existing_doc(material_id=None, chemical_system_id="Fe-O", formula="Fe2O3")
         existing.data = {"sample_id": 42}
-        contrib_repo.get_one.return_value = existing
+        contrib_repo.read_one.return_value = existing
 
         with pytest.raises(ValidationError, match="unique_column"):
-            await svc.patch_one(
+            await svc.update_one(
                 str(existing.id), ContributionPatch(data={"y": 9.0}), replace_data=True
             )
-        contrib_repo.patch_one.assert_not_called()
+        contrib_repo.update_one.assert_not_called()

--- a/mpcontribs-api/tests/unit/domains/test_contribution_service.py
+++ b/mpcontribs-api/tests/unit/domains/test_contribution_service.py
@@ -199,6 +199,9 @@ def _make_service(
     struct_repo = structures or AsyncMock()
     table_repo = tables or AsyncMock()
     attach_repo = attachments or AsyncMock()
+    # The service builds documents via ``repo.document_model.from_input_model``; keep it the real
+    # class so the classmethod runs (an AsyncMock child would return a coroutine).
+    contrib_repo.document_model = Contribution
     # ``coerce_identifiers`` is a *sync* repo method (see MongoDbRepository), but a bare AsyncMock
     # would turn it into a coroutine factory: the service passes its result straight into get_one/
     # patch_one without awaiting, leaking un-awaited coroutines. Make it a sync passthrough on every

--- a/mpcontribs-api/tests/unit/domains/test_contributions_models.py
+++ b/mpcontribs-api/tests/unit/domains/test_contributions_models.py
@@ -495,7 +495,7 @@ class TestContributionOutDefaultFields:
 
 
 # ---------------------------------------------------------------------------
-# MongoDbContributionRepository._build_scope (pure logic, no DB needed)
+# MongoDbContributionRepository.read_scope (pure logic, no DB needed)
 # ---------------------------------------------------------------------------
 
 _ADMIN = User(username="google:admin@example.com", groups=frozenset({"admin"}))
@@ -505,34 +505,34 @@ _ANON = User()
 
 class TestContributionRepoScope:
     def test_admin_scope_is_empty(self):
-        assert MongoDbContributionRepository._build_scope(_ADMIN) == {}
+        assert MongoDbContributionRepository.read_scope.query(_ADMIN) == {}
 
     def test_anon_scope_has_or_clause(self):
-        scope = MongoDbContributionRepository._build_scope(_ANON)
+        scope = MongoDbContributionRepository.read_scope.query(_ANON)
         assert "$or" in scope
 
     def test_anon_scope_includes_is_public_true(self):
-        ors = MongoDbContributionRepository._build_scope(_ANON)["$or"]
+        ors = MongoDbContributionRepository.read_scope.query(_ANON)["$or"]
         assert any(c == {"is_public": True} for c in ors)
 
     def test_anon_scope_has_no_group_id_clause(self):
-        ors = MongoDbContributionRepository._build_scope(_ANON)["$or"]
+        ors = MongoDbContributionRepository.read_scope.query(_ANON)["$or"]
         assert not any("_id" in c for c in ors)
 
     def test_authed_user_scope_includes_is_public(self):
-        ors = MongoDbContributionRepository._build_scope(_ALICE)["$or"]
+        ors = MongoDbContributionRepository.read_scope.query(_ALICE)["$or"]
         assert any(c == {"is_public": True} for c in ors)
 
     def test_authed_user_with_groups_has_group_id_clause(self):
         user = User(username="u@example.com", groups=frozenset({"g1", "g2"}))
-        ors = MongoDbContributionRepository._build_scope(user)["$or"]
+        ors = MongoDbContributionRepository.read_scope.query(user)["$or"]
         group_clause = next((c for c in ors if "project" in c), None)
         assert group_clause is not None
         assert set(group_clause["project"]["$in"]) == {"g1", "g2"}
 
     def test_authed_user_no_groups_has_no_group_id_clause(self):
         user = User(username="u@example.com", groups=frozenset())
-        ors = MongoDbContributionRepository._build_scope(user)["$or"]
+        ors = MongoDbContributionRepository.read_scope.query(user)["$or"]
         assert not any("_id" in c for c in ors)
 
 

--- a/mpcontribs-api/tests/unit/domains/test_initiative_service.py
+++ b/mpcontribs-api/tests/unit/domains/test_initiative_service.py
@@ -1,0 +1,169 @@
+"""Mock-repo unit tests for :class:`InitiativeService` write policy.
+
+Fast and hermetic: the repository is an ``AsyncMock``, so these exercise the service's branch logic
+directly — which exception each policy violation raises, and which repository primitive the happy
+path calls. Real-DB behaviour is covered in ``tests/integration/db/test_initiatives_service.py``.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from beanie import PydanticObjectId
+
+from mpcontribs_api.authz import User
+from mpcontribs_api.config import get_settings
+from mpcontribs_api.domains._shared.models import DeleteResponse
+from mpcontribs_api.domains.initiatives.models import InitiativeIn, InitiativePatch
+from mpcontribs_api.domains.initiatives.service import InitiativeService
+from mpcontribs_api.exceptions import ConflictError, NotFoundError, ValidationError
+from mpcontribs_api.exceptions import PermissionError as AppPermissionError
+
+pytestmark = pytest.mark.asyncio
+
+ADMIN = User(username="google:admin@example.com", groups=frozenset({"admin"}))
+ALICE = User(username="google:alice@example.com", groups=frozenset())
+ANON = User()
+
+ALICE_EMAIL = "google:alice@example.com"
+
+
+def _collaborator(slug: str, username: str = "google:bob@example.com") -> User:
+    return User(username=username, groups=frozenset({f"initiative:{slug}"}))
+
+
+def _existing(owner: str = ALICE_EMAIL, *, is_public: bool = False, is_approved: bool = False):
+    """A stand-in for the scoped InitiativeOut a read returns (only the fields the service reads)."""
+    return SimpleNamespace(
+        id=PydanticObjectId(), slug="init-1", owner=owner, is_public=is_public, is_approved=is_approved
+    )
+
+
+def _service(user: User, *, existing=None, unapproved: int = 0):
+    initiatives = AsyncMock()
+    initiatives.get_one.return_value = existing
+    initiatives.count_unapproved_for_owner.return_value = unapproved
+    initiatives.insert_one.side_effect = lambda data, owner: SimpleNamespace(slug=data.slug, owner=owner)
+    initiatives.patch_one.return_value = _existing()
+    initiatives.delete_one.return_value = DeleteResponse(num_deleted=1)
+    projects = AsyncMock()
+    projects.clear_initiative_refs.return_value = 0
+    return InitiativeService(user=user, initiatives=initiatives, projects=projects), initiatives
+
+
+def _limit() -> int:
+    return get_settings().domain.initiatives.max_unapproved_per_owner
+
+
+# ---------------------------------------------------------------------------
+# insert_one
+# ---------------------------------------------------------------------------
+
+
+class TestInsert:
+    async def test_anonymous_raises_permission(self):
+        svc, initiatives = _service(ANON)
+        with pytest.raises(AppPermissionError):
+            await svc.insert_one(InitiativeIn(slug="x-init", name="X"))
+        initiatives.insert_one.assert_not_called()
+
+    async def test_over_quota_raises_conflict(self):
+        svc, initiatives = _service(ALICE, unapproved=_limit())
+        with pytest.raises(ConflictError):
+            await svc.insert_one(InitiativeIn(slug="x-init", name="X"))
+        initiatives.insert_one.assert_not_called()
+
+    async def test_admin_bypasses_quota(self):
+        svc, initiatives = _service(ADMIN, unapproved=_limit() + 5)
+        await svc.insert_one(InitiativeIn(slug="x-init", name="X"))
+        initiatives.insert_one.assert_awaited_once()
+        # count is never consulted for an admin
+        initiatives.count_unapproved_for_owner.assert_not_called()
+
+    async def test_happy_path_forces_owner(self):
+        svc, initiatives = _service(ALICE, unapproved=0)
+        await svc.insert_one(InitiativeIn(slug="x-init", name="X"))
+        assert initiatives.insert_one.call_args.kwargs["owner"] == ALICE_EMAIL
+
+
+# ---------------------------------------------------------------------------
+# patch_one
+# ---------------------------------------------------------------------------
+
+
+class TestPatch:
+    async def test_missing_raises_not_found(self):
+        svc, initiatives = _service(ADMIN, existing=None)
+        with pytest.raises(NotFoundError):
+            await svc.patch_one({"slug": "init-1"}, InitiativePatch(name="new-name"))
+        initiatives.patch_one.assert_not_called()
+
+    async def test_unmanaged_caller_raises_permission(self):
+        # A stranger who can see the initiative still cannot manage it.
+        stranger = User(username="google:carol@example.com", groups=frozenset())
+        svc, initiatives = _service(stranger, existing=_existing(owner=ALICE_EMAIL))
+        with pytest.raises(AppPermissionError):
+            await svc.patch_one({"slug": "init-1"}, InitiativePatch(name="hijack"))
+        initiatives.patch_one.assert_not_called()
+
+    async def test_collaborator_can_patch(self):
+        svc, initiatives = _service(_collaborator("init-1"), existing=_existing(owner=ALICE_EMAIL))
+        await svc.patch_one({"slug": "init-1"}, InitiativePatch(name="ok"))
+        initiatives.patch_one.assert_awaited_once()
+
+    async def test_non_admin_approve_raises_permission(self):
+        svc, initiatives = _service(ALICE, existing=_existing(owner=ALICE_EMAIL))
+        with pytest.raises(AppPermissionError):
+            await svc.patch_one({"slug": "init-1"}, InitiativePatch(is_approved=True))
+        initiatives.patch_one.assert_not_called()
+
+    async def test_public_on_unapproved_raises_validation(self):
+        svc, initiatives = _service(ADMIN, existing=_existing(owner=ALICE_EMAIL, is_approved=False))
+        with pytest.raises(ValidationError):
+            await svc.patch_one({"slug": "init-1"}, InitiativePatch(is_public=True))
+        initiatives.patch_one.assert_not_called()
+
+    async def test_admin_approve_and_publish_together_ok(self):
+        svc, initiatives = _service(ADMIN, existing=_existing(owner=ALICE_EMAIL, is_approved=False))
+        await svc.patch_one({"slug": "init-1"}, InitiativePatch(is_approved=True, is_public=True))
+        initiatives.patch_one.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# delete_one
+# ---------------------------------------------------------------------------
+
+
+class TestDelete:
+    async def test_missing_raises_not_found(self):
+        svc, initiatives = _service(ALICE, existing=None)
+        with pytest.raises(NotFoundError):
+            await svc.delete_one({"slug": "init-1"})
+        initiatives.delete_one.assert_not_called()
+
+    async def test_collaborator_cannot_delete(self):
+        # Collaborators may manage/patch but not dissolve — delete needs owner or admin.
+        svc, initiatives = _service(_collaborator("init-1"), existing=_existing(owner=ALICE_EMAIL))
+        with pytest.raises(AppPermissionError):
+            await svc.delete_one({"slug": "init-1"})
+        initiatives.delete_one.assert_not_called()
+
+    async def test_owner_deletes(self):
+        existing = _existing(owner=ALICE_EMAIL)
+        svc, initiatives = _service(ALICE, existing=existing)
+        await svc.delete_one({"slug": "init-1"})
+        initiatives.delete_one.assert_awaited_once_with({"slug": "init-1"})
+        # The member projects' dangling links are cleared by the deleted initiative's id.
+        svc._projects.clear_initiative_refs.assert_awaited_once_with(existing.id)
+
+    async def test_admin_deletes_any(self):
+        svc, initiatives = _service(ADMIN, existing=_existing(owner=ALICE_EMAIL))
+        await svc.delete_one({"slug": "init-1"})
+        initiatives.delete_one.assert_awaited_once()
+
+    async def test_denied_delete_leaves_projects_untouched(self):
+        # A blocked delete must not orphan project links: no cleanup runs when the gate rejects.
+        svc, initiatives = _service(_collaborator("init-1"), existing=_existing(owner=ALICE_EMAIL))
+        with pytest.raises(AppPermissionError):
+            await svc.delete_one({"slug": "init-1"})
+        svc._projects.clear_initiative_refs.assert_not_called()

--- a/mpcontribs-api/tests/unit/domains/test_initiative_service.py
+++ b/mpcontribs-api/tests/unit/domains/test_initiative_service.py
@@ -41,12 +41,12 @@ def _existing(owner: str = ALICE_EMAIL, *, is_public: bool = False, is_approved:
 
 def _service(user: User, *, existing=None, unapproved: int = 0):
     initiatives = AsyncMock()
-    initiatives.get_one.return_value = existing
+    initiatives.read_one.return_value = existing
     initiatives.count_matching.return_value = unapproved
     # The service builds the stored document (document_model.from_input_model, which stamps owner)
     # before inserting; keep document_model a sync mock so it returns a document, not a coroutine.
     initiatives.document_model = MagicMock()
-    initiatives.patch_one.return_value = _existing()
+    initiatives.update_one.return_value = _existing()
     initiatives.delete_one.return_value = DeleteResponse(num_deleted=1)
     projects = AsyncMock()
     projects.clear_initiative_refs.return_value = 0
@@ -91,7 +91,7 @@ class TestInsert:
 
 
 # ---------------------------------------------------------------------------
-# patch_one
+# update_one
 # ---------------------------------------------------------------------------
 
 
@@ -99,38 +99,38 @@ class TestPatch:
     async def test_missing_raises_not_found(self):
         svc, initiatives = _service(ADMIN, existing=None)
         with pytest.raises(NotFoundError):
-            await svc.patch_one({"slug": "init-1"}, InitiativePatch(name="new-name"))
-        initiatives.patch_one.assert_not_called()
+            await svc.update_one({"slug": "init-1"}, InitiativePatch(name="new-name"))
+        initiatives.update_one.assert_not_called()
 
     async def test_unmanaged_caller_raises_permission(self):
         # A stranger who can see the initiative still cannot manage it.
         stranger = User(username="google:carol@example.com", groups=frozenset())
         svc, initiatives = _service(stranger, existing=_existing(owner=ALICE_EMAIL))
         with pytest.raises(AppPermissionError):
-            await svc.patch_one({"slug": "init-1"}, InitiativePatch(name="hijack"))
-        initiatives.patch_one.assert_not_called()
+            await svc.update_one({"slug": "init-1"}, InitiativePatch(name="hijack"))
+        initiatives.update_one.assert_not_called()
 
     async def test_collaborator_can_patch(self):
         svc, initiatives = _service(_collaborator("init-1"), existing=_existing(owner=ALICE_EMAIL))
-        await svc.patch_one({"slug": "init-1"}, InitiativePatch(name="ok"))
-        initiatives.patch_one.assert_awaited_once()
+        await svc.update_one({"slug": "init-1"}, InitiativePatch(name="ok"))
+        initiatives.update_one.assert_awaited_once()
 
     async def test_non_admin_approve_raises_permission(self):
         svc, initiatives = _service(ALICE, existing=_existing(owner=ALICE_EMAIL))
         with pytest.raises(AppPermissionError):
-            await svc.patch_one({"slug": "init-1"}, InitiativePatch(is_approved=True))
-        initiatives.patch_one.assert_not_called()
+            await svc.update_one({"slug": "init-1"}, InitiativePatch(is_approved=True))
+        initiatives.update_one.assert_not_called()
 
     async def test_public_on_unapproved_raises_validation(self):
         svc, initiatives = _service(ADMIN, existing=_existing(owner=ALICE_EMAIL, is_approved=False))
         with pytest.raises(ValidationError):
-            await svc.patch_one({"slug": "init-1"}, InitiativePatch(is_public=True))
-        initiatives.patch_one.assert_not_called()
+            await svc.update_one({"slug": "init-1"}, InitiativePatch(is_public=True))
+        initiatives.update_one.assert_not_called()
 
     async def test_admin_approve_and_publish_together_ok(self):
         svc, initiatives = _service(ADMIN, existing=_existing(owner=ALICE_EMAIL, is_approved=False))
-        await svc.patch_one({"slug": "init-1"}, InitiativePatch(is_approved=True, is_public=True))
-        initiatives.patch_one.assert_awaited_once()
+        await svc.update_one({"slug": "init-1"}, InitiativePatch(is_approved=True, is_public=True))
+        initiatives.update_one.assert_awaited_once()
 
 
 # ---------------------------------------------------------------------------

--- a/mpcontribs-api/tests/unit/domains/test_initiative_service.py
+++ b/mpcontribs-api/tests/unit/domains/test_initiative_service.py
@@ -42,7 +42,7 @@ def _existing(owner: str = ALICE_EMAIL, *, is_public: bool = False, is_approved:
 def _service(user: User, *, existing=None, unapproved: int = 0):
     initiatives = AsyncMock()
     initiatives.get_one.return_value = existing
-    initiatives.count_unapproved_for_owner.return_value = unapproved
+    initiatives.count_matching.return_value = unapproved
     # The service builds the stored document (document_model.from_input_model, which stamps owner)
     # before inserting; keep document_model a sync mock so it returns a document, not a coroutine.
     initiatives.document_model = MagicMock()
@@ -80,7 +80,7 @@ class TestInsert:
         await svc.insert_one(InitiativeIn(slug="x-init", name="X"))
         initiatives.insert_one.assert_awaited_once()
         # count is never consulted for an admin
-        initiatives.count_unapproved_for_owner.assert_not_called()
+        initiatives.count_matching.assert_not_called()
 
     async def test_happy_path_forces_owner(self):
         svc, initiatives = _service(ALICE, unapproved=0)

--- a/mpcontribs-api/tests/unit/domains/test_initiative_service.py
+++ b/mpcontribs-api/tests/unit/domains/test_initiative_service.py
@@ -6,7 +6,7 @@ path calls. Real-DB behaviour is covered in ``tests/integration/db/test_initiati
 """
 
 from types import SimpleNamespace
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from beanie import PydanticObjectId
@@ -43,7 +43,9 @@ def _service(user: User, *, existing=None, unapproved: int = 0):
     initiatives = AsyncMock()
     initiatives.get_one.return_value = existing
     initiatives.count_unapproved_for_owner.return_value = unapproved
-    initiatives.insert_one.side_effect = lambda data, owner: SimpleNamespace(slug=data.slug, owner=owner)
+    # The service builds the stored document (document_model.from_input_model, which stamps owner)
+    # before inserting; keep document_model a sync mock so it returns a document, not a coroutine.
+    initiatives.document_model = MagicMock()
     initiatives.patch_one.return_value = _existing()
     initiatives.delete_one.return_value = DeleteResponse(num_deleted=1)
     projects = AsyncMock()
@@ -83,7 +85,9 @@ class TestInsert:
     async def test_happy_path_forces_owner(self):
         svc, initiatives = _service(ALICE, unapproved=0)
         await svc.insert_one(InitiativeIn(slug="x-init", name="X"))
-        assert initiatives.insert_one.call_args.kwargs["owner"] == ALICE_EMAIL
+        # owner is stamped during document construction, then the built document is inserted.
+        assert initiatives.document_model.from_input_model.call_args.kwargs["owner"] == ALICE_EMAIL
+        initiatives.insert_one.assert_awaited_once_with(initiatives.document_model.from_input_model.return_value)
 
 
 # ---------------------------------------------------------------------------

--- a/mpcontribs-api/tests/unit/domains/test_project_group_service.py
+++ b/mpcontribs-api/tests/unit/domains/test_project_group_service.py
@@ -34,9 +34,9 @@ def _make_service(group: ProjectGroupOut | None, *, visible_projects: set[str] |
     admin = User(username="google:admin@example.com", groups=frozenset({"admin"}))
 
     if ambiguous:
-        groups.get_one.side_effect = ConflictError("ambiguous")
+        groups.read_one.side_effect = ConflictError("ambiguous")
     else:
-        groups.get_one.return_value = group
+        groups.read_one.return_value = group
     # coerce_identifiers is a sync repo method; keep it sync so the service gets a real dict, not a coroutine.
     def _coerce_identifiers(identifiers):
         if isinstance(identifiers.get("id"), str):

--- a/mpcontribs-api/tests/unit/domains/test_project_group_service.py
+++ b/mpcontribs-api/tests/unit/domains/test_project_group_service.py
@@ -44,6 +44,9 @@ def _make_service(group: ProjectGroupOut | None, *, visible_projects: set[str] |
         return identifiers
 
     groups.coerce_identifiers = MagicMock(side_effect=_coerce_identifiers)
+    # The service builds the stored document (document_model.from_input_model) before inserting;
+    # keep document_model a sync mock so from_input_model returns a document, not a coroutine.
+    groups.document_model = MagicMock()
     groups.add_project_refs.return_value = group
     groups.delete_project_refs.return_value = group
 
@@ -80,7 +83,9 @@ class TestInsert_one:
         payload = self._payload(["mp-1", "mp-2"])
         result = await service.insert_one(payload)
         assert result == "stored"
-        groups.insert_one.assert_awaited_once_with(in_resource=payload)
+        # The service converts the payload to a document, then inserts that document.
+        groups.document_model.from_input_model.assert_called_once_with(payload)
+        groups.insert_one.assert_awaited_once_with(groups.document_model.from_input_model.return_value)
 
     async def test_missing_project_raises_not_found_and_skips_insert_one(self):
         service, groups, _ = _make_service(None, visible_projects={"mp-1"})
@@ -94,7 +99,8 @@ class TestInsert_one:
         payload = self._payload([])
         await service.insert_one(payload)
         projects.get_one.assert_not_awaited()
-        groups.insert_one.assert_awaited_once_with(in_resource=payload)
+        groups.document_model.from_input_model.assert_called_once_with(payload)
+        groups.insert_one.assert_awaited_once_with(groups.document_model.from_input_model.return_value)
 
 
 # ---------------------------------------------------------------------------

--- a/mpcontribs-api/tests/unit/domains/test_project_group_service.py
+++ b/mpcontribs-api/tests/unit/domains/test_project_group_service.py
@@ -50,11 +50,12 @@ def _make_service(group: ProjectGroupOut | None, *, visible_projects: set[str] |
     groups.add_project_refs.return_value = group
     groups.delete_project_refs.return_value = group
 
-    async def _get_project(identifiers, fields=None):
-        pid = identifiers["id"]
-        return {"_id": pid} if pid in visible else None
+    # Project references are validated in one batched lookup: the projects repo reports the visible
+    # subset of the requested ids in a single call.
+    async def _existing_ids(ids, *, scoped):
+        return {pid for pid in ids if pid in visible}
 
-    projects.get_one.side_effect = _get_project
+    projects.existing_ids = AsyncMock(side_effect=_existing_ids)
 
     return ProjectGroupService(user=admin, groups=groups, projects=projects), groups, projects
 
@@ -94,11 +95,26 @@ class TestInsert_one:
         assert exc.value.context["ids"] == ["ghost"]
         groups.insert_one.assert_not_awaited()
 
-    async def test_empty_projects_insert_ones_without_validation(self):
+    async def test_projects_validated_in_single_batched_call(self):
+        service, groups, projects = _make_service(None, visible_projects={"mp-1", "mp-2", "mp-3"})
+        groups.insert_one.return_value = "stored"
+        await service.insert_one(self._payload(["mp-1", "mp-2", "mp-3"]))
+        # One lookup for the whole batch, not one query per project id.
+        projects.existing_ids.assert_awaited_once_with(["mp-1", "mp-2", "mp-3"], scoped=True)
+
+    async def test_mixed_valid_and_missing_reported_from_one_batch(self):
+        service, groups, _ = _make_service(None, visible_projects={"mp-1", "mp-3"})
+        with pytest.raises(NotFoundError) as exc:
+            await service.insert_one(self._payload(["mp-1", "mp-ghost", "mp-3"]))
+        assert exc.value.context["ids"] == ["mp-ghost"]
+        groups.insert_one.assert_not_awaited()
+
+    async def test_empty_projects_insert_ones_in_single_batched_check(self):
         service, groups, projects = _make_service(None)
         payload = self._payload([])
         await service.insert_one(payload)
-        projects.get_one.assert_not_awaited()
+        # Validation is one batched call (a no-op for an empty reference list), never per-project.
+        projects.existing_ids.assert_awaited_once_with([], scoped=True)
         groups.document_model.from_input_model.assert_called_once_with(payload)
         groups.insert_one.assert_awaited_once_with(groups.document_model.from_input_model.return_value)
 
@@ -165,6 +181,13 @@ class TestAddProjects:
         summary = await service.add_projects({"id": str(group.id)}, ["mp-1", "mp-1"])
         assert summary.succeeded == ["mp-1"]
         groups.add_project_refs.assert_awaited_once_with(group.id, ["mp-1"])
+
+    async def test_projects_validated_in_single_batched_call(self):
+        group = _group()
+        service, groups, projects = _make_service(group, visible_projects={"mp-1", "mp-2", "mp-3"})
+        await service.add_projects({"id": str(group.id)}, ["mp-1", "mp-2", "mp-3"])
+        # One lookup for the whole batch, not one query per project id.
+        projects.existing_ids.assert_awaited_once_with(["mp-1", "mp-2", "mp-3"], scoped=True)
 
 
 # ---------------------------------------------------------------------------

--- a/mpcontribs-api/tests/unit/domains/test_project_group_service.py
+++ b/mpcontribs-api/tests/unit/domains/test_project_group_service.py
@@ -28,10 +28,10 @@ def _make_service(group: ProjectGroupOut | None, *, visible_projects: set[str] |
     visible = visible_projects or set()
     groups = AsyncMock()
     projects = AsyncMock()
-    #.insert_one() forces owner to the caller for non-admins; give the stub an admin user so these
+    # insert_one forces owner to the caller for non-admins; construct the service as an admin so these
     # payload-identity assertions exercise the pass-through path (owner-forcing is covered end-to-end
     # in the db service test).
-    groups._user = User(username="google:admin@example.com", groups=frozenset({"admin"}))
+    admin = User(username="google:admin@example.com", groups=frozenset({"admin"}))
 
     if ambiguous:
         groups.get_one.side_effect = ConflictError("ambiguous")
@@ -53,7 +53,7 @@ def _make_service(group: ProjectGroupOut | None, *, visible_projects: set[str] |
 
     projects.get_one.side_effect = _get_project
 
-    return ProjectGroupService(groups=groups, projects=projects), groups, projects
+    return ProjectGroupService(user=admin, groups=groups, projects=projects), groups, projects
 
 
 def _group(project_ids: list[str] | None = None) -> ProjectGroupOut:

--- a/mpcontribs-api/tests/unit/domains/test_project_service.py
+++ b/mpcontribs-api/tests/unit/domains/test_project_service.py
@@ -62,10 +62,10 @@ def _service(user: User, *, existing=None, scoped=None, count: int = 0, limits: 
     # class (an AsyncMock child would turn the classmethod call into a coroutine).
     projects.document_model = Project
     projects.find_by_id_unscoped.return_value = existing
-    projects.get_one.return_value = scoped
+    projects.read_one.return_value = scoped
     projects.count_matching.return_value = count
     projects.upsert_one.side_effect = lambda doc, **kw: doc
-    projects.patch_one.return_value = _project()
+    projects.update_one.return_value = _project()
     projects.delete_one.return_value = DeleteResponse(num_deleted=1)
     initiatives = AsyncMock()
     svc = ProjectService(user=user, projects=projects, initiatives=initiatives, limits=limits)
@@ -159,7 +159,7 @@ class TestUpsert:
 
 
 # ---------------------------------------------------------------------------
-# patch_one
+# update_one
 # ---------------------------------------------------------------------------
 
 
@@ -167,39 +167,39 @@ class TestPatch:
     async def test_non_admin_is_approved_raises_permission(self):
         svc, projects, _ = _service(ALICE, scoped=_project())
         with pytest.raises(AppPermissionError):
-            await svc.patch_one({"id": "proj-1"}, ProjectPatch(is_approved=True))
-        projects.patch_one.assert_not_called()
+            await svc.update_one({"id": "proj-1"}, ProjectPatch(is_approved=True))
+        projects.update_one.assert_not_called()
 
     async def test_missing_raises_not_found(self):
         svc, projects, _ = _service(ADMIN, scoped=None)
         with pytest.raises(NotFoundError):
-            await svc.patch_one({"id": "proj-1"}, ProjectPatch(title="new-title"))
-        projects.patch_one.assert_not_called()
+            await svc.update_one({"id": "proj-1"}, ProjectPatch(title="new-title"))
+        projects.update_one.assert_not_called()
 
     async def test_public_on_unapproved_raises_validation(self):
         svc, projects, _ = _service(ADMIN, scoped=_project(is_approved=False, is_public=False))
         with pytest.raises(ValidationError):
-            await svc.patch_one({"id": "proj-1"}, ProjectPatch(is_public=True))
-        projects.patch_one.assert_not_called()
+            await svc.update_one({"id": "proj-1"}, ProjectPatch(is_public=True))
+        projects.update_one.assert_not_called()
 
     async def test_plain_patch_forwards_to_repo(self):
         svc, projects, _ = _service(ADMIN, scoped=_project(is_approved=True))
-        await svc.patch_one({"id": "proj-1"}, ProjectPatch(title="new"))
-        projects.patch_one.assert_awaited_once()
+        await svc.update_one({"id": "proj-1"}, ProjectPatch(title="new"))
+        projects.update_one.assert_awaited_once()
         # plain path: no extra_set
-        assert "extra_set" not in projects.patch_one.call_args.kwargs
+        assert "extra_set" not in projects.update_one.call_args.kwargs
 
     async def test_initiative_assignment_resolves_link_and_sets_extra(self):
         oid = PydanticObjectId()
         svc, projects, initiatives = _service(ADMIN, scoped=_project(is_approved=True))
-        initiatives.get_one.return_value = MagicMock(id=oid, owner="someone@x.com", is_approved=True)
-        await svc.patch_one({"id": "proj-1"}, ProjectPatch(initiative="solar"))
+        initiatives.read_one.return_value = MagicMock(id=oid, owner="someone@x.com", is_approved=True)
+        await svc.update_one({"id": "proj-1"}, ProjectPatch(initiative="solar"))
         # The service resolves the slug to a DBRef and hands it to the repo via extra_set.
-        extra = projects.patch_one.call_args.kwargs["extra_set"]
+        extra = projects.update_one.call_args.kwargs["extra_set"]
         assert extra["initiative"] == DBRef("initiatives", oid)
 
     async def test_initiative_unassign_passes_none(self):
         svc, projects, initiatives = _service(ADMIN, scoped=_project(is_approved=True))
-        await svc.patch_one({"id": "proj-1"}, ProjectPatch(initiative=None))
-        initiatives.get_one.assert_not_called()
-        assert projects.patch_one.call_args.kwargs["extra_set"] == {"initiative": None}
+        await svc.update_one({"id": "proj-1"}, ProjectPatch(initiative=None))
+        initiatives.read_one.assert_not_called()
+        assert projects.update_one.call_args.kwargs["extra_set"] == {"initiative": None}

--- a/mpcontribs-api/tests/unit/domains/test_project_service.py
+++ b/mpcontribs-api/tests/unit/domains/test_project_service.py
@@ -64,7 +64,7 @@ def _service(user: User, *, existing=None, scoped=None, count: int = 0, limits: 
     projects.find_by_id_unscoped.return_value = existing
     projects.get_one.return_value = scoped
     projects.count_for_owner.return_value = count
-    projects.save.side_effect = lambda doc, **kw: doc
+    projects.upsert_one.side_effect = lambda doc, **kw: doc
     projects.patch_one.return_value = _project()
     projects.delete_one.return_value = DeleteResponse(num_deleted=1)
     initiatives = AsyncMock()
@@ -111,13 +111,13 @@ class TestUpsert:
         svc, projects, _ = _service(ANON)
         with pytest.raises(AppPermissionError):
             await svc.upsert_one({"id": "proj-1"}, _project_in("p1"))
-        projects.save.assert_not_called()
+        projects.upsert_one.assert_not_called()
 
     async def test_existing_non_owner_raises_permission(self):
         svc, projects, _ = _service(BOB, existing=_project(owner=ALICE_EMAIL))
         with pytest.raises(AppPermissionError):
             await svc.upsert_one({"id": "proj-1"}, _project_in("p1"))
-        projects.save.assert_not_called()
+        projects.upsert_one.assert_not_called()
 
     async def test_update_preserves_owner_and_server_fields(self):
         existing = _project(
@@ -130,7 +130,7 @@ class TestUpsert:
         svc, projects, _ = _service(ALICE, existing=existing)
         # Body tries to reassign owner and drop publication; both must be ignored/preserved.
         await svc.upsert_one({"id": "proj-1"}, _project_in("p1", owner=BOB_EMAIL, is_public=False))
-        saved = projects.save.call_args.args[0]
+        saved = projects.upsert_one.call_args.args[0]
         assert saved.owner == ALICE_EMAIL
         assert saved.is_public is True
         assert saved.is_approved is True
@@ -140,7 +140,7 @@ class TestUpsert:
     async def test_new_forces_owner_and_unapproves(self):
         svc, projects, _ = _service(BOB, existing=None, count=0)
         await svc.upsert_one({"id": "proj-1"}, _project_in("p1", owner=ALICE_EMAIL, is_approved=True))
-        saved = projects.save.call_args.args[0]
+        saved = projects.upsert_one.call_args.args[0]
         assert saved.owner == BOB_EMAIL
         assert saved.is_approved is False
 
@@ -148,14 +148,14 @@ class TestUpsert:
         svc, projects, _ = _service(ALICE, existing=None, count=5, limits=ConsumerSettings(max_projects=2))
         with pytest.raises(AppPermissionError):
             await svc.upsert_one({"id": "proj-1"}, _project_in("p1", owner=ALICE_EMAIL))
-        projects.save.assert_not_called()
+        projects.upsert_one.assert_not_called()
 
     async def test_public_unapproved_raises_validation(self):
         # Admin new project: approval is not forced off, so a public+unapproved body trips the invariant.
         svc, projects, _ = _service(ADMIN, existing=None, count=0)
         with pytest.raises(ValidationError):
             await svc.upsert_one({"id": "proj-1"}, _project_in("p1", is_public=True, is_approved=False))
-        projects.save.assert_not_called()
+        projects.upsert_one.assert_not_called()
 
 
 # ---------------------------------------------------------------------------

--- a/mpcontribs-api/tests/unit/domains/test_project_service.py
+++ b/mpcontribs-api/tests/unit/domains/test_project_service.py
@@ -1,0 +1,205 @@
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from beanie import PydanticObjectId
+from bson import DBRef
+
+from mpcontribs_api.authz import User
+from mpcontribs_api.domains._shared.models import DeleteResponse
+from mpcontribs_api.domains.consumers.models import ConsumerSettings
+from mpcontribs_api.domains.projects.models import Column, Project, ProjectIn, ProjectPatch, Stats
+from mpcontribs_api.domains.projects.service import ProjectService
+from mpcontribs_api.exceptions import NotFoundError, ValidationError
+from mpcontribs_api.exceptions import PermissionError as AppPermissionError
+
+pytestmark = pytest.mark.asyncio
+
+ADMIN = User(username="google:admin@example.com", groups=frozenset({"admin"}))
+ALICE = User(username="google:alice@example.com", groups=frozenset())
+BOB = User(username="google:bob@example.com", groups=frozenset())
+ANON = User()
+
+ALICE_EMAIL = "google:alice@example.com"
+BOB_EMAIL = "google:bob@example.com"
+
+
+def _project(
+    id: str = "proj-1",
+    owner: str = ALICE_EMAIL,
+    *,
+    is_public: bool = False,
+    is_approved: bool = False,
+    stats: Stats | None = None,
+    columns: list[Column] | None = None,
+) -> Project:
+    doc = Project.from_input_model(
+        ProjectIn(
+            title="test-project",
+            authors="a",
+            description="d",
+            owner=owner,
+            is_public=is_public,
+            is_approved=is_approved,
+        ),
+        id=id,
+    )
+    if stats is not None:
+        doc.stats = stats
+    if columns is not None:
+        doc.columns = columns
+    return doc
+
+
+def _project_in(id: str = "p1", **overrides) -> ProjectIn:
+    defaults = {"title": "test-project", "authors": "a", "description": "d", "owner": ALICE_EMAIL}
+    defaults.update(overrides)
+    return ProjectIn(**defaults)
+
+
+def _service(user: User, *, existing=None, scoped=None, count: int = 0, limits: ConsumerSettings | None = None):
+    projects = AsyncMock()
+    # The service builds documents via ``repo.document_model.from_input_model`` — keep that the real
+    # class (an AsyncMock child would turn the classmethod call into a coroutine).
+    projects.document_model = Project
+    projects.find_by_id_unscoped.return_value = existing
+    projects.get_one.return_value = scoped
+    projects.count_for_owner.return_value = count
+    projects.save.side_effect = lambda doc, **kw: doc
+    projects.patch_one.return_value = _project()
+    projects.delete_one.return_value = DeleteResponse(num_deleted=1)
+    initiatives = AsyncMock()
+    svc = ProjectService(user=user, projects=projects, initiatives=initiatives, limits=limits)
+    return svc, projects, initiatives
+
+
+# ---------------------------------------------------------------------------
+# delete_one
+# ---------------------------------------------------------------------------
+
+
+class TestDelete:
+    async def test_missing_raises_not_found(self):
+        svc, projects, _ = _service(ALICE, scoped=None)
+        with pytest.raises(NotFoundError):
+            await svc.delete_one({"id": "proj-1"})
+        projects.delete_one.assert_not_called()
+
+    async def test_non_owner_raises_permission(self):
+        svc, projects, _ = _service(BOB, scoped=_project(owner=ALICE_EMAIL))
+        with pytest.raises(AppPermissionError):
+            await svc.delete_one({"id": "proj-1"})
+        projects.delete_one.assert_not_called()
+
+    async def test_owner_deletes(self):
+        svc, projects, _ = _service(ALICE, scoped=_project(owner=ALICE_EMAIL))
+        await svc.delete_one({"id": "proj-1"})
+        projects.delete_one.assert_awaited_once_with({"id": "proj-1"})
+
+    async def test_admin_deletes_any(self):
+        svc, projects, _ = _service(ADMIN, scoped=_project(owner=ALICE_EMAIL))
+        await svc.delete_one({"id": "proj-1"})
+        projects.delete_one.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# upsert_one
+# ---------------------------------------------------------------------------
+
+
+class TestUpsert:
+    async def test_anonymous_raises_permission(self):
+        svc, projects, _ = _service(ANON)
+        with pytest.raises(AppPermissionError):
+            await svc.upsert_one({"id": "proj-1"}, _project_in("p1"))
+        projects.save.assert_not_called()
+
+    async def test_existing_non_owner_raises_permission(self):
+        svc, projects, _ = _service(BOB, existing=_project(owner=ALICE_EMAIL))
+        with pytest.raises(AppPermissionError):
+            await svc.upsert_one({"id": "proj-1"}, _project_in("p1"))
+        projects.save.assert_not_called()
+
+    async def test_update_preserves_owner_and_server_fields(self):
+        existing = _project(
+            owner=ALICE_EMAIL,
+            is_public=True,
+            is_approved=True,
+            stats=Stats(contributions=9),
+            columns=[Column(path="data.x")],
+        )
+        svc, projects, _ = _service(ALICE, existing=existing)
+        # Body tries to reassign owner and drop publication; both must be ignored/preserved.
+        await svc.upsert_one({"id": "proj-1"}, _project_in("p1", owner=BOB_EMAIL, is_public=False))
+        saved = projects.save.call_args.args[0]
+        assert saved.owner == ALICE_EMAIL
+        assert saved.is_public is True
+        assert saved.is_approved is True
+        assert saved.stats.contributions == 9
+        assert [c.path for c in saved.columns] == ["data.x"]
+
+    async def test_new_forces_owner_and_unapproves(self):
+        svc, projects, _ = _service(BOB, existing=None, count=0)
+        await svc.upsert_one({"id": "proj-1"}, _project_in("p1", owner=ALICE_EMAIL, is_approved=True))
+        saved = projects.save.call_args.args[0]
+        assert saved.owner == BOB_EMAIL
+        assert saved.is_approved is False
+
+    async def test_new_over_cap_raises_permission(self):
+        svc, projects, _ = _service(ALICE, existing=None, count=5, limits=ConsumerSettings(max_projects=2))
+        with pytest.raises(AppPermissionError):
+            await svc.upsert_one({"id": "proj-1"}, _project_in("p1", owner=ALICE_EMAIL))
+        projects.save.assert_not_called()
+
+    async def test_public_unapproved_raises_validation(self):
+        # Admin new project: approval is not forced off, so a public+unapproved body trips the invariant.
+        svc, projects, _ = _service(ADMIN, existing=None, count=0)
+        with pytest.raises(ValidationError):
+            await svc.upsert_one({"id": "proj-1"}, _project_in("p1", is_public=True, is_approved=False))
+        projects.save.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# patch_one
+# ---------------------------------------------------------------------------
+
+
+class TestPatch:
+    async def test_non_admin_is_approved_raises_permission(self):
+        svc, projects, _ = _service(ALICE, scoped=_project())
+        with pytest.raises(AppPermissionError):
+            await svc.patch_one({"id": "proj-1"}, ProjectPatch(is_approved=True))
+        projects.patch_one.assert_not_called()
+
+    async def test_missing_raises_not_found(self):
+        svc, projects, _ = _service(ADMIN, scoped=None)
+        with pytest.raises(NotFoundError):
+            await svc.patch_one({"id": "proj-1"}, ProjectPatch(title="new-title"))
+        projects.patch_one.assert_not_called()
+
+    async def test_public_on_unapproved_raises_validation(self):
+        svc, projects, _ = _service(ADMIN, scoped=_project(is_approved=False, is_public=False))
+        with pytest.raises(ValidationError):
+            await svc.patch_one({"id": "proj-1"}, ProjectPatch(is_public=True))
+        projects.patch_one.assert_not_called()
+
+    async def test_plain_patch_forwards_to_repo(self):
+        svc, projects, _ = _service(ADMIN, scoped=_project(is_approved=True))
+        await svc.patch_one({"id": "proj-1"}, ProjectPatch(title="new"))
+        projects.patch_one.assert_awaited_once()
+        # plain path: no extra_set
+        assert "extra_set" not in projects.patch_one.call_args.kwargs
+
+    async def test_initiative_assignment_resolves_link_and_sets_extra(self):
+        oid = PydanticObjectId()
+        svc, projects, initiatives = _service(ADMIN, scoped=_project(is_approved=True))
+        initiatives.get_one.return_value = MagicMock(id=oid, owner="someone@x.com", is_approved=True)
+        await svc.patch_one({"id": "proj-1"}, ProjectPatch(initiative="solar"))
+        # The service resolves the slug to a DBRef and hands it to the repo via extra_set.
+        extra = projects.patch_one.call_args.kwargs["extra_set"]
+        assert extra["initiative"] == DBRef("initiatives", oid)
+
+    async def test_initiative_unassign_passes_none(self):
+        svc, projects, initiatives = _service(ADMIN, scoped=_project(is_approved=True))
+        await svc.patch_one({"id": "proj-1"}, ProjectPatch(initiative=None))
+        initiatives.get_one.assert_not_called()
+        assert projects.patch_one.call_args.kwargs["extra_set"] == {"initiative": None}

--- a/mpcontribs-api/tests/unit/domains/test_project_service.py
+++ b/mpcontribs-api/tests/unit/domains/test_project_service.py
@@ -63,7 +63,7 @@ def _service(user: User, *, existing=None, scoped=None, count: int = 0, limits: 
     projects.document_model = Project
     projects.find_by_id_unscoped.return_value = existing
     projects.get_one.return_value = scoped
-    projects.count_for_owner.return_value = count
+    projects.count_matching.return_value = count
     projects.upsert_one.side_effect = lambda doc, **kw: doc
     projects.patch_one.return_value = _project()
     projects.delete_one.return_value = DeleteResponse(num_deleted=1)

--- a/mpcontribs-api/tests/unit/domains/test_shared_repository_download.py
+++ b/mpcontribs-api/tests/unit/domains/test_shared_repository_download.py
@@ -15,6 +15,7 @@ from pydantic import BaseModel
 from mpcontribs_api.authz import User
 from mpcontribs_api.domains._shared.repository import MongoDbRepository
 from mpcontribs_api.domains._shared.types import DownloadFormat, ShortMimeFormat
+from mpcontribs_api.scope import Scope
 
 # ---------------------------------------------------------------------------
 # Test doubles
@@ -73,10 +74,7 @@ class _FakeRepo(MongoDbRepository):
 
     document_model = MagicMock()
     out_model = _Out
-
-    @staticmethod
-    def _build_scope(user: User) -> dict[str, Any]:
-        return {}
+    read_scope = Scope()
 
 
 def _repo(out_model: type[BaseModel] = _Out) -> _FakeRepo:

--- a/mpcontribs-api/tests/unit/test_scope.py
+++ b/mpcontribs-api/tests/unit/test_scope.py
@@ -1,0 +1,201 @@
+"""Unit tests for the composable read-visibility scope (``mpcontribs_api.scope``).
+
+Pure and DB-free. Two layers:
+- each clause's ``to_query`` in isolation (including the ``None`` "inapplicable" cases and
+  ``RoleIn`` coercion / invalid-drop);
+- ``Scope.query`` composition (admin bypass, empty scope, ``$or`` element order);
+- the per-repository ``read_scope`` declarations still produce the exact Mongo fragments the
+  collections relied on (the integration ``db`` visibility suites remain the end-to-end guard).
+"""
+
+from beanie import PydanticObjectId
+
+from mpcontribs_api.authz import (
+    INITIATIVE_ROLE_PREFIX,
+    PROJECT_GROUP_ROLE_PREFIX,
+    User,
+)
+from mpcontribs_api.domains.contributions.repository import MongoDbContributionRepository
+from mpcontribs_api.domains.initiatives.repository import InitiativeRepository
+from mpcontribs_api.domains.project_groups.repository import ProjectGroupRepository
+from mpcontribs_api.domains.projects.repository import MongoDbProjectRepository
+from mpcontribs_api.scope import Owned, Public, RoleIn, Scope
+
+ADMIN = User(username="google:admin@example.com", groups=frozenset({"admin"}))
+ANON = User()
+ALICE = User(username="google:alice@example.com", groups=frozenset())
+
+
+def _clauses(scope: dict) -> list[dict]:
+    """The ``$or`` clauses of a non-empty scope."""
+    return scope["$or"]
+
+
+# ---------------------------------------------------------------------------
+# Clauses in isolation
+# ---------------------------------------------------------------------------
+
+
+class TestPublicClause:
+    def test_unapproved_public_only(self):
+        assert Public().to_query(ANON) == {"is_public": True}
+
+    def test_approved_adds_is_approved(self):
+        assert Public(approved=True).to_query(ANON) == {"is_public": True, "is_approved": True}
+
+    def test_applies_to_everyone(self):
+        # Public is the baseline clause: it never returns None, even for anonymous callers.
+        assert Public().to_query(ANON) is not None
+        assert Public().to_query(ALICE) is not None
+
+
+class TestOwnedClause:
+    def test_authenticated_gets_owner_clause(self):
+        assert Owned().to_query(ALICE) == {"owner": "google:alice@example.com"}
+
+    def test_custom_owner_field(self):
+        assert Owned("created_by").to_query(ALICE) == {"created_by": "google:alice@example.com"}
+
+    def test_anonymous_is_inapplicable(self):
+        # {owner: None} would wrongly match owner-less documents, so the clause drops out.
+        assert Owned().to_query(ANON) is None
+
+
+class TestRoleInClause:
+    def test_membership_test_sorted(self):
+        user = User(username="u@x.com", groups=frozenset({"mp-b", "mp-a"}))
+        assert RoleIn("_id", "project_roles").to_query(user) == {"_id": {"$in": ["mp-a", "mp-b"]}}
+
+    def test_no_roles_is_inapplicable(self):
+        user = User(username="u@x.com", groups=frozenset())
+        assert RoleIn("_id", "project_roles").to_query(user) is None
+
+    def test_coerce_maps_each_value(self):
+        oid = "a" * 24
+        user = User(username="u@x.com", groups=frozenset({f"{PROJECT_GROUP_ROLE_PREFIX}{oid}"}))
+        clause = RoleIn("_id", "project_group_roles", coerce=PydanticObjectId)
+        assert clause.to_query(user) == {"_id": {"$in": [PydanticObjectId(oid)]}}
+
+    def test_coerce_drops_invalid_values(self):
+        oid = "a" * 24
+        user = User(
+            username="u@x.com",
+            groups=frozenset({f"{PROJECT_GROUP_ROLE_PREFIX}{oid}", f"{PROJECT_GROUP_ROLE_PREFIX}not-an-oid"}),
+        )
+        clause = RoleIn("_id", "project_group_roles", coerce=PydanticObjectId)
+        # The malformed hex string is fail-closed dropped; only the valid ObjectId survives.
+        assert clause.to_query(user) == {"_id": {"$in": [PydanticObjectId(oid)]}}
+
+    def test_coerce_all_invalid_is_inapplicable(self):
+        user = User(username="u@x.com", groups=frozenset({f"{PROJECT_GROUP_ROLE_PREFIX}nope"}))
+        clause = RoleIn("_id", "project_group_roles", coerce=PydanticObjectId)
+        assert clause.to_query(user) is None
+
+
+# ---------------------------------------------------------------------------
+# Scope composition
+# ---------------------------------------------------------------------------
+
+
+class TestScopeQuery:
+    scope = Scope(Public(approved=True), Owned(), RoleIn("_id", "project_roles"))
+
+    def test_admin_bypasses_scope(self):
+        assert self.scope.query(ADMIN) == {}
+
+    def test_empty_scope_matches_all(self):
+        # No clauses (unscoped collection) → no filter, for any caller.
+        assert Scope().query(ANON) == {}
+        assert Scope().query(ALICE) == {}
+
+    def test_anonymous_gets_only_applicable_clauses(self):
+        # Public applies; Owned and (no-role) RoleIn drop out.
+        assert self.scope.query(ANON) == {"$or": [{"is_public": True, "is_approved": True}]}
+
+    def test_clause_order_preserved(self):
+        user = User(username="alice@x.com", groups=frozenset({"mp-a"}))
+        assert _clauses(self.scope.query(user)) == [
+            {"is_public": True, "is_approved": True},
+            {"owner": "alice@x.com"},
+            {"_id": {"$in": ["mp-a"]}},
+        ]
+
+
+# ---------------------------------------------------------------------------
+# Per-repository declarations reproduce the expected fragments
+# ---------------------------------------------------------------------------
+
+
+class TestProjectScope:
+    scope = MongoDbProjectRepository.read_scope
+
+    def test_admin_unfiltered(self):
+        assert self.scope.query(ADMIN) == {}
+
+    def test_public_approved_owner_and_bare_project_ids(self):
+        user = User(username="alice@x.com", groups=frozenset({"mp-a", "mp-b"}))
+        clauses = _clauses(self.scope.query(user))
+        assert {"is_public": True, "is_approved": True} in clauses
+        assert {"owner": "alice@x.com"} in clauses
+        assert {"_id": {"$in": ["mp-a", "mp-b"]}} in clauses
+
+    def test_prefixed_and_admin_roles_excluded_from_id_clause(self):
+        # Only bare project ids may key the _id clause; resource-scoped/admin roles must not leak in.
+        user = User(
+            username="alice@x.com",
+            groups=frozenset({"mp-a", f"{INITIATIVE_ROLE_PREFIX}foo", f"{PROJECT_GROUP_ROLE_PREFIX}deadbeef"}),
+        )
+        role_clause = next(c for c in _clauses(self.scope.query(user)) if "_id" in c)
+        assert role_clause == {"_id": {"$in": ["mp-a"]}}
+
+
+class TestInitiativeScope:
+    scope = InitiativeRepository.read_scope
+
+    def test_admin_unfiltered(self):
+        assert self.scope.query(ADMIN) == {}
+
+    def test_public_approved_owner_and_slug_roles(self):
+        user = User(username="alice@x.com", groups=frozenset({f"{INITIATIVE_ROLE_PREFIX}solar"}))
+        clauses = _clauses(self.scope.query(user))
+        assert {"is_public": True, "is_approved": True} in clauses
+        assert {"owner": "alice@x.com"} in clauses
+        assert {"slug": {"$in": ["solar"]}} in clauses
+
+
+class TestProjectGroupScope:
+    scope = ProjectGroupRepository.read_scope
+
+    def test_admin_unfiltered(self):
+        assert self.scope.query(ADMIN) == {}
+
+    def test_public_clause_has_no_approval(self):
+        clauses = _clauses(self.scope.query(ANON))
+        assert {"is_public": True} in clauses
+        assert all("is_approved" not in c for c in clauses)
+
+    def test_valid_group_roles_become_objectids_invalid_dropped(self):
+        oid = "a" * 24
+        user = User(
+            username="alice@x.com",
+            groups=frozenset({f"{PROJECT_GROUP_ROLE_PREFIX}{oid}", f"{PROJECT_GROUP_ROLE_PREFIX}not-an-oid"}),
+        )
+        role_clause = next(c for c in _clauses(self.scope.query(user)) if "_id" in c)
+        assert role_clause == {"_id": {"$in": [PydanticObjectId(oid)]}}
+
+
+class TestContributionScope:
+    scope = MongoDbContributionRepository.read_scope
+
+    def test_admin_unfiltered(self):
+        assert self.scope.query(ADMIN) == {}
+
+    def test_no_owner_clause_and_public_unapproved(self):
+        user = User(username="alice@x.com", groups=frozenset({"mp-a"}))
+        clauses = _clauses(self.scope.query(user))
+        assert {"is_public": True} in clauses
+        assert all("owner" not in c for c in clauses)
+        assert {"project": {"$in": ["mp-a"]}} in clauses
+
+    def test_anonymous_only_public(self):
+        assert _clauses(self.scope.query(ANON)) == [{"is_public": True}]

--- a/mpcontribs-api/tests/unit/test_scope.py
+++ b/mpcontribs-api/tests/unit/test_scope.py
@@ -16,8 +16,8 @@ from mpcontribs_api.authz import (
     User,
 )
 from mpcontribs_api.domains.contributions.repository import MongoDbContributionRepository
-from mpcontribs_api.domains.initiatives.repository import InitiativeRepository
-from mpcontribs_api.domains.project_groups.repository import ProjectGroupRepository
+from mpcontribs_api.domains.initiatives.repository import MongoDbInitiativeRepository
+from mpcontribs_api.domains.project_groups.repository import MongoDbProjectGroupRepository
 from mpcontribs_api.domains.projects.repository import MongoDbProjectRepository
 from mpcontribs_api.scope import Owned, Public, RoleIn, Scope
 
@@ -150,7 +150,7 @@ class TestProjectScope:
 
 
 class TestInitiativeScope:
-    scope = InitiativeRepository.read_scope
+    scope = MongoDbInitiativeRepository.read_scope
 
     def test_admin_unfiltered(self):
         assert self.scope.query(ADMIN) == {}
@@ -164,7 +164,7 @@ class TestInitiativeScope:
 
 
 class TestProjectGroupScope:
-    scope = ProjectGroupRepository.read_scope
+    scope = MongoDbProjectGroupRepository.read_scope
 
     def test_admin_unfiltered(self):
         assert self.scope.query(ADMIN) == {}


### PR DESCRIPTION
## Summary
Previously, some routers talked to the service AND the repo, and the repo knew a lot about the broader domain and business logic. This branch strengthened the relationships and clarified the boundaries. Routers now exclusively call service methods, which know about domain models and how they relate, as well as the shape of the domain repo. The repo exposes thin (when possible) methods for interacting with the underlying DB.

## Major changes:
- All routers now only call to the related service instead of repos
- All repos are more focused on pure database interactions
    - Most business logic now lives in the service layer
    - Methods now expect Documents rather than DocumentIn
- Scope transitioned from a per-repo _build_scope method to a declarative Policy pattern
    - See scope.py