### PR TITLE
Align QuantityLeaf fields with current field names

### DIFF
--- a/mpcontribs-api/src/mpcontribs_api/_openapi.py
+++ b/mpcontribs-api/src/mpcontribs_api/_openapi.py
@@ -13,7 +13,7 @@ collapses to a single underscore. So `"bandGap"`, `"Band Gap"`, and `"band-gap"`
 `"band_gap"`, and the **keys you read back may differ from the keys you submitted**. Keys must be
 ASCII and must not reduce to an empty string (e.g. `"***"` is rejected).
 
-**Reserved keys:** `value`, `unit`, `input_value`, `input_unit`, `error`, `input_error`,
+**Reserved keys:** `si_value`, `si_unit`, `value`, `unit`, `si_error`, `error`,
 `precision`, and `display` are reserved for the stored value-leaf shape and may **not** be used as
 data keys (a key that coerces to any of these is rejected).
 
@@ -41,7 +41,7 @@ see the response schema); an unrecognized unit is kept verbatim. Magnitudes may 
 magnitude such as `"1.000"`; a bare JSON number carries no trailing-zero information.
 
 The server does **not** produce a formatted `display` string — the response returns the structured
-fields (`input_value`/`input_unit`/`input_error`/`precision`) so clients render values however they
+fields (`value`/`unit`/`error`/`precision`) so clients render values however they
 prefer. (`display` remains a reserved key for backward compatibility with older stored leaves.)
 
 **Pivoting on conditions:** if any key carries conditions, the single submission is *expanded* into
@@ -63,16 +63,16 @@ coercion rules), so they may differ from the keys originally submitted.
 
 Any value that reads as a number is stored as a **quantity leaf** object:
 
-- `value` / `unit`: the SI-canonical magnitude and unit (or the submitted form when the unit is
+- `si_value` / `si_unit`: the SI-canonical magnitude and unit (or the submitted form when the unit is
   unrecognized or dimensionless)
-- `input_value` / `input_unit`: the magnitude and unit as submitted (omitted for a bare, unitless,
-  exact number that ``value`` already fully describes)
-- `error`: the (SI-propagated) standard deviation — present only when the magnitude carried an
-  uncertainty; `input_error` is the same in the submitted unit
+- `value` / `unit`: the magnitude and unit as submitted (omitted for a bare, unitless,
+  exact number that ``si_value`` already fully describes)
+- `si_error`: the (SI-propagated) standard deviation — present only when the magnitude carried an
+  uncertainty; `error` is the same in the submitted unit
 - `precision`: the number of significant figures the submission carried — present only when it is
   derivable (a string magnitude such as `"1.000"`)
 
-There is no server-rendered `display` string: `input_value`, `input_unit`, `input_error`, and
+There is no server-rendered `display` string: `value`, `unit`, `error`, and
 `precision` reproduce the submitted form exactly, so a client can format the value however it likes.
 
 Values that are not numeric (words, booleans, lists) keep whatever JSON shape they were submitted

--- a/mpcontribs-api/src/mpcontribs_api/domains/_shared/units.py
+++ b/mpcontribs-api/src/mpcontribs_api/domains/_shared/units.py
@@ -73,7 +73,7 @@ def _reject_non_finite(nominal: float, source: Any) -> None:
     """Reject inf/-inf/NaN magnitudes.
 
     ``float("1e999")`` overflows to ``inf`` and ``float("nan")`` parses cleanly, so a finite-looking
-    submission can slip a non-finite value into ``value``. This prevents those values from entering our storage.
+    submission can slip a non-finite value into ``si_value``. This prevents those values from entering our storage.
     """
     if not math.isfinite(nominal):
         raise UnitError(f"non-finite magnitude is not allowed: {source!r}")
@@ -150,11 +150,11 @@ def _reconcile_units(mag: str, embedded_unit: str | None, key_unit: str | None) 
 class QuantityLeaf(BaseModel):
     """The canonical shape of a ``Contribution.data`` quantity leaf, its factory, and its predicates.
 
-    ``value``/``unit`` hold the SI-canonical form (or the submitted form when the unit is
+    ``si_value``/``si_unit`` hold the SI-canonical form (or the submitted form when the unit is
         unrecognized/dimensionless)
-    ``input_value``/``input_unit`` hold the submitted form.
-    ``error`` is the (SI-propagated) standard deviation, present only when the magnitude carried an uncertainty
-    ``input_error`` is the same uncertainty in the submitted unit.
+    ``value``/``unit`` hold the submitted form.
+    ``si_error`` is the (SI-propagated) standard deviation, present only when the magnitude carried an uncertainty
+    ``error`` is the same uncertainty in the submitted unit.
     ``precision`` is the number of significant digits the submission carried (string magnitudes only); it is ``None``
         for a numeric submission, which carries no trailing-zero information. ``display`` is an optional free-form
         human-readable string (never derived; carried verbatim when supplied).
@@ -163,20 +163,20 @@ class QuantityLeaf(BaseModel):
     them as plain ``data`` keys.
     """
 
-    value: float
+    si_value: float
+    si_unit: str | None = None
+    value: float | None = None
     unit: str | None = None
-    input_value: float | None = None
-    input_unit: str | None = None
+    si_error: float | None = None
     error: float | None = None
-    input_error: float | None = None
     precision: int | None = None
     display: str | None = None
 
-    # Each canonical leaf field paired with the ``input_*`` field that records its submitted form.
+    # Each SI-canonical leaf field paired with the submitted-form field that records its submitted value.
     _INPUT_FIELD_OF: ClassVar[dict[str, str]] = {
-        "value": "input_value",
-        "unit": "input_unit",
-        "error": "input_error",
+        "si_value": "value",
+        "si_unit": "unit",
+        "si_error": "error",
     }
 
     @classmethod
@@ -189,11 +189,11 @@ class QuantityLeaf(BaseModel):
 
     @classmethod
     def is_leaf(cls, node: Any) -> bool:
-        """True when ``node`` is a stored quantity leaf (numeric ``value`` + only reserved keys)."""
+        """True when ``node`` is a stored quantity leaf (numeric ``si_value`` + only reserved keys)."""
         if not isinstance(node, dict):
             return False
-        value = node.get("value")
-        if not isinstance(value, (int, float)) or isinstance(value, bool):
+        si_value = node.get("si_value")
+        if not isinstance(si_value, (int, float)) or isinstance(si_value, bool):
             return False
         return node.keys() <= cls.reserved_keys()
 
@@ -215,9 +215,9 @@ class QuantityLeaf(BaseModel):
             value: the submitted magnitude (number, or a string possibly carrying uncertainty)
             unit: the resolved unit string, or ``None``/empty for unit-less
 
-        ``value``/``unit`` are canonical SI when convertible else the submitted form;
-        ``input_value``/``input_unit`` hold the submitted form (kept only when a unit is present or
-        canonicalization changed the magnitude); ``error`` is present only for an uncertain magnitude;
+        ``si_value``/``si_unit`` are canonical SI when convertible else the submitted form;
+        ``value``/``unit`` hold the submitted form (kept only when a unit is present or
+        canonicalization changed the magnitude); ``si_error`` is present only for an uncertain magnitude;
         ``precision`` is the submitted significant-figure count for a string magnitude (``None`` for a
         numeric submission).
 
@@ -239,10 +239,10 @@ class QuantityLeaf(BaseModel):
         """Canonicalize a pre-split ``(nominal, error, unit)`` submission into a leaf.
 
         The post-parse half of :meth:`from_submission`, shared with :meth:`patch_leaf`: SI-convert
-        (propagating the uncertainty through Pint) when the unit is recognized, keep the ``input_*``
-        provenance when a unit is present or canonicalization changed the magnitude, and carry
-        ``precision`` through. ``nominal``/``error`` are the submitted magnitude and uncertainty in
-        ``unit``.
+        (propagating the uncertainty through Pint) when the unit is recognized, keep the submitted-form
+        (``value``/``unit``/``error``) provenance when a unit is present or canonicalization changed the
+        magnitude, and carry ``precision`` through. ``nominal``/``error`` are the submitted magnitude and
+        uncertainty in ``unit``.
         """
         if unit:
             unit = nfc_normalize(unit)
@@ -263,15 +263,15 @@ class QuantityLeaf(BaseModel):
                     canon_value, canon_error = cv, ce
                     canon_unit = _format_unit(quantity.units)
 
-        # Keep the input_* if we had to coerce things
+        # Keep the submitted-form fields if we had to coerce things
         keep_input = bool(unit) or canon_value != nominal
         return cls(
-            value=canon_value,
-            unit=canon_unit,
-            input_value=nominal if keep_input else None,
-            input_unit=unit if keep_input else None,
-            error=canon_error,
-            input_error=error if keep_input else None,
+            si_value=canon_value,
+            si_unit=canon_unit,
+            value=nominal if keep_input else None,
+            unit=unit if keep_input else None,
+            si_error=canon_error,
+            error=error if keep_input else None,
             precision=precision,
         )
 
@@ -300,17 +300,17 @@ class QuantityLeaf(BaseModel):
                 return existing[input_key]
             return existing.get(canon_key)
 
-        unit = submitted("unit")
-        magnitude = _parse_magnitude(submitted("value"))
+        unit = submitted("si_unit")
+        magnitude = _parse_magnitude(submitted("si_value"))
         nominal, parsed_error = _split_ufloat(magnitude)
         # An explicit error override wins; otherwise an uncertainty embedded in the magnitude wins;
         # otherwise the existing submitted error carries over.
-        if "error" in overrides or "input_error" in overrides:
-            error = overrides.get("error", overrides.get("input_error"))
+        if "si_error" in overrides or "error" in overrides:
+            error = overrides.get("si_error", overrides.get("error"))
         elif parsed_error is not None:
             error = parsed_error
         else:
-            error = submitted("error")
+            error = submitted("si_error")
 
         precision = overrides.get("precision", existing.get("precision"))
         leaf = cls._from_parts(nominal, error, unit, precision=precision).as_dict()
@@ -423,15 +423,15 @@ class QuantityLeaf(BaseModel):
         """Render one canonical condition value for the identity string.
 
         A categorical string is returned verbatim; a leaf dict is rendered from its canonical (SI)
-        ``value`` at fixed precision (``:unit`` suffix when present) so physically-equal conditions
+        ``si_value`` at fixed precision (``:si_unit`` suffix when present) so physically-equal conditions
         collapse to the same key.
         """
         if isinstance(leaf, str):
             return leaf
-        value = leaf.get("value")
-        unit = leaf.get("unit")
-        num = _IDENTITY_FMT.format(value) if isinstance(value, (int, float)) else str(value)
-        return f"{num}:{unit}" if unit else num
+        si_value = leaf.get("si_value")
+        si_unit = leaf.get("si_unit")
+        num = _IDENTITY_FMT.format(si_value) if isinstance(si_value, (int, float)) else str(si_value)
+        return f"{num}:{si_unit}" if si_unit else num
 
     @staticmethod
     def condition_key(conditions: dict[str, dict[str, Any] | str]) -> str:

--- a/mpcontribs-api/src/mpcontribs_api/domains/contributions/stats.py
+++ b/mpcontribs-api/src/mpcontribs_api/domains/contributions/stats.py
@@ -45,7 +45,7 @@ def iter_leaves(data: dict[str, Any], prefix: str = "") -> Iterator[tuple[str, f
         path = f"{prefix}.{key}" if prefix else key
         if isinstance(node, dict):
             if QuantityLeaf.is_leaf(node):
-                yield path, float(node["value"]), node.get("unit")
+                yield path, float(node["si_value"]), node.get("si_unit")
             else:
                 yield from iter_leaves(node, path)
         elif isinstance(node, bool):

--- a/mpcontribs-api/tests/integration/db/test_bulk_publish.py
+++ b/mpcontribs-api/tests/integration/db/test_bulk_publish.py
@@ -164,7 +164,7 @@ class TestBulkPatchPerRow:
 
     async def test_bare_scalar_updates_quantity_leaf_magnitude(self, db, mongo_client):
         # A stored quantity leaf is conceptually a scalar: a bare-scalar patch is the new submitted
-        # magnitude. The leaf is re-derived end-to-end (unit kept, input_value updated), and the
+        # magnitude. The leaf is re-derived end-to-end (unit kept, value updated), and the
         # persisted leaf matches the pure patch_leaf helper.
         leaf = QuantityLeaf.from_submission(2.0, "m").as_dict()
         c = await _insert_row(PROJ_A, formula="Fe2O3", data={"bandgap": leaf})
@@ -175,26 +175,26 @@ class TestBulkPatchPerRow:
 
         assert (summary.matched, summary.modified) == (1, 1)
         reloaded = (await _reload(c.id)).data["bandgap"]
-        assert reloaded == QuantityLeaf.patch_leaf(leaf, {"value": 5.0})
-        assert reloaded["input_value"] == 5.0
-        assert reloaded["unit"] == "m"
+        assert reloaded == QuantityLeaf.patch_leaf(leaf, {"si_value": 5.0})
+        assert reloaded["value"] == 5.0
+        assert reloaded["si_unit"] == "m"
 
     async def test_unit_change_re_syncs_and_re_converts_leaf(self, db, mongo_client):
-        # Updating the unit re-canonicalizes the whole leaf: input_unit tracks the new unit and the
-        # canonical value/error are re-converted to SI (2 m -> input 2 km -> 2000 m).
+        # Updating the unit re-canonicalizes the whole leaf: unit tracks the new unit and the
+        # canonical si_value/si_error are re-converted to SI (2 m -> input 2 km -> 2000 m).
         leaf = QuantityLeaf.from_submission(2.0, "m").as_dict()
         c = await _insert_row(PROJ_A, formula="Fe2O3", data={"bandgap": leaf})
 
         summary = await _service(mongo_client, ALICE).update_many(
-            ContributionFilter(chemical_system_id="Fe-O"), ContributionPatch(data={"bandgap": {"unit": "km"}})
+            ContributionFilter(chemical_system_id="Fe-O"), ContributionPatch(data={"bandgap": {"si_unit": "km"}})
         )
 
         assert (summary.matched, summary.modified) == (1, 1)
         reloaded = (await _reload(c.id)).data["bandgap"]
-        assert reloaded == QuantityLeaf.patch_leaf(leaf, {"unit": "km"})
-        assert reloaded["input_unit"] == "km"
-        assert reloaded["input_value"] == 2.0
-        assert reloaded["value"] == 2000.0
+        assert reloaded == QuantityLeaf.patch_leaf(leaf, {"si_unit": "km"})
+        assert reloaded["unit"] == "km"
+        assert reloaded["value"] == 2.0
+        assert reloaded["si_value"] == 2000.0
 
     async def test_identity_collision_reports_per_row_conflict(self, db, mongo_client):
         # Setting formula to a value another matched row already owns collides on the identity index:

--- a/mpcontribs-api/tests/unit/domains/test_conditions_fuzz.py
+++ b/mpcontribs-api/tests/unit/domains/test_conditions_fuzz.py
@@ -43,10 +43,10 @@ class TestParseConditionValueRobustness:
         if isinstance(out, dict):
             # A numeric leaf must be finite (the inf/NaN guard) and representable in strict JSON so it
             # survives storage and canonical_md5 hashing.
-            assert math.isfinite(out["value"])
-            # input_value is omitted for a bare, exact, unit-less number (value fully describes it).
-            if "input_value" in out:
-                assert math.isfinite(out["input_value"])
+            assert math.isfinite(out["si_value"])
+            # value is omitted for a bare, exact, unit-less number (si_value fully describes it).
+            if "value" in out:
+                assert math.isfinite(out["value"])
             json.dumps(out, allow_nan=False)
 
     @settings(max_examples=200, deadline=None, suppress_health_check=[HealthCheck.too_slow])
@@ -180,11 +180,11 @@ class TestConditionEdgeCases:
     def test_negative_numeric_condition(self):
         leaf = parse_condition_value("-40degC")
         assert isinstance(leaf, dict)
-        assert leaf["input_value"] == -40.0
+        assert leaf["value"] == -40.0
 
     def test_exponent_numeric_condition(self):
         leaf = parse_condition_value("1.5e3 K")
-        assert math.isclose(leaf["value"], 1500.0)
+        assert math.isclose(leaf["si_value"], 1500.0)
 
     def test_condition_value_unit_nfc_normalized(self):
         ohm_sign, greek_omega = "\u2126", "\u03a9"  # OHM SIGN vs GREEK CAPITAL OMEGA

--- a/mpcontribs-api/tests/unit/domains/test_contribution_repository.py
+++ b/mpcontribs-api/tests/unit/domains/test_contribution_repository.py
@@ -3,7 +3,7 @@
 Covers the additive-merge translation of a patch's ``data`` against the *stored* shape:
 ``flatten_merge_paths`` produces the dotted ``$set`` paths Mongo receives, and ``merge_data`` produces
 the equivalent post-write view used to resolve identity. Both follow one rule — a patch onto a stored
-quantity leaf re-derives the whole leaf (so its canonical and ``input_*`` halves stay in sync, see
+quantity leaf re-derives the whole leaf (so its SI-canonical and submitted-form halves stay in sync, see
 ``patch_leaf``), a plain group is descended so unmentioned siblings survive, and any other scalar
 sets its path directly. Precise SI-conversion behavior of ``patch_leaf`` is covered in ``test_units``.
 """
@@ -38,20 +38,20 @@ class TestFlattenMergePaths:
 
     def test_leaf_patch_sets_the_whole_recomputed_leaf(self):
         # A fragment touching a stored leaf writes the whole re-derived leaf at its path (not a
-        # sub-path), so value/unit/error and input_* can be re-synced together. Changing the unit to
-        # km re-converts the magnitude (2 m -> input 2 km -> 2000 m) and updates input_unit.
-        out = flatten_merge_paths({"bandgap": LEAF}, {"bandgap": {"unit": "km"}}, prefix="data.")
-        assert set(out) == {"data.bandgap"}  # whole leaf, not data.bandgap.unit
-        assert out["data.bandgap"] == QuantityLeaf.patch_leaf(LEAF, {"unit": "km"})
-        assert out["data.bandgap"]["value"] == 2000.0
-        assert out["data.bandgap"]["input_unit"] == "km"
+        # sub-path), so si_value/si_unit/si_error and value/unit/error can be re-synced together.
+        # Changing the unit to km re-converts the magnitude (2 m -> input 2 km -> 2000 m) and updates unit.
+        out = flatten_merge_paths({"bandgap": LEAF}, {"bandgap": {"si_unit": "km"}}, prefix="data.")
+        assert set(out) == {"data.bandgap"}  # whole leaf, not data.bandgap.si_unit
+        assert out["data.bandgap"] == QuantityLeaf.patch_leaf(LEAF, {"si_unit": "km"})
+        assert out["data.bandgap"]["si_value"] == 2000.0
+        assert out["data.bandgap"]["unit"] == "km"
 
     def test_bare_scalar_onto_leaf_updates_magnitude(self):
         # A bare scalar is the new submitted magnitude; the leaf is re-derived, keeping the unit.
         out = flatten_merge_paths({"bandgap": LEAF}, {"bandgap": 5.0}, prefix="data.")
-        assert out == {"data.bandgap": QuantityLeaf.patch_leaf(LEAF, {"value": 5.0})}
-        assert out["data.bandgap"]["input_value"] == 5.0
-        assert out["data.bandgap"]["unit"] == "m"
+        assert out == {"data.bandgap": QuantityLeaf.patch_leaf(LEAF, {"si_value": 5.0})}
+        assert out["data.bandgap"]["value"] == 5.0
+        assert out["data.bandgap"]["si_unit"] == "m"
 
     def test_plain_group_descends_and_keeps_siblings(self):
         assert flatten_merge_paths({"grp": {"a": 1}}, {"grp": {"b": 2}}, prefix="data.") == {"data.grp.b": 2}
@@ -74,12 +74,12 @@ class TestFlattenMergePaths:
 class TestMergeData:
     def test_leaf_patch_matches_flatten(self):
         # merge_data is the post-write view flatten_merge_paths would produce, key by key.
-        merged = merge_data({"bandgap": LEAF}, {"bandgap": {"unit": "km"}})
-        assert merged["bandgap"] == QuantityLeaf.patch_leaf(LEAF, {"unit": "km"})
+        merged = merge_data({"bandgap": LEAF}, {"bandgap": {"si_unit": "km"}})
+        assert merged["bandgap"] == QuantityLeaf.patch_leaf(LEAF, {"si_unit": "km"})
 
     def test_bare_scalar_rederives_leaf(self):
         merged = merge_data({"bandgap": LEAF}, {"bandgap": 5.0})
-        assert merged["bandgap"] == QuantityLeaf.patch_leaf(LEAF, {"value": 5.0})
+        assert merged["bandgap"] == QuantityLeaf.patch_leaf(LEAF, {"si_value": 5.0})
 
     def test_new_key_and_sibling_survival(self):
         merged = merge_data({"x": 1, "grp": {"a": 1}}, {"y": 2, "grp": {"b": 2}})

--- a/mpcontribs-api/tests/unit/domains/test_contribution_stats.py
+++ b/mpcontribs-api/tests/unit/domains/test_contribution_stats.py
@@ -11,9 +11,9 @@ from mpcontribs_api.domains.contributions.stats import (
 
 def _annotated(value: float, unit: str | None = None) -> dict:
     """A minimal canonical annotated-leaf dict (see QuantityLeaf.as_dict)."""
-    leaf = {"value": value, "input_value": value, "display": str(value)}
+    leaf = {"si_value": value, "value": value, "display": str(value)}
     if unit is not None:
-        leaf["unit"] = unit
+        leaf["si_unit"] = unit
     return leaf
 
 

--- a/mpcontribs-api/tests/unit/domains/test_contributions_models.py
+++ b/mpcontribs-api/tests/unit/domains/test_contributions_models.py
@@ -8,6 +8,7 @@ from mpcontribs_api.authz import User
 from mpcontribs_api.domains.contributions.repository import MongoDbContributionRepository
 
 from mpcontribs_api.domains._shared.types import Identity
+from mpcontribs_api.domains._shared.units import QuantityLeaf
 from mpcontribs_api.domains.contributions.models import (
     Contribution,
     ContributionFilter,
@@ -43,7 +44,7 @@ def _make_contribution_in(**overrides) -> ContributionIn:
         "material_id": "mp-1234",
         "chemical_system_id": "Fe-O",
         "formula": "Fe2O3",
-        "data": {"band_gap": {"value": 2.1, "unit": "eV"}},
+        "data": {"band_gap": QuantityLeaf.from_submission(2.1, "eV").as_dict()},
     }
     defaults.update(overrides)
     return ContributionIn(**defaults)
@@ -116,7 +117,7 @@ class TestContributionBase:
         assert contrib.data == {}
 
     def test_data_accepts_nested_structure(self):
-        nested = {"band_gap": {"value": 1.5, "unit": "eV"}, "volume": 42.3}
+        nested = {"band_gap": QuantityLeaf.from_submission(1.5, "eV").as_dict(), "volume": 42.3}
         contrib = _make_contribution_in(data=nested)
         assert contrib.data["band_gap"]["value"] == 1.5
 
@@ -150,7 +151,7 @@ class TestContributionBase:
 
     def test_reserved_leaf_keys_rejected(self):
         # A data key that coerces to a reserved value-leaf name is rejected on write.
-        for bad in ("value", "unit", "error", "precision", "input_value", "display"):
+        for bad in ("value", "unit", "error", "precision", "si_unit", "display"):
             with pytest.raises(ValidationError, match="reserved"):
                 _make_contribution_in(data={bad: 1})
         # rejected when nested, too

--- a/mpcontribs-api/tests/unit/domains/test_contributions_pivot.py
+++ b/mpcontribs-api/tests/unit/domains/test_contributions_pivot.py
@@ -142,14 +142,14 @@ class TestExpandContribution:
         assert len(rows) == 1
         assert rows[0].condition_key == ""
         # Every numeric scalar is promoted to a quantity leaf, at any nesting depth.
-        assert rows[0].contribution.data == {"a": {"b": {"value": 1.5}}, "plain": {"value": 3.0}}
+        assert rows[0].contribution.data == {"a": {"b": {"si_value": 1.5}}, "plain": {"si_value": 3.0}}
 
     def test_unit_only_annotates_in_place_single_row(self):
         rows = expand_contribution(_contrib_in({"bandgap (eV)": 1.1}))
         assert len(rows) == 1
         assert rows[0].condition_key == ""
         leaf = rows[0].contribution.data["bandgap"]
-        assert leaf["input_unit"] == "eV"
+        assert leaf["unit"] == "eV"
 
     def test_pivots_into_one_row_per_signature(self):
         rows = expand_contribution(
@@ -174,7 +174,7 @@ class TestExpandContribution:
         )
         assert len(rows) == 2
         for r in rows:
-            assert math.isclose(r.contribution.data["shared"]["input_value"], 9.0)
+            assert math.isclose(r.contribution.data["shared"]["value"], 9.0)
 
     def test_conditions_stored_as_columns(self):
         rows = expand_contribution(_contrib_in({"conductivity (S/cm, T=300K)": 4.2}))
@@ -182,12 +182,12 @@ class TestExpandContribution:
         data = rows[0].contribution.data
         # condition name coerced to snake_case (T -> t)
         assert "t" in data
-        assert math.isclose(data["t"]["value"], 300.0)
+        assert math.isclose(data["t"]["si_value"], 300.0)
 
     def test_dotted_path_nests(self):
         rows = expand_contribution(_contrib_in({"a.b.c (eV, T=300K)": 2.0}))
         data = rows[0].contribution.data
-        assert "value" in data["a"]["b"]["c"]
+        assert "si_value" in data["a"]["b"]["c"]
 
     def test_same_name_signature_different_unit_collision(self):
         with pytest.raises(ValidationError, match="same path"):
@@ -229,19 +229,19 @@ class TestExpandContribution:
         rows = expand_contribution(_contrib_in({"Band Gap": 1.5, "nested": {"Sub Key": 2}}))
         assert len(rows) == 1
         # keys coerced to snake_case, numeric values promoted to leaves
-        assert rows[0].contribution.data == {"band_gap": {"value": 1.5}, "nested": {"sub_key": {"value": 2.0}}}
+        assert rows[0].contribution.data == {"band_gap": {"si_value": 1.5}, "nested": {"sub_key": {"si_value": 2.0}}}
 
     def test_already_snake_case_keys_still_leafify_numbers(self):
         # Even with nothing to coerce, bare numbers are normalized to quantity leaves.
         c = _contrib_in({"band_gap": 1.5, "nested": {"sub_key": 2}})
         rows = expand_contribution(c)
-        assert rows[0].contribution.data == {"band_gap": {"value": 1.5}, "nested": {"sub_key": {"value": 2.0}}}
+        assert rows[0].contribution.data == {"band_gap": {"si_value": 1.5}, "nested": {"sub_key": {"si_value": 2.0}}}
 
     def test_annotated_path_segments_coerced(self):
         rows = expand_contribution(_contrib_in({"Band Gap (eV, T=300K)": 1.1}))
         data = rows[0].contribution.data
         assert set(data) == {"band_gap", "t"}
-        assert data["band_gap"]["input_unit"] == "eV"
+        assert data["band_gap"]["unit"] == "eV"
 
     def test_forbidden_name_chars_folded_to_underscore(self):
         # '*', '/', and '|' are allowed in the name portion but folded to '_' (not rejected). The
@@ -249,20 +249,20 @@ class TestExpandContribution:
         rows = expand_contribution(_contrib_in({"a/b*c|d (S/cm)": 5}))
         data = rows[0].contribution.data
         assert set(data) == {"a_b_c_d"}
-        assert data["a_b_c_d"]["input_unit"] == "S/cm"
+        assert data["a_b_c_d"]["unit"] == "S/cm"
 
     def test_dotted_path_segments_coerced(self):
         rows = expand_contribution(_contrib_in({"Outer.Inner Key (eV)": 1.1}))
         data = rows[0].contribution.data
-        assert "value" in data["outer"]["inner_key"]
+        assert "si_value" in data["outer"]["inner_key"]
 
     def test_unit_and_condition_value_preserved_verbatim(self):
         # unit (eV) and condition value (300K -> canonical) are never snake_cased; only names are
         rows = expand_contribution(_contrib_in({"Band Gap (eV, Temp=300K)": 1.1}))
         data = rows[0].contribution.data
-        assert data["band_gap"]["input_unit"] == "eV"
+        assert data["band_gap"]["unit"] == "eV"
         assert "temp" in data  # condition name coerced
-        assert math.isclose(data["temp"]["value"], 300.0)
+        assert math.isclose(data["temp"]["si_value"], 300.0)
 
     def test_coercion_collision_across_columns_rejected(self):
         with pytest.raises(ValidationError, match="same path"):

--- a/mpcontribs-api/tests/unit/domains/test_units.py
+++ b/mpcontribs-api/tests/unit/domains/test_units.py
@@ -26,25 +26,25 @@ def _ckey(condition_value: str) -> str:
 class TestAnnotateValue:
     def test_recognized_unit_canonicalizes_to_si_and_keeps_original(self):
         leaf = QuantityLeaf.from_submission(4.2, "eV").as_dict()
-        assert leaf["input_value"] == 4.2
-        assert leaf["input_unit"] == "eV"
+        assert leaf["value"] == 4.2
+        assert leaf["unit"] == "eV"
         # 4.2 eV in joules
-        assert math.isclose(leaf["value"], 4.2 * 1.602176634e-19, rel_tol=1e-9)
-        assert leaf["unit"] != "eV"  # canonicalized to base units
-        assert "error" not in leaf
+        assert math.isclose(leaf["si_value"], 4.2 * 1.602176634e-19, rel_tol=1e-9)
+        assert leaf["si_unit"] != "eV"  # canonicalized to base units
+        assert "si_error" not in leaf
         # no formatted display string is ever stored; clients format from the structured fields
         assert "display" not in leaf
 
     def test_unitless_value(self):
-        # A bare, exact, unit-less number is fully described by ``value``: input_*/display are omitted.
+        # A bare, exact, unit-less number is fully described by ``si_value``: value/unit/display are omitted.
         leaf = QuantityLeaf.from_submission(5, None).as_dict()
-        assert leaf == {"value": 5.0}
+        assert leaf == {"si_value": 5.0}
 
     def test_unknown_unit_stored_as_submitted(self):
         leaf = QuantityLeaf.from_submission(1.0, "widgets").as_dict()
-        assert leaf["value"] == 1.0
+        assert leaf["si_value"] == 1.0
+        assert leaf["si_unit"] == "widgets"
         assert leaf["unit"] == "widgets"
-        assert leaf["input_unit"] == "widgets"
 
     def test_unit_nfc_normalized(self):
         # A unit spelled with the OHM SIGN (U+2126) is NFC-folded onto the Greek omega (U+03A9)
@@ -52,29 +52,29 @@ class TestAnnotateValue:
         ohm_sign, greek_omega = "Ω", "Ω"
         assert ohm_sign != greek_omega
         leaf = QuantityLeaf.from_submission(1.0, ohm_sign).as_dict()
-        assert leaf["input_unit"] == greek_omega
-        assert ohm_sign not in leaf["input_unit"]
+        assert leaf["unit"] == greek_omega
+        assert ohm_sign not in leaf["unit"]
         # Both spellings produce the identical stored/canonical leaf.
         assert leaf == QuantityLeaf.from_submission(1.0, greek_omega).as_dict()
 
     def test_offset_unit_canonicalizes_to_kelvin(self):
         # degC magnitude passed separately is convertible (unlike the string form).
         leaf = QuantityLeaf.from_submission(26.85, "degC").as_dict()
-        assert math.isclose(leaf["value"], 300.0, rel_tol=1e-6)
-        assert leaf["unit"] == "K"
-        assert leaf["input_value"] == 26.85
-        assert leaf["input_unit"] == "degC"
+        assert math.isclose(leaf["si_value"], 300.0, rel_tol=1e-6)
+        assert leaf["si_unit"] == "K"
+        assert leaf["value"] == 26.85
+        assert leaf["unit"] == "degC"
 
     def test_uncertainty_notation_parsed_and_propagated(self):
         leaf = QuantityLeaf.from_submission("4.2(3)", "eV").as_dict()
-        assert "error" in leaf
+        assert "si_error" in leaf
         # error scales with the same eV->J factor as the value
-        assert math.isclose(leaf["error"], 0.3 * 1.602176634e-19, rel_tol=1e-6)
+        assert math.isclose(leaf["si_error"], 0.3 * 1.602176634e-19, rel_tol=1e-6)
 
     def test_plain_numeric_string_has_no_implied_uncertainty(self):
         leaf = QuantityLeaf.from_submission("300", "K").as_dict()
-        assert "error" not in leaf
-        assert math.isclose(leaf["value"], 300.0)
+        assert "si_error" not in leaf
+        assert math.isclose(leaf["si_value"], 300.0)
 
     def test_unparseable_magnitude_raises(self):
         with pytest.raises(UnitError):
@@ -93,14 +93,14 @@ class TestAnnotateValue:
 class TestParseConditionValue:
     def test_numeric_with_unit(self):
         leaf = parse_condition_value("300K")
-        assert leaf["unit"] == "K"
-        assert math.isclose(leaf["value"], 300.0)
+        assert leaf["si_unit"] == "K"
+        assert math.isclose(leaf["si_value"], 300.0)
 
     def test_bare_numeric(self):
         leaf = parse_condition_value("5")
-        assert leaf["value"] == 5.0
+        assert leaf["si_value"] == 5.0
         # unit is omitted (exclude_none) for a unit-less leaf
-        assert leaf.get("unit") is None
+        assert leaf.get("si_unit") is None
 
     def test_categorical_returned_verbatim(self):
         assert parse_condition_value("cubic") == "cubic"
@@ -111,8 +111,8 @@ class TestParseConditionValue:
 
     def test_offset_unit_condition_canonicalizes(self):
         leaf = parse_condition_value("26.85degC")
-        assert leaf["unit"] == "K"
-        assert math.isclose(leaf["value"], 300.0, rel_tol=1e-6)
+        assert leaf["si_unit"] == "K"
+        assert math.isclose(leaf["si_value"], 300.0, rel_tol=1e-6)
 
 
 # ---------------------------------------------------------------------------
@@ -179,11 +179,11 @@ class TestScientificNotationEquivalence:
     def test_measurement_leaf_value_is_hundred(self):
         # The measurement-leaf path (QuantityLeaf.from_submission) normalizes too, not just conditions.
         for spelling in ("1x10^2", "1×10^2", "10²", "1x10**2"):
-            assert math.isclose(QuantityLeaf.from_submission(spelling, "m").as_dict()["input_value"], 100.0)
+            assert math.isclose(QuantityLeaf.from_submission(spelling, "m").as_dict()["value"], 100.0)
 
     def test_negative_exponent_measurement_leaf(self):
         for spelling in ("1x10^-5", "1×10⁻⁵"):
-            assert math.isclose(QuantityLeaf.from_submission(spelling, "m").as_dict()["input_value"], 1e-5)
+            assert math.isclose(QuantityLeaf.from_submission(spelling, "m").as_dict()["value"], 1e-5)
 
 
 # ---------------------------------------------------------------------------
@@ -276,9 +276,9 @@ class TestPrecisionCapture:
         assert QuantityLeaf.from_submission(zeros, "eV").precision == _FLOAT_PRECISION
 
     def test_precision_does_not_change_stored_numeric_value(self):
-        # Recording precision must not alter the stored float value/input_value.
+        # Recording precision must not alter the stored float si_value/value.
         leaf = QuantityLeaf.from_submission("1.000", "eV").as_dict()
-        assert leaf["input_value"] == 1.0
+        assert leaf["value"] == 1.0
 
     def test_identity_still_normalizes_regardless_of_trailing_zeros(self):
         # condition_key uses the canonical float, not precision: "300" and "300.0" still collapse.
@@ -294,22 +294,22 @@ class TestPrecisionCapture:
 
 class TestQuantityLeaf:
     def test_unit_and_error_optional(self):
-        leaf = QuantityLeaf(value=5.0, input_value=5.0)
+        leaf = QuantityLeaf(si_value=5.0, value=5.0)
+        assert leaf.si_unit is None
         assert leaf.unit is None
-        assert leaf.input_unit is None
-        assert leaf.error is None
+        assert leaf.si_error is None
         assert leaf.precision is None
 
     def test_unit_case_preserved(self):
         # units must never be casefolded (eV stays eV, not ev)
-        leaf = QuantityLeaf(value=1.0, unit="eV", input_value=1.0, input_unit="eV")
+        leaf = QuantityLeaf(si_value=1.0, si_unit="eV", value=1.0, unit="eV")
+        assert leaf.si_unit == "eV"
         assert leaf.unit == "eV"
-        assert leaf.input_unit == "eV"
 
     def test_display_not_stored(self):
-        # display is derived on read, never a stored field: value alone is a valid leaf.
-        leaf = QuantityLeaf(value=5.0).as_dict()
-        assert leaf == {"value": 5.0}
+        # display is derived on read, never a stored field: si_value alone is a valid leaf.
+        leaf = QuantityLeaf(si_value=5.0).as_dict()
+        assert leaf == {"si_value": 5.0}
         assert "display" not in leaf
 
 
@@ -319,14 +319,14 @@ class TestQuantityLeafFactory:
     def test_from_submission_returns_model(self):
         leaf = QuantityLeaf.from_submission("4.2", "eV")
         assert isinstance(leaf, QuantityLeaf)
-        assert leaf.input_value == 4.2
-        assert leaf.input_unit == "eV"
+        assert leaf.value == 4.2
+        assert leaf.unit == "eV"
         assert leaf.precision == 2  # "4.2" -> 2 significant figures
 
     def test_from_submission_canonicalizes_to_si(self):
         leaf = QuantityLeaf.from_submission(4.2, "eV")
-        assert leaf.unit != "eV"  # base units
-        assert math.isclose(leaf.value, 4.2 * 1.602176634e-19, rel_tol=1e-9)
+        assert leaf.si_unit != "eV"  # base units
+        assert math.isclose(leaf.si_value, 4.2 * 1.602176634e-19, rel_tol=1e-9)
 
     def test_from_submission_raises_on_unparseable(self):
         with pytest.raises(UnitError):
@@ -334,7 +334,7 @@ class TestQuantityLeafFactory:
 
     def test_as_dict_omits_none_fields(self):
         leaf = QuantityLeaf.from_submission(5, None).as_dict()
-        assert leaf == {"value": 5.0}
+        assert leaf == {"si_value": 5.0}
 
     def test_identity_scalar_categorical_verbatim(self):
         assert QuantityLeaf.identity_scalar("cubic") == "cubic"
@@ -366,26 +366,26 @@ class TestTryFromValue:
     def test_bare_number_becomes_unitless_leaf(self):
         leaf = QuantityLeaf.try_from_value(5, None)
         assert leaf is not None
-        assert leaf.as_dict() == {"value": 5.0}
+        assert leaf.as_dict() == {"si_value": 5.0}
 
     def test_number_with_key_unit(self):  # spreadsheet scenario A: "bandgap (eV)" -> 5
         leaf = QuantityLeaf.try_from_value(5, "eV")
         assert leaf is not None
-        assert leaf.input_value == 5.0
-        assert leaf.input_unit == "eV"
+        assert leaf.value == 5.0
+        assert leaf.unit == "eV"
 
     def test_string_with_embedded_unit(self):  # spreadsheet scenario B: "bandgap" -> "5 eV"
         leaf = QuantityLeaf.try_from_value("5 eV", None)
         assert leaf is not None
-        assert leaf.input_value == 5.0
-        assert leaf.input_unit == "eV"
+        assert leaf.value == 5.0
+        assert leaf.unit == "eV"
 
     def test_scenarios_a_and_b_converge(self):
         # Unit-in-key (number value) and unit-in-value (string) produce the same physical leaf.
         a = QuantityLeaf.try_from_value(5, "eV")
         b = QuantityLeaf.try_from_value("5 eV", None)
         assert a is not None and b is not None
-        for field in ("value", "unit", "input_value", "input_unit"):
+        for field in ("si_value", "si_unit", "value", "unit"):
             assert getattr(a, field) == getattr(b, field)
 
     def test_categorical_string_is_not_a_leaf(self):
@@ -397,9 +397,9 @@ class TestTryFromValue:
     def test_unrecognized_unit_in_value_kept_verbatim(self):
         leaf = QuantityLeaf.try_from_value("5 apples", None)
         assert leaf is not None
-        assert leaf.value == 5.0
+        assert leaf.si_value == 5.0
+        assert leaf.si_unit == "apples"
         assert leaf.unit == "apples"
-        assert leaf.input_unit == "apples"
 
     def test_precision_captured_from_string(self):
         leaf = QuantityLeaf.try_from_value("5.00 eV", None)
@@ -410,14 +410,14 @@ class TestTryFromValue:
         # key unit eV, value unit meV -> converted into eV (5 meV == 0.005 eV).
         leaf = QuantityLeaf.try_from_value("5 meV", "eV")
         assert leaf is not None
-        assert leaf.input_unit == "eV"
-        assert math.isclose(leaf.input_value, 0.005, rel_tol=1e-9)
+        assert leaf.unit == "eV"
+        assert math.isclose(leaf.value, 0.005, rel_tol=1e-9)
 
     def test_conflicting_units_same_dimension_ok(self):
         leaf = QuantityLeaf.try_from_value("5 eV", "eV")
         assert leaf is not None
-        assert leaf.input_unit == "eV"
-        assert leaf.input_value == 5.0
+        assert leaf.unit == "eV"
+        assert leaf.value == 5.0
 
     def test_incompatible_units_rejected(self):
         with pytest.raises(UnitError):
@@ -432,52 +432,52 @@ class TestRepatchLeaf:
 
     def test_unit_change_reconverts_value(self):
         # 2 m stored; re-submit the unit as km -> the magnitude is reinterpreted (2 km) and
-        # re-canonicalized to SI (2000 m); input_unit tracks the new unit, input_value is unchanged.
+        # re-canonicalized to SI (2000 m); unit tracks the new unit, value is unchanged.
         leaf = self._leaf(2.0, "m")
-        out = QuantityLeaf.patch_leaf(leaf, {"unit": "km"})
-        assert out["input_unit"] == "km"
-        assert out["input_value"] == 2.0
-        assert out["value"] == 2000.0
+        out = QuantityLeaf.patch_leaf(leaf, {"si_unit": "km"})
+        assert out["unit"] == "km"
+        assert out["value"] == 2.0
+        assert out["si_value"] == 2000.0
 
-    def test_input_unit_change_is_equivalent_to_unit_change(self):
-        # "vice versa": patching the input_ member drives the same re-derivation.
+    def test_unit_change_is_equivalent_to_si_unit_change(self):
+        # "vice versa": patching the submitted member drives the same re-derivation.
         leaf = self._leaf(2.0, "m")
-        assert QuantityLeaf.patch_leaf(leaf, {"input_unit": "km"}) == QuantityLeaf.patch_leaf(
-            leaf, {"unit": "km"}
+        assert QuantityLeaf.patch_leaf(leaf, {"unit": "km"}) == QuantityLeaf.patch_leaf(
+            leaf, {"si_unit": "km"}
         )
 
     def test_value_change_keeps_unit_and_reconverts(self):
         leaf = self._leaf(2.0, "km")  # canonical 2000 m
-        out = QuantityLeaf.patch_leaf(leaf, {"value": 3.0})
-        assert out["input_value"] == 3.0
-        assert out["input_unit"] == "km"
-        assert out["value"] == 3000.0
+        out = QuantityLeaf.patch_leaf(leaf, {"si_value": 3.0})
+        assert out["value"] == 3.0
+        assert out["unit"] == "km"
+        assert out["si_value"] == 3000.0
 
     def test_error_and_value_reconvert_together_on_unit_change(self):
-        # An uncertain magnitude: changing the unit re-converts both value and error; input_error
+        # An uncertain magnitude: changing the unit re-converts both value and error; error
         # stays in the submitted unit and precision is preserved.
         leaf = self._leaf("2.0+/-0.1", "km")
-        out = QuantityLeaf.patch_leaf(leaf, {"unit": "m"})
-        assert out["input_unit"] == "m"
-        assert out["input_value"] == 2.0
-        assert out["input_error"] == 0.1
-        assert out["value"] == 2.0  # 2 m
+        out = QuantityLeaf.patch_leaf(leaf, {"si_unit": "m"})
+        assert out["unit"] == "m"
+        assert out["value"] == 2.0
         assert out["error"] == 0.1
+        assert out["si_value"] == 2.0  # 2 m
+        assert out["si_error"] == 0.1
         assert out["precision"] == 2
 
     def test_explicit_error_override(self):
         leaf = self._leaf("2.0+/-0.1", "m")
-        out = QuantityLeaf.patch_leaf(leaf, {"error": 0.5})
-        assert out["input_error"] == 0.5
+        out = QuantityLeaf.patch_leaf(leaf, {"si_error": 0.5})
         assert out["error"] == 0.5
+        assert out["si_error"] == 0.5
 
     def test_unrelated_field_unchanged(self):
         # Patching only the unit leaves the submitted magnitude and its canonical value intact.
         leaf = self._leaf(2.0, "m")
-        out = QuantityLeaf.patch_leaf(leaf, {"unit": "m"})
+        out = QuantityLeaf.patch_leaf(leaf, {"si_unit": "m"})
         assert out == leaf
 
     def test_unparseable_override_raises(self):
         leaf = self._leaf(2.0, "m")
         with pytest.raises(UnitError):
-            QuantityLeaf.patch_leaf(leaf, {"value": "not-a-number"})
+            QuantityLeaf.patch_leaf(leaf, {"si_value": "not-a-number"})


### PR DESCRIPTION
## Summary
QuantityLeaf stored input values in fields following the `input_*` pattern. This would force consumers of the server to change their references to accommodate. Now stores inputs in plain fields (ie. `value`) and stores the SI coerced fields in `si_*` fields
Major changes:
- value, unit, error -> si_value, si_unit, si_error
- input_value, input_unit, input_error -> value, unit, error
