### PR TITLE
ProjectTag to control Project.tags vocabulary

### DIFF
--- a/mpcontribs-api/src/mpcontribs_api/domains/projects/models.py
+++ b/mpcontribs-api/src/mpcontribs_api/domains/projects/models.py
@@ -1,3 +1,4 @@
+from enum import StrEnum
 from typing import Any, Literal
 
 from beanie import Link
@@ -58,6 +59,44 @@ class Reference(BaseModel):
     url: HttpUrl
 
 
+class ProjectTag(StrEnum):
+    """Controlled vocabulary for tagging projects"""
+
+    catalysis = "catalysis"
+    batteries = "batteries"
+    photovoltaics = "photovoltaics"
+    thermoelectrics = "thermoelectrics"
+    carbon_capture = "carbon_capture"
+    superconductors = "superconductors"
+    hydrogen_storage = "hydrogen_storage"
+    fuel_cells = "fuel_cells"
+    magnets = "magnets"
+    coatings = "coatings"
+    perovskites = "perovskites"
+    mofs = "mofs"
+    alloys = "alloys"
+    two_d_materials = "two_d_materials"
+    oxides = "oxides"
+    polymers = "polymers"
+    zeolites = "zeolites"
+    high_entropy_alloys = "high_entropy_alloys"
+    electronic_structure = "electronic_structure"
+    thermodynamics = "thermodynamics"
+    mechanical = "mechanical"
+    magnetism = "magentism"
+    dielectric = "dielectric"
+    optical = "optical"
+    phonons = "phonons"
+    defects = "defects"
+    surfaces = "surfaces"
+    transport = "transport"
+    dft = "dft"
+    machine_learning = "machine_learning"
+    experimental = "experimental"
+    high_throughput = "high_throughput"
+    spectroscopy = "spectroscopy"
+
+
 class ProjectBase(BaseModel):
     title: ShortStr
     authors: str
@@ -71,7 +110,7 @@ class ProjectBase(BaseModel):
 
     # Optional
     stats: Stats = Field(default_factory=Stats)
-    tags: list[SearchStr] | None = None
+    tags: list[ProjectTag] | None = None
     mp_category: str | None = None
     references: list[Reference] = Field(default_factory=list)
     long_title: str | None = None

--- a/mpcontribs-api/tests/integration/db/test_projects_repository.py
+++ b/mpcontribs-api/tests/integration/db/test_projects_repository.py
@@ -215,11 +215,11 @@ class TestGetProjectsTagsFilter:
     async def test_contains_requires_all_tags_as_subset(self, db):
         from mpcontribs_api.domains.projects.models import ProjectFilter
 
-        await _insert("tags-superset", tags=["alpha", "beta", "gamma"])
-        await _insert("tags-partial", tags=["alpha", "beta"])
-        await _insert("tags-none", tags=["delta"])
+        await _insert("tags-superset", tags=["catalysis", "batteries", "photovoltaics"])
+        await _insert("tags-partial", tags=["catalysis", "batteries"])
+        await _insert("tags-none", tags=["alloys"])
         page = await _repo(ADMIN).read_many(
-            filter=ProjectFilter(tags__contains=["alpha", "gamma"]),
+            filter=ProjectFilter(tags__contains=["catalysis", "batteries", "photovoltaics"]),
             pagination=CursorParams(),
             fields=None,
         )
@@ -228,10 +228,10 @@ class TestGetProjectsTagsFilter:
     async def test_contains_single_tag(self, db):
         from mpcontribs_api.domains.projects.models import ProjectFilter
 
-        await _insert("tags-single-hit", tags=["alpha", "beta"])
-        await _insert("tags-single-miss", tags=["beta", "gamma"])
+        await _insert("tags-single-hit", tags=["catalysis", "batteries", "photovoltaics"])
+        await _insert("tags-single-miss", tags=["catalysis", "batteries"])
         page = await _repo(ADMIN).read_many(
-            filter=ProjectFilter(tags__contains=["alpha"]),
+            filter=ProjectFilter(tags__contains=["photovoltaics"]),
             pagination=CursorParams(),
             fields=None,
         )
@@ -240,12 +240,12 @@ class TestGetProjectsTagsFilter:
     async def test_contains_parses_comma_string(self, db):
         from mpcontribs_api.domains.projects.models import ProjectFilter
 
-        await _insert("tags-csv-hit", tags=["alpha", "beta", "gamma"])
-        await _insert("tags-csv-miss", tags=["alpha"])
+        await _insert("tags-csv-hit", tags=["catalysis", "batteries", "photovoltaics"])
+        await _insert("tags-csv-miss", tags=["catalysis"])
         # FilterDepends collapses the list query param to a comma string; the
         # BaseFilter validator must re-expand it.
         page = await _repo(ADMIN).read_many(
-            filter=ProjectFilter(tags__contains="alpha,beta"),
+            filter=ProjectFilter(tags__contains="catalysis,batteries"),
             pagination=CursorParams(),
             fields=None,
         )

--- a/mpcontribs-api/tests/unit/domains/test_search_str_tags.py
+++ b/mpcontribs-api/tests/unit/domains/test_search_str_tags.py
@@ -79,35 +79,6 @@ def test_searchstr_fuzz_output_is_stripped_and_casefolded():
 
 
 # ligature + uppercase + trailing NBSP -> "file": exercises fold, casefold, and trim at once.
-_MESSY_TAG = "  ﬁLE "
-
-_TAG_FIELD_EXTRACTORS = [
-    (
-        "project_in_tags",
-        lambda t: ProjectIn(
-            title="title-x",
-            authors="a",
-            description="d",
-            owner="google:a@b.com",
-            tags=[t],
-        ).tags,
-    ),
-    ("project_patch_tags", lambda t: ProjectPatch(tags=[t]).tags),
-    ("filter_tags", lambda t: ProjectFilter(tags=[t]).tags),
-    ("filter_tags__in", lambda t: ProjectFilter(tags__in=[t]).tags__in),
-    ("filter_tags__contains", lambda t: ProjectFilter(tags__contains=[t]).tags__contains),
-    # "etc.": the same SearchStr normalizer, reused on a non-tag list field on another model.
-    ("project_group_filter_name__in", lambda t: ProjectGroupFilter(name__in=[t]).name__in),
-]
-
-
-@pytest.mark.parametrize(
-    "extract", [e for _, e in _TAG_FIELD_EXTRACTORS], ids=[i for i, _ in _TAG_FIELD_EXTRACTORS]
-)
-def test_searchstr_normalized_across_models(extract):
-    assert extract(_MESSY_TAG) == ["file"]
-
-
 def test_searchstr_casefold_expansion_is_idempotent():
     """Covers the tricky edge: a casefold-expanding char (ß -> ss) followed by a combining mark.
 


### PR DESCRIPTION
## Summary
Added ``ProjectTag`` to control the vocabulary of Project.tags

Major changes:
- Added ``ProjectTag``
- ``Project.tags`` is now ``list[ProjectTag]``