### PR TITLE
User improvement

### DIFF
--- a/mpcontribs-api/src/mpcontribs_api/authz.py
+++ b/mpcontribs-api/src/mpcontribs_api/authz.py
@@ -1,6 +1,6 @@
 from fastapi.security import APIKeyHeader
 
-from mpcontribs_api.authz_core import ADMIN_ROLE, PERSSON_ROLE, ReservedRole, Role, UserGroup
+from mpcontribs_api.authz_core import ReservedRole, Role, UserGroup
 from mpcontribs_api.authz_core import User as _CoreUser
 from mpcontribs_api.config import get_settings
 
@@ -33,10 +33,6 @@ authenticated_groups_scheme = APIKeyHeader(
 # The top-level path segment naming this service's authz domain
 DOMAIN = settings.authz.domain
 
-# Reserved roles are only meaningful at the domain root and must never be put on an anonymous caller.
-# Re-exported here (imported by test/other modules) as well as consumed by the legacy parser below.
-_RESERVED_ROLES = frozenset({ADMIN_ROLE, PERSSON_ROLE})
-
 # Canonical second-level path segments (plural collection identifiers, per GCP AIP-122) for the
 # resources with flat authorization consumers today.
 PROJECT_SEGMENT = "projects"
@@ -58,9 +54,9 @@ _LEGACY_ROLE = Role.owner
 def _parse_legacy(token: str) -> UserGroup | None:
     # Only the ``=``-less forms Kong currently forwards are honored; anything else is malformed.
     # Prefixed legacy strings (``initiative:``/``project-group:``) are gone — those are ARN-only now.
-    if token in _RESERVED_ROLES:
-        # Guard guarantees ``token`` is a reserved keyword, so this coercion never raises.
-        return UserGroup(path=(DOMAIN,), role=ReservedRole(token))
+    reserved = ReservedRole.parse(token)
+    if reserved is not None:
+        return UserGroup(path=(DOMAIN,), role=reserved)
     if ":" in token or "/" in token:
         return None
     return UserGroup(path=(DOMAIN, PROJECT_SEGMENT, token), role=_LEGACY_ROLE)

--- a/mpcontribs-api/src/mpcontribs_api/authz.py
+++ b/mpcontribs-api/src/mpcontribs_api/authz.py
@@ -1,7 +1,9 @@
-from typing import Any
+from dataclasses import dataclass, field
+from enum import StrEnum
+from typing import Any, Self
 
 from fastapi.security import APIKeyHeader
-from pydantic import BaseModel, ConfigDict, model_validator
+from pydantic import BaseModel, ConfigDict, PrivateAttr, model_validator
 
 from mpcontribs_api.config import get_settings
 
@@ -31,17 +33,97 @@ authenticated_groups_scheme = APIKeyHeader(
 )
 
 
-ADMIN_GROUP = settings.mongo.admin_group
+# The top-level path segment naming this service's domain. Grants in other domains (e.g. ``core:...``)
+# are parsed and stored but ignored by this service's accessors.
+DOMAIN = "mpcontribs"
 
-# prefix to user roles to disambiguate from project roles, which are bare ids
-INITIATIVE_ROLE_PREFIX = "initiative:"
+# Role name that grants global admin. Held at the domain root (``mpcontribs=admin``).
+ADMIN_ROLE = settings.mongo.admin_group
 
-# prefix for project-group roles: a group's _id (an ObjectId hex string) is granted as ``project-group:<oid>``
-PROJECT_GROUP_ROLE_PREFIX = "project-group:"
+# Reserved sentinel role Kong forwards for the Persson group.
+PERSSON_ROLE = "persson_group"
 
-# A role carrying one of these prefixes is scoped to a non-project resource; a role with none of
-# them is a bare project id.
-_RESOURCE_ROLE_PREFIXES = (INITIATIVE_ROLE_PREFIX, PROJECT_GROUP_ROLE_PREFIX)
+# Reserved roles are only meaningful at the domain root and must never be smuggled onto an
+# anonymous caller.
+_RESERVED_ROLES = frozenset({ADMIN_ROLE, PERSSON_ROLE})
+
+# Canonical second-level path segments for the resources with flat authorization consumers today.
+PROJECT_SEGMENT = "project"
+INITIATIVE_SEGMENT = "initiative"
+PROJECT_GROUP_SEGMENT = "project-group"
+
+# Default role applied to the legacy (``=``-less) forms Kong still emits, preserving prior full access.
+_LEGACY_ROLE = "owner"
+
+
+class Role(StrEnum):
+    """Roles a caller can hold on a scoped resource, ordered most- to least-privileged."""
+
+    owner = "owner"
+    editor = "editor"
+    viewer = "viewer"
+
+
+# Read is granted by the presence of ANY grant; write and manage require these roles.
+WRITE_ROLES: frozenset[str] = frozenset({Role.owner, Role.editor})
+MANAGE_ROLES: frozenset[str] = frozenset({Role.owner})
+
+
+class UserGroup(BaseModel):
+    """A single parsed access grant: an arbitrary-depth path plus the role held on it.
+
+    The input format is ``seg1:seg2:...:segN=role`` (ie. ``mpcontribs:project:mp-a=editor``). The path
+    is hierarchical and unbounded in depth; ``path[0]`` is the domain (ie. mpcontribs).
+    """
+
+    model_config = ConfigDict(frozen=True)
+    path: tuple[str, ...]
+    role: str
+
+    @property
+    def domain(self) -> str:
+        return self.path[0]
+
+    def __str__(self) -> str:
+        return f"{':'.join(self.path)}={self.role}"
+
+    @classmethod
+    def parse(cls, raw: str) -> Self | None:
+        """Parse one wire token into a grant, or ``None`` if malformed (fail-closed, never raises).
+
+        Accepts the ARN grammar (any depth, requires a non-empty ``=role``) and the three legacy forms
+        Kong still emits: a bare project id, the admin sentinel, and the Persson sentinel.
+        """
+        token = raw.strip()
+        if not token:
+            return None
+        if "=" not in token:
+            return cls._parse_legacy(token)
+        left, role = token.rsplit("=", 1)
+        if not role:
+            return None
+        segments = left.split(":")
+        if any(not segment for segment in segments):
+            return None
+        return cls(path=tuple(segments), role=role)
+
+    @classmethod
+    def _parse_legacy(cls, token: str) -> Self | None:
+        # Only the ``=``-less forms Kong currently forwards are honored; anything else is malformed.
+        # Prefixed legacy strings (``initiative:``/``project-group:``) are gone — those are ARN-only now.
+        if token in _RESERVED_ROLES:
+            return cls(path=(DOMAIN,), role=token)
+        if ":" in token:
+            return None
+        return cls(path=(DOMAIN, PROJECT_SEGMENT, token), role=_LEGACY_ROLE)
+
+
+@dataclass
+class _Node:
+    """One node of the grant tree: the role granted at this exact path (if any) plus child segments."""
+
+    role: str | None = None
+    children: dict[str, _Node] = field(default_factory=dict)
 
 
 class User(BaseModel):
@@ -50,21 +132,82 @@ class User(BaseModel):
     Attributes:
         consumer_id (str | None): Kong id
         username (str | None): the username of the active user - if None, the user is anonymous
-        groups (frozenset[str]): the groups the user is part of - used for access control
+        groups (tuple[UserGroup, ...]): the parsed access grants the user carries
     """
 
     model_config = ConfigDict(frozen=True)
     consumer_id: str | None = None
     username: str | None = None
-    groups: frozenset[str] = frozenset()
+    groups: tuple[UserGroup, ...] = ()
+
+    # O(depth) lookup structure built once from ``groups``; excluded from the model's fields/hash.
+    _index: _Node = PrivateAttr(default_factory=_Node)
 
     @model_validator(mode="before")
     @classmethod
-    def drop_admin_on_anonymous(cls, config: dict[str, Any]) -> dict[str, Any]:
-        if not config.get("username"):
-            groups = config.get("groups", frozenset())
-            config["groups"] = frozenset(g for g in groups if g != ADMIN_GROUP)
-        return config
+    def _normalize_groups(cls, data: Any) -> Any:
+        """Parse raw group tokens into grants and drop reserved grants from anonymous callers."""
+        if not isinstance(data, dict):
+            return data
+        raw_groups = data.get("groups")
+        if raw_groups is not None:
+            parsed: list[UserGroup] = []
+            for item in raw_groups:
+                if isinstance(item, UserGroup):
+                    grant = item
+                elif isinstance(item, str):
+                    grant = UserGroup.parse(item)
+                elif isinstance(item, dict):
+                    grant = UserGroup(**item)
+                else:
+                    grant = None
+                if grant is not None:
+                    parsed.append(grant)
+            data["groups"] = tuple(parsed)
+        if not data.get("username"):
+            data["groups"] = tuple(g for g in data.get("groups", ()) if g.role not in _RESERVED_ROLES)
+        return data
+
+    @model_validator(mode="after")
+    def _build_index(self) -> Self:
+        root = _Node()
+        for grant in self.groups:
+            node = root
+            for segment in grant.path:
+                node = node.children.setdefault(segment, _Node())
+            node.role = grant.role  # last-wins on duplicate identical paths
+        self._index = root
+        return self
+
+    def role_for(self, *path: str) -> str | None:
+        """The role held at exactly ``path``, or ``None``. O(len(path)) tree walk."""
+        node = self._index
+        for segment in path:
+            child = node.children.get(segment)
+            if child is None:
+                return None
+            node = child
+        return node.role
+
+    def has_grant(self, *prefix: str) -> bool:
+        """Whether the user holds any grant at or beneath ``prefix``."""
+        node = self._index
+        for segment in prefix:
+            child = node.children.get(segment)
+            if child is None:
+                return False
+            node = child
+        return True
+
+    def _resource_roles(self, segment: str) -> dict[str, str]:
+        """``{resource_name: role}`` for direct grants under ``DOMAIN:segment`` (deeper grants excluded)."""
+        node = self._index.children.get(DOMAIN)
+        if node is None:
+            return {}
+        node = node.children.get(segment)
+        if node is None:
+            return {}
+        return {name: child.role for name, child in node.children.items() if child.role is not None}
 
     @property
     def is_anonymous(self) -> bool:
@@ -72,61 +215,40 @@ class User(BaseModel):
 
     @property
     def is_admin(self) -> bool:
-        return (not self.is_anonymous) and (ADMIN_GROUP in self.groups)
+        return (not self.is_anonymous) and (self.role_for(DOMAIN) == ADMIN_ROLE)
 
     @property
-    def project_roles(self) -> list[str]:
-        """The project ids this user carries, from their bare (unprefixed) roles.
-
-        Resource-scoped roles (``initiative:``, ``project-group:``) and the admin sentinel are
-        excluded, leaving only bare project ids.
-        """
-        return [role for role in self.groups if role != ADMIN_GROUP and not role.startswith(_RESOURCE_ROLE_PREFIXES)]
+    def project_groups(self) -> dict[str, str]:
+        """``{project_id: role}`` for the projects this user is granted on (any role)."""
+        return self._resource_roles(PROJECT_SEGMENT)
 
     @property
-    def initiative_roles(self) -> list[str]:
-        """The initiative slugs this user collaborates on, decoded from their ``initiative:<slug>`` roles."""
-        return [role[len(INITIATIVE_ROLE_PREFIX) :] for role in self.groups if role.startswith(INITIATIVE_ROLE_PREFIX)]
+    def initiative_groups(self) -> dict[str, str]:
+        """``{slug: role}`` for the initiatives this user is granted on (any role)."""
+        return self._resource_roles(INITIATIVE_SEGMENT)
 
     @property
-    def project_group_roles(self) -> list[str]:
-        """The project-group ids this user may access, decoded from their ``project-group:<oid>`` roles.
+    def project_group_groups(self) -> dict[str, str]:
+        """``{oid_hex: role}`` for the project groups this user is granted on (any role)."""
+        return self._resource_roles(PROJECT_GROUP_SEGMENT)
 
-        Values are the raw hex strings; callers that query by ``_id`` must convert them
-        """
-        return [
-            role[len(PROJECT_GROUP_ROLE_PREFIX) :] for role in self.groups if role.startswith(PROJECT_GROUP_ROLE_PREFIX)
-        ]
-
-    def has_role(self, role: str, *, resource: str | None = None) -> bool:
-        """Determine whether a user has a role assigned to them.
-
-        Specifying resource as:
-        - ``INITIATIVE_ROLE_PREFIX`` looks for roles scoped to initiatives
-        - "project" looks for bare (unprefixed) project roles
-        - None looks for roles by matching the entire string
-        """
-        if resource == INITIATIVE_ROLE_PREFIX[:-1]:
-            return role in self.initiative_roles
-        if resource == "project":
-            return role in self.project_roles
-        return role in self.groups
+    @property
+    def readable_projects(self) -> frozenset[str]:
+        """Projects this user may read: presence of any grant is enough (viewer included)."""
+        if self.is_anonymous:
+            return frozenset()
+        return frozenset(self.project_groups)
 
     @property
     def writable_projects(self) -> frozenset[str]:
-        """Projects this user may write to. Admins are unbounded (handled by can_write)"""
+        """Projects this user may write to (owner/editor). Admins are unbounded (handled by can_write)."""
         if self.is_anonymous:
             return frozenset()
-        # only bare project roles are writable projects; the admin sentinel and resource-scoped
-        # roles (initiative:/project-group:) must never leak into a $in / membership test
-        return frozenset(self.project_roles)
+        return frozenset(name for name, role in self.project_groups.items() if role in WRITE_ROLES)
 
     def can_manage(self, id: str, resource: str) -> bool:
-        """Determines whether a user can manage a resource.
-
-        If the user is known and either an admin or has a valid role assigned, they can manage
-        """
-        return (not self.is_anonymous) and (self.is_admin or self.has_role(role=id, resource=resource))
+        """Whether the user may manage ``DOMAIN:resource:id`` (admin, or an owner-role grant on it)."""
+        return (not self.is_anonymous) and (self.is_admin or (self.role_for(DOMAIN, resource, id) in MANAGE_ROLES))
 
     def can_write(self, project: str) -> bool:
         """Single source of truth for write authorization."""

--- a/mpcontribs-api/src/mpcontribs_api/authz.py
+++ b/mpcontribs-api/src/mpcontribs_api/authz.py
@@ -1,10 +1,7 @@
-from dataclasses import dataclass, field
-from enum import StrEnum
-from typing import Any, Self
-
 from fastapi.security import APIKeyHeader
-from pydantic import BaseModel, ConfigDict, PrivateAttr, model_validator
 
+from mpcontribs_api.authz_core import ADMIN_ROLE, PERSSON_ROLE, ReservedRole, Role, UserGroup
+from mpcontribs_api.authz_core import User as _CoreUser
 from mpcontribs_api.config import get_settings
 
 settings = get_settings()
@@ -33,223 +30,62 @@ authenticated_groups_scheme = APIKeyHeader(
 )
 
 
-# The top-level path segment naming this service's domain. Grants in other domains (e.g. ``core:...``)
-# are parsed and stored but ignored by this service's accessors.
-DOMAIN = "mpcontribs"
+# The top-level path segment naming this service's authz domain
+DOMAIN = settings.authz.domain
 
-# Role name that grants global admin. Held at the domain root (``mpcontribs=admin``).
-ADMIN_ROLE = settings.mongo.admin_group
-
-# Reserved sentinel role Kong forwards for the Persson group.
-PERSSON_ROLE = "persson_group"
-
-# Reserved roles are only meaningful at the domain root and must never be smuggled onto an
-# anonymous caller.
+# Reserved roles are only meaningful at the domain root and must never be put on an anonymous caller.
+# Re-exported here (imported by test/other modules) as well as consumed by the legacy parser below.
 _RESERVED_ROLES = frozenset({ADMIN_ROLE, PERSSON_ROLE})
 
-# Canonical second-level path segments for the resources with flat authorization consumers today.
-PROJECT_SEGMENT = "project"
-INITIATIVE_SEGMENT = "initiative"
-PROJECT_GROUP_SEGMENT = "project-group"
+# Canonical second-level path segments (plural collection identifiers, per GCP AIP-122) for the
+# resources with flat authorization consumers today.
+PROJECT_SEGMENT = "projects"
+INITIATIVE_SEGMENT = "initiatives"
+PROJECT_GROUP_SEGMENT = "project-groups"
+
+# Full ARN-prefix paths with the domain baked in. These are the only handles the rest of the app uses
+# to talk to the domain-agnostic ``User`` accessors — callers just spread a constant
+# (``user.can_write(*PROJECT_PATH, project_id)``) and never name the domain themselves.
+ROOT_PATH = (DOMAIN,)
+PROJECT_PATH = (DOMAIN, PROJECT_SEGMENT)
+INITIATIVE_PATH = (DOMAIN, INITIATIVE_SEGMENT)
+PROJECT_GROUP_PATH = (DOMAIN, PROJECT_GROUP_SEGMENT)
 
 # Default role applied to the legacy (``=``-less) forms Kong still emits, preserving prior full access.
-_LEGACY_ROLE = "owner"
+_LEGACY_ROLE = Role.owner
 
 
-class Role(StrEnum):
-    """Roles a caller can hold on a scoped resource, ordered most- to least-privileged."""
-
-    owner = "owner"
-    editor = "editor"
-    viewer = "viewer"
-
-
-# Read is granted by the presence of ANY grant; write and manage require these roles.
-WRITE_ROLES: frozenset[str] = frozenset({Role.owner, Role.editor})
-MANAGE_ROLES: frozenset[str] = frozenset({Role.owner})
+def _parse_legacy(token: str) -> UserGroup | None:
+    # Only the ``=``-less forms Kong currently forwards are honored; anything else is malformed.
+    # Prefixed legacy strings (``initiative:``/``project-group:``) are gone — those are ARN-only now.
+    if token in _RESERVED_ROLES:
+        # Guard guarantees ``token`` is a reserved keyword, so this coercion never raises.
+        return UserGroup(path=(DOMAIN,), role=ReservedRole(token))
+    if ":" in token or "/" in token:
+        return None
+    return UserGroup(path=(DOMAIN, PROJECT_SEGMENT, token), role=_LEGACY_ROLE)
 
 
-class UserGroup(BaseModel):
-    """A single parsed access grant: an arbitrary-depth path plus the role held on it.
+def parse_grant(raw: str) -> UserGroup | None:
+    """Parse one wire token into a grant, or ``None`` if malformed (fail-closed, never raises).
 
-    The input format is ``seg1:seg2:...:segN=role`` (ie. ``mpcontribs:project:mp-a=editor``). The path
-    is hierarchical and unbounded in depth; ``path[0]`` is the domain (ie. mpcontribs).
+    Accepts the ARN grammar (delegated to the core) plus the three legacy forms Kong still emits: a
+    bare project id, the admin sentinel, and the Persson sentinel.
+    """
+    token = raw.strip()
+    if not token:
+        return None
+    if "=" not in token:
+        return _parse_legacy(token)
+    return UserGroup.parse(token)
+
+
+class User(_CoreUser):
+    """This server's :class:`User`: the domain-agnostic core plus the temporary legacy token parser.
+
+    Only used to handle the legacy format (each grant is just the project name and forces "owner" role)
     """
 
-    model_config = ConfigDict(frozen=True)
-    path: tuple[str, ...]
-    role: str
-
-    @property
-    def domain(self) -> str:
-        return self.path[0]
-
-    def __str__(self) -> str:
-        return f"{':'.join(self.path)}={self.role}"
-
     @classmethod
-    def parse(cls, raw: str) -> Self | None:
-        """Parse one wire token into a grant, or ``None`` if malformed (fail-closed, never raises).
-
-        Accepts the ARN grammar (any depth, requires a non-empty ``=role``) and the three legacy forms
-        Kong still emits: a bare project id, the admin sentinel, and the Persson sentinel.
-        """
-        token = raw.strip()
-        if not token:
-            return None
-        if "=" not in token:
-            return cls._parse_legacy(token)
-        left, role = token.rsplit("=", 1)
-        if not role:
-            return None
-        segments = left.split(":")
-        if any(not segment for segment in segments):
-            return None
-        return cls(path=tuple(segments), role=role)
-
-    @classmethod
-    def _parse_legacy(cls, token: str) -> Self | None:
-        # Only the ``=``-less forms Kong currently forwards are honored; anything else is malformed.
-        # Prefixed legacy strings (``initiative:``/``project-group:``) are gone — those are ARN-only now.
-        if token in _RESERVED_ROLES:
-            return cls(path=(DOMAIN,), role=token)
-        if ":" in token:
-            return None
-        return cls(path=(DOMAIN, PROJECT_SEGMENT, token), role=_LEGACY_ROLE)
-
-
-@dataclass
-class _Node:
-    """One node of the grant tree: the role granted at this exact path (if any) plus child segments."""
-
-    role: str | None = None
-    children: dict[str, _Node] = field(default_factory=dict)
-
-
-class User(BaseModel):
-    """User definition derived from request headers.
-
-    Attributes:
-        consumer_id (str | None): Kong id
-        username (str | None): the username of the active user - if None, the user is anonymous
-        groups (tuple[UserGroup, ...]): the parsed access grants the user carries
-    """
-
-    model_config = ConfigDict(frozen=True)
-    consumer_id: str | None = None
-    username: str | None = None
-    groups: tuple[UserGroup, ...] = ()
-
-    # O(depth) lookup structure built once from ``groups``; excluded from the model's fields/hash.
-    _index: _Node = PrivateAttr(default_factory=_Node)
-
-    @model_validator(mode="before")
-    @classmethod
-    def _normalize_groups(cls, data: Any) -> Any:
-        """Parse raw group tokens into grants and drop reserved grants from anonymous callers."""
-        if not isinstance(data, dict):
-            return data
-        raw_groups = data.get("groups")
-        if raw_groups is not None:
-            parsed: list[UserGroup] = []
-            for item in raw_groups:
-                if isinstance(item, UserGroup):
-                    grant = item
-                elif isinstance(item, str):
-                    grant = UserGroup.parse(item)
-                elif isinstance(item, dict):
-                    grant = UserGroup(**item)
-                else:
-                    grant = None
-                if grant is not None:
-                    parsed.append(grant)
-            data["groups"] = tuple(parsed)
-        if not data.get("username"):
-            data["groups"] = tuple(g for g in data.get("groups", ()) if g.role not in _RESERVED_ROLES)
-        return data
-
-    @model_validator(mode="after")
-    def _build_index(self) -> Self:
-        root = _Node()
-        for grant in self.groups:
-            node = root
-            for segment in grant.path:
-                node = node.children.setdefault(segment, _Node())
-            node.role = grant.role  # last-wins on duplicate identical paths
-        self._index = root
-        return self
-
-    def role_for(self, *path: str) -> str | None:
-        """The role held at exactly ``path``, or ``None``. O(len(path)) tree walk."""
-        node = self._index
-        for segment in path:
-            child = node.children.get(segment)
-            if child is None:
-                return None
-            node = child
-        return node.role
-
-    def has_grant(self, *prefix: str) -> bool:
-        """Whether the user holds any grant at or beneath ``prefix``."""
-        node = self._index
-        for segment in prefix:
-            child = node.children.get(segment)
-            if child is None:
-                return False
-            node = child
-        return True
-
-    def _resource_roles(self, segment: str) -> dict[str, str]:
-        """``{resource_name: role}`` for direct grants under ``DOMAIN:segment`` (deeper grants excluded)."""
-        node = self._index.children.get(DOMAIN)
-        if node is None:
-            return {}
-        node = node.children.get(segment)
-        if node is None:
-            return {}
-        return {name: child.role for name, child in node.children.items() if child.role is not None}
-
-    @property
-    def is_anonymous(self) -> bool:
-        return self.username is None
-
-    @property
-    def is_admin(self) -> bool:
-        return (not self.is_anonymous) and (self.role_for(DOMAIN) == ADMIN_ROLE)
-
-    @property
-    def project_groups(self) -> dict[str, str]:
-        """``{project_id: role}`` for the projects this user is granted on (any role)."""
-        return self._resource_roles(PROJECT_SEGMENT)
-
-    @property
-    def initiative_groups(self) -> dict[str, str]:
-        """``{slug: role}`` for the initiatives this user is granted on (any role)."""
-        return self._resource_roles(INITIATIVE_SEGMENT)
-
-    @property
-    def project_group_groups(self) -> dict[str, str]:
-        """``{oid_hex: role}`` for the project groups this user is granted on (any role)."""
-        return self._resource_roles(PROJECT_GROUP_SEGMENT)
-
-    @property
-    def readable_projects(self) -> frozenset[str]:
-        """Projects this user may read: presence of any grant is enough (viewer included)."""
-        if self.is_anonymous:
-            return frozenset()
-        return frozenset(self.project_groups)
-
-    @property
-    def writable_projects(self) -> frozenset[str]:
-        """Projects this user may write to (owner/editor). Admins are unbounded (handled by can_write)."""
-        if self.is_anonymous:
-            return frozenset()
-        return frozenset(name for name, role in self.project_groups.items() if role in WRITE_ROLES)
-
-    def can_manage(self, id: str, resource: str) -> bool:
-        """Whether the user may manage ``DOMAIN:resource:id`` (admin, or an owner-role grant on it)."""
-        return (not self.is_anonymous) and (self.is_admin or (self.role_for(DOMAIN, resource, id) in MANAGE_ROLES))
-
-    def can_write(self, project: str) -> bool:
-        """Single source of truth for write authorization."""
-        return self.is_admin or project in self.writable_projects
+    def _parse_token(cls, raw: str) -> UserGroup | None:
+        return parse_grant(raw)

--- a/mpcontribs-api/src/mpcontribs_api/authz_core.py
+++ b/mpcontribs-api/src/mpcontribs_api/authz_core.py
@@ -1,0 +1,299 @@
+from dataclasses import dataclass, field
+from enum import StrEnum
+from typing import Any, ClassVar, Self
+
+from pydantic import BaseModel, ConfigDict, PrivateAttr, model_validator
+
+from mpcontribs_api.exceptions import PermissionError
+
+
+class Role(StrEnum):
+    """Roles a caller can hold on a scoped resource, ranked ``viewer < editor < owner``."""
+
+    viewer = "viewer"
+    editor = "editor"
+    owner = "owner"
+
+    def __lt__(self, other) -> bool:
+        if self.__class__ is not other.__class__:
+            return NotImplemented
+        members = list(self.__class__.__members__.values())
+        return members.index(self) < members.index(other)
+
+    def __le__(self, other) -> bool:
+        if self.__class__ is not other.__class__:
+            return NotImplemented
+        members = list(self.__class__.__members__.values())
+        return members.index(self) <= members.index(other)
+
+    def __gt__(self, other) -> bool:
+        if self.__class__ is not other.__class__:
+            return NotImplemented
+        members = list(self.__class__.__members__.values())
+        return members.index(self) > members.index(other)
+
+    def __ge__(self, other) -> bool:
+        if self.__class__ is not other.__class__:
+            return NotImplemented
+        members = list(self.__class__.__members__.values())
+        return members.index(self) >= members.index(other)
+
+    @classmethod
+    def parse(cls, value: str | None) -> Role | None:
+        """The matching rankable role, or ``None`` for an unknown/reserved role string (never raises).
+
+        Unknown roles (reserved sentinels, new roles from other services) never rank against a scoped minimum.
+        """
+        return cls.__members__.get(value) if value is not None else None
+
+
+class ReservedRole(StrEnum):
+    """Globally reserved role keywords that sit at a domain root, not on a scoped resource.
+
+    Unlike :class:`Role` these are **not rankable** — they grant elevated access through the admin path
+    (see :meth:`User.is_admin`), never by satisfying a ``>= editor`` comparison. They are a shared,
+    global concept: every server that speaks the ARN grammar understands the same reserved set, so they
+    live here in the core rather than in any one server. Reserved grants are stripped from anonymous
+    callers (see :attr:`User.reserved_roles`).
+    """
+
+    admin = "admin"
+    persson_group = "persson_group"
+
+    @classmethod
+    def parse(cls, value: str | None) -> ReservedRole | None:
+        """The matching reserved role, or ``None`` for anything else (never raises)."""
+        return cls.__members__.get(value) if value is not None else None
+
+
+# The value stored in a grant's role slot: either a rankable resource role or a reserved keyword.
+GrantRole = Role | ReservedRole
+
+
+def parse_role(value: str | None) -> GrantRole | None:
+    """Coerce a raw role string to a rankable :class:`Role` or a :class:`ReservedRole`, else ``None``.
+
+    Fail-closed: an unknown role string is not a role, so parsers drop the grant carrying it.
+    """
+    return Role.parse(value) or ReservedRole.parse(value)
+
+
+class UserGroup(BaseModel):
+    """A single parsed access grant: an arbitrary-depth path plus the role held on it.
+
+    The input format is ``domain:collection/id/collection/id...=role`` (ie.
+    ``mpcontribs:projects/mp-a=editor``). One ``:`` separates the fixed domain from the variable-depth
+    resource path, which is delimited by ``/``. A domain-root grant has no path (``mpcontribs=admin``).
+    The path is hierarchical and unbounded in depth; ``path[0]`` is the domain (ie. mpcontribs).
+    """
+
+    model_config = ConfigDict(frozen=True)
+    path: tuple[str, ...]
+    role: GrantRole
+
+    @property
+    def domain(self) -> str:
+        return self.path[0]
+
+    def __str__(self) -> str:
+        domain, *rest = self.path
+        prefix = f"{domain}:{'/'.join(rest)}" if rest else domain
+        return f"{prefix}={self.role}"
+
+    @classmethod
+    def parse(cls, raw: str) -> Self | None:
+        """Parse one wire token into a grant, or ``None`` if malformed (fail-closed, never raises).
+
+        Accepts **only** the ARN grammar: one ``:`` after the domain, a ``/``-delimited path of any
+        depth, and a non-empty ``=role`` suffix (the last ``=`` splits path from role). Segments must be
+        non-empty and free of the delimiters ``:``, ``/``, and ``=`` — so a stray ``=`` in a name (e.g.
+        ``d:proj/a=b=owner``) is rejected.
+        """
+        token = raw.strip()
+        if not token or "=" not in token:
+            return None
+        left, role = token.rsplit("=", 1)
+        if not role:
+            return None
+        domain, sep, tail = left.partition(":")
+        segments = (domain, *tail.split("/")) if sep else (domain,)
+        if any(not s or ":" in s or "/" in s or "=" in s for s in segments):
+            return None
+        parsed_role = parse_role(role)
+        if parsed_role is None:
+            # Fail-closed: a role outside the known set (rankable or reserved) is not a grant.
+            return None
+        return cls(path=tuple(segments), role=parsed_role)
+
+
+@dataclass
+class _Node:
+    """One node of the grant tree: the role granted at this exact path (if any) plus child segments."""
+
+    role: GrantRole | None = None
+    children: dict[str, _Node] = field(default_factory=dict)
+
+
+class User(BaseModel):
+    """User derived from request headers, with fully domain-agnostic, path-based authorization accessors.
+
+    Class hooks (a server subclass may override):
+        admin_role: the reserved role at a path root that confers admin beneath it (``None`` → no admin concept)
+        reserved_roles: roles stripped from anonymous callers (e.g. admin/sentinel grants)
+        _parse_token: turns one raw wire token into a :class:`UserGroup` (temp while MPContribs roles migrate to ARN)
+
+    Attributes:
+        consumer_id (str | None): gateway consumer id
+        username (str | None): the active user's username; ``None`` means anonymous
+        groups (tuple[UserGroup, ...]): the parsed access grants the user carries
+    """
+
+    model_config = ConfigDict(frozen=True)
+    consumer_id: str | None = None
+    username: str | None = None
+    groups: tuple[UserGroup, ...] = ()
+
+    # O(depth) lookup structure built once from ``groups``; excluded from the model's fields/hash.
+    _index: _Node = PrivateAttr(default_factory=_Node)
+
+    # Globally reserved role keywords bound as the defaults. A server subclass may override them.
+    admin_role: ClassVar[ReservedRole | None] = ReservedRole.admin
+    reserved_roles: ClassVar[frozenset[ReservedRole]] = frozenset(ReservedRole)
+
+    @classmethod
+    def _parse_token(cls, raw: str) -> UserGroup | None:
+        """Turn one raw token into a grant."""
+        return UserGroup.parse(raw)
+
+    @model_validator(mode="before")
+    @classmethod
+    def _normalize_groups(cls, data: Any) -> Any:
+        """Parse raw group tokens into grants and drop reserved grants from anonymous callers."""
+        if not isinstance(data, dict):
+            return data
+        raw_groups = data.get("groups")
+        if raw_groups is not None:
+            parsed: list[UserGroup] = []
+            for item in raw_groups:
+                if isinstance(item, UserGroup):
+                    grant = item
+                elif isinstance(item, str):
+                    grant = cls._parse_token(item)
+                elif isinstance(item, dict):
+                    grant = UserGroup(**item)
+                else:
+                    grant = None
+                if grant is not None:
+                    parsed.append(grant)
+            data["groups"] = tuple(parsed)
+        if not data.get("username") and cls.reserved_roles:
+            data["groups"] = tuple(g for g in data.get("groups", ()) if g.role not in cls.reserved_roles)
+        return data
+
+    @model_validator(mode="after")
+    def _build_index(self) -> Self:
+        root = _Node()
+        for grant in self.groups:
+            node = root
+            for segment in grant.path:
+                node = node.children.setdefault(segment, _Node())
+            node.role = grant.role  # last-wins on duplicate identical paths
+        self._index = root
+        return self
+
+    def role_for(self, *path: str) -> GrantRole | None:
+        """The role held at exactly ``path``, or ``None``. O(len(path)) tree walk."""
+        node = self._index
+        for segment in path:
+            child = node.children.get(segment)
+            if child is None:
+                return None
+            node = child
+        return node.role
+
+    def has_grant(self, *prefix: str) -> bool:
+        """Whether the user holds any grant at or beneath ``prefix``."""
+        node = self._index
+        for segment in prefix:
+            child = node.children.get(segment)
+            if child is None:
+                return False
+            node = child
+        return True
+
+    def grants_in(self, *prefix: str) -> dict[str, GrantRole]:
+        """``{resource_id: role}`` for the direct, role-bearing grants under ``prefix`` (deeper grants excluded).
+
+        ``prefix`` is the full path to the scope whose members are wanted, e.g.
+        ``grants_in("mpcontribs", "projects")`` → ``{"mp-a": "owner", ...}``.
+        """
+        node = self._index
+        for segment in prefix:
+            child = node.children.get(segment)
+            if child is None:
+                return {}
+            node = child
+        return {name: child.role for name, child in node.children.items() if child.role is not None}
+
+    @property
+    def is_anonymous(self) -> bool:
+        return self.username is None
+
+    def is_admin(self, *path: str) -> bool:
+        """Whether the caller holds :attr:`admin_role` at exactly ``path`` (e.g. a domain root)."""
+        return self.admin_role is not None and not self.is_anonymous and self.role_for(*path) == self.admin_role
+
+    def writable(self, *prefix: str, min_role: Role = Role.editor) -> frozenset[str]:
+        """Resource ids directly under ``prefix`` the caller may write (role >= ``min_role``).
+
+        Admins are unbounded and handled by ``can_write``, not reflected here.
+        """
+        if self.is_anonymous:
+            return frozenset()
+        return frozenset(
+            rid for rid, role in self.grants_in(*prefix).items() if isinstance(role, Role) and role >= min_role
+        )
+
+    def can_write(self, *path: str | None, min_role: Role = Role.editor) -> bool:
+        """Whether the caller may write the resource at ``path`` (admin at ``path[0]``, or role >= editor on it).
+
+        A ``None`` anywhere in ``path`` (a document missing a scoping segment) is never writable.
+        """
+        if not path or any(segment is None for segment in path):
+            return False
+        if self.is_admin(path[0]):  # type: ignore[arg-type]  # None-free after the guard above
+            return True
+        role = self.role_for(*path)  # type: ignore[arg-type]
+        return isinstance(role, Role) and role >= min_role
+
+    def can_manage(self, *path: str | None, doc_owner: str | None = None) -> bool:
+        """Whether the caller may manage the resource at ``path``.
+
+        True for an admin at ``path[0]``, an owner-role grant on the resource, or the document's own
+        ``owner`` (passed in by the caller, which holds the loaded document). Roles below owner do not
+        manage. A ``None`` anywhere in ``path`` denies role/admin-based management (a matching
+        ``doc_owner`` still manages).
+        """
+        if self.is_anonymous:
+            return False
+        has_path = bool(path) and not any(segment is None for segment in path)
+        if has_path and self.is_admin(path[0]):  # type: ignore[arg-type]
+            return True
+        if doc_owner is not None and doc_owner == self.username:
+            return True
+        if not has_path:
+            return False
+        role = self.role_for(*path)  # type: ignore[arg-type]
+        return isinstance(role, Role) and role >= Role.owner
+
+    def require_write(self, *path: str | None) -> None:
+        """Gate: raise ``PermissionError`` unless the caller may write the resource at ``path`` (role >= editor)."""
+        if not self.can_write(*path):
+            segments = ["?" if segment is None else segment for segment in path]
+            joined = f"{segments[0]}:{'/'.join(segments[1:])}" if len(segments) > 1 else "".join(segments)
+            raise PermissionError(f"not authorized to write to '{joined}'", path=list(path))
+
+    def require_manage(self, *path: str | None, doc_owner: str | None = None) -> None:
+        """Gate: raise ``PermissionError`` unless the caller may manage the resource at ``path`` (owner-level)."""
+        if not self.can_manage(*path, doc_owner=doc_owner):
+            raise PermissionError(required_role="owner-or-admin", path=list(path), doc_owner=doc_owner)

--- a/mpcontribs-api/src/mpcontribs_api/config.py
+++ b/mpcontribs-api/src/mpcontribs_api/config.py
@@ -192,6 +192,15 @@ class DomainSettings(BaseModel):
     initiatives: InitiativeSettings = Field(default_factory=InitiativeSettings)
 
 
+class AuthzSettings(BaseModel):
+    """Authorization settings for the grant-validation layer."""
+
+    domain: str = Field(
+        description="Top-level ARN segment naming this service's authz domain (the grant-tree root). "
+        "Required; each server must declare the domain it enforces. Env: MPCONTRIBS_AUTHZ__DOMAIN.",
+    )
+
+
 class MPContribsSettings(BaseModel):
     max_contrib_data_depth: int = Field(
         default=7, description="The max number of levels allowed in a Contribution's data dictionary."
@@ -240,6 +249,9 @@ class Settings(BaseSettings):
 
     # MPContribs_domain_*
     domain: DomainSettings = Field(default_factory=DomainSettings)
+
+    # MPContribs_authz__* (requires domain)
+    authz: AuthzSettings
 
     # MPContribs_consumer__*
     consumer: QuotaLimits = Field(default_factory=QuotaLimits)

--- a/mpcontribs-api/src/mpcontribs_api/dependencies.py
+++ b/mpcontribs-api/src/mpcontribs_api/dependencies.py
@@ -52,10 +52,12 @@ def get_user(request: Request) -> User:
         user = User()  # anonymous = all defaults
     else:
         groups = _split(h.get("x-authenticated-groups")) | _split(h.get("x-consumer-groups"))
-        user = User(
-            consumer_id=h.get("x-consumer-id"),
-            username=username,
-            groups=frozenset(groups),
+        user = User.model_validate(
+            {
+                "consumer_id": h.get("x-consumer-id"),
+                "username": username,
+                "groups": groups,
+            }
         )
     structlog.contextvars.bind_contextvars(
         consumer_id=user.consumer_id,

--- a/mpcontribs-api/src/mpcontribs_api/dependencies.py
+++ b/mpcontribs-api/src/mpcontribs_api/dependencies.py
@@ -7,7 +7,7 @@ from pymongo import AsyncMongoClient
 from pymongo.asynchronous.database import AsyncDatabase
 from types_aiobotocore_s3 import S3Client
 
-from mpcontribs_api.authz import User
+from mpcontribs_api.authz import PROJECT_PATH, ROOT_PATH, User
 from mpcontribs_api.exceptions import AuthenticationError, PermissionError
 
 
@@ -61,7 +61,7 @@ def get_user(request: Request) -> User:
         )
     structlog.contextvars.bind_contextvars(
         consumer_id=user.consumer_id,
-        is_admin=user.is_admin,
+        is_admin=user.is_admin(*ROOT_PATH),
     )
     return user
 
@@ -83,7 +83,7 @@ def require_writer(user: UserDep) -> User:
     """
     if user.is_anonymous:
         raise AuthenticationError("authentication required")
-    if not (user.is_admin or user.writable_projects):
+    if not (user.is_admin(*ROOT_PATH) or user.writable(*PROJECT_PATH)):
         raise PermissionError("write access to at least one project is required")
     return user
 
@@ -97,6 +97,6 @@ def require_admin(user: UserDep) -> User:
     """
     if user.is_anonymous:
         raise AuthenticationError("authentication required")
-    if not user.is_admin:
+    if not user.is_admin(*ROOT_PATH):
         raise PermissionError(required_role="admin")
     return user

--- a/mpcontribs-api/src/mpcontribs_api/dependencies.py
+++ b/mpcontribs-api/src/mpcontribs_api/dependencies.py
@@ -83,6 +83,7 @@ def require_writer(user: UserDep) -> User:
         raise AuthenticationError("authentication required")
     if not (user.is_admin or user.writable_projects):
         raise PermissionError("write access to at least one project is required")
+    return user
 
 
 def require_admin(user: UserDep) -> User:

--- a/mpcontribs-api/src/mpcontribs_api/domains/_shared/types.py
+++ b/mpcontribs-api/src/mpcontribs_api/domains/_shared/types.py
@@ -355,7 +355,7 @@ NFKCStr = Annotated[str, BeforeValidator(func=nfkc_normalize)]
 DisplayStr = Annotated[str, BeforeValidator(func=nfc_normalize)]
 
 # A URL-safe, human-readable slug
-# carried in user.groups like ``initiative:<slug>``
+# carried in a grant path like ``mpcontribs:initiative:<slug>=<role>``
 _SLUG_RE = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
 
 

--- a/mpcontribs-api/src/mpcontribs_api/domains/_shared/types.py
+++ b/mpcontribs-api/src/mpcontribs_api/domains/_shared/types.py
@@ -355,7 +355,7 @@ NFKCStr = Annotated[str, BeforeValidator(func=nfkc_normalize)]
 DisplayStr = Annotated[str, BeforeValidator(func=nfc_normalize)]
 
 # A URL-safe, human-readable slug
-# carried in a grant path like ``mpcontribs:initiative:<slug>=<role>``
+# carried in a grant path like ``mpcontribs:initiatives/<slug>=<role>``
 _SLUG_RE = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
 
 

--- a/mpcontribs-api/src/mpcontribs_api/domains/contributions/repository.py
+++ b/mpcontribs-api/src/mpcontribs_api/domains/contributions/repository.py
@@ -5,6 +5,7 @@ from beanie.operators import Set
 from pymongo.asynchronous.client_session import AsyncClientSession
 from pymongo.errors import DuplicateKeyError
 
+from mpcontribs_api.authz import PROJECT_PATH
 from mpcontribs_api.domains._shared.bulk import BulkUpdateSummary
 from mpcontribs_api.domains._shared.repository import MongoDbRepository
 from mpcontribs_api.domains._shared.units import QuantityLeaf
@@ -24,7 +25,7 @@ from mpcontribs_api.domains.contributions.stats import (
     merge_contribution_columns,
 )
 from mpcontribs_api.exceptions import ConflictError, NotFoundError
-from mpcontribs_api.scope import Public, RoleIn, Scope
+from mpcontribs_api.scope import Granted, Public, Scope
 
 # Sentinel for "leave unique_value untouched" on patch (distinct from a real None value).
 _UNSET: Any = object()
@@ -59,8 +60,8 @@ class MongoDbContributionRepository(
     out_model = ContributionOut
     # Contributions have no owner of their own; visible when public or belonging to a project the
     # caller is granted any role on, viewer included (keyed on ``project``). Writes are separately
-    # gated on ``writable_projects``. Admins bypass scope (handled by ``Scope``).
-    read_scope = Scope(Public(), RoleIn("project", "readable_projects"))
+    # gated on ``User.writable(*PROJECT_PATH)``. Admins bypass scope (handled by ``Scope``).
+    read_scope = Scope(Public(), Granted("project", PROJECT_PATH))
 
     async def update_one(  # pyright: ignore[reportIncompatibleMethodOverride]
         self,

--- a/mpcontribs-api/src/mpcontribs_api/domains/contributions/repository.py
+++ b/mpcontribs-api/src/mpcontribs_api/domains/contributions/repository.py
@@ -58,8 +58,9 @@ class MongoDbContributionRepository(
     document_model = Contribution
     out_model = ContributionOut
     # Contributions have no owner of their own; visible when public or belonging to a project the
-    # caller may write to (keyed on ``project``). Admins bypass scope (handled by ``Scope``).
-    read_scope = Scope(Public(), RoleIn("project", "writable_projects"))
+    # caller is granted any role on, viewer included (keyed on ``project``). Writes are separately
+    # gated on ``writable_projects``. Admins bypass scope (handled by ``Scope``).
+    read_scope = Scope(Public(), RoleIn("project", "readable_projects"))
 
     async def update_one(  # pyright: ignore[reportIncompatibleMethodOverride]
         self,

--- a/mpcontribs-api/src/mpcontribs_api/domains/contributions/service.py
+++ b/mpcontribs-api/src/mpcontribs_api/domains/contributions/service.py
@@ -13,7 +13,7 @@ from pymongo.asynchronous.client_session import AsyncClientSession
 from pymongo.errors import BulkWriteError
 from types_aiobotocore_s3 import S3Client
 
-from mpcontribs_api.authz import User
+from mpcontribs_api.authz import PROJECT_PATH, ROOT_PATH, User
 from mpcontribs_api.config import MongoSettings, get_settings
 from mpcontribs_api.domains._shared.bulk import (
     BulkDeleteSummary,
@@ -244,7 +244,7 @@ class ContributionService:
         remaining: list[PreparedWrite] = []
         for item in items:
             contrib = item.contribution
-            if self._user.can_write(contrib.project):
+            if self._user.can_write(*PROJECT_PATH, contrib.project):
                 remaining.append(item)
             else:
                 unauthorized.append(
@@ -734,8 +734,8 @@ class ContributionService:
             return BulkUpdateSummary(matched=0, modified=0, projects=[])
         filter = (
             filter
-            if self._user.is_admin
-            else filter.model_copy(update={"project__in": sorted(self._user.writable_projects)})
+            if self._user.is_admin(*ROOT_PATH)
+            else filter.model_copy(update={"project__in": sorted(self._user.writable(*PROJECT_PATH))})
         )
 
         touches_identity = bool(ContributionIdentity.model_fields() & fields.keys()) or "data" in fields
@@ -799,8 +799,7 @@ class ContributionService:
         ``unique_column``) is resolved and stamped so the identity index stays correct, and an
         unapproved project's contribution cap is enforced when the upsert would insert a new document.
         """
-        if not self._user.can_write(contribution.project):
-            raise PermissionError(f"not authorized to write to project '{contribution.project}'")
+        self._user.require_write(*PROJECT_PATH, contribution.project)
         existing = await self._contributions.read_one(identifiers, None)
         if existing is None:
             stored = await self._unapproved_stored_count(contribution.project)
@@ -831,12 +830,11 @@ class ContributionService:
         re-validated strictly (the permissive patch validator allows leaf fragments a full doc may not).
         ``unique_value`` is resolved against the same post-write view the repository will persist.
         """
-        if not self._user.is_admin:
+        if not self._user.is_admin(*ROOT_PATH):
             target = await self._contributions.read_one(identifiers, frozenset({"id", "project"}))
             if target is None:
                 raise NotFoundError("contribution not found", identifiers=identifiers)
-            if target.project not in self._user.writable_projects:
-                raise PermissionError(f"not authorized to write to project '{target.project}'")
+            self._user.require_write(*PROJECT_PATH, target.project)
         set_fields = update.model_dump(exclude_unset=True)
         touches_unique = "data" in set_fields or "project" in set_fields
         touches_identity = bool(ContributionIdentity.HIERARCHY_FIELDS & set_fields.keys())
@@ -919,8 +917,8 @@ class ContributionService:
         Returns:
             BulkDeleteSummary: a summary of how many documents and child documents were deleted
         """
-        if not self._user.is_admin:
-            filter = filter.model_copy(update={"project__in": sorted(self._user.writable_projects)})
+        if not self._user.is_admin(*ROOT_PATH):
+            filter = filter.model_copy(update={"project__in": sorted(self._user.writable(*PROJECT_PATH))})
         num_deleted_components = 0
         num_deleted_contributions = 0
         # Projects touched by this delete, so their rollup stats can be recomputed once at the end.

--- a/mpcontribs-api/src/mpcontribs_api/domains/initiatives/repository.py
+++ b/mpcontribs-api/src/mpcontribs_api/domains/initiatives/repository.py
@@ -16,6 +16,6 @@ class MongoDbInitiativeRepository(
 
     document_model = Initiative
     out_model = InitiativeOut
-    # Visible when public+approved, owned by the caller, or collaborated on via an
-    # ``initiative:<slug>`` role (keyed on ``slug``). Admins bypass scope (handled by ``Scope``).
-    read_scope = Scope(Public(approved=True), Owned(), RoleIn("slug", "initiative_roles"))
+    # Visible when public+approved, owned by the caller, or granted any role on the initiative via a
+    # ``mpcontribs:initiative:<slug>=<role>`` grant (keyed on ``slug``). Admins bypass scope.
+    read_scope = Scope(Public(approved=True), Owned(), RoleIn("slug", "initiative_groups"))

--- a/mpcontribs-api/src/mpcontribs_api/domains/initiatives/repository.py
+++ b/mpcontribs-api/src/mpcontribs_api/domains/initiatives/repository.py
@@ -1,3 +1,4 @@
+from mpcontribs_api.authz import INITIATIVE_PATH
 from mpcontribs_api.domains._shared.repository import MongoDbRepository
 from mpcontribs_api.domains.initiatives.models import (
     Initiative,
@@ -6,7 +7,7 @@ from mpcontribs_api.domains.initiatives.models import (
     InitiativeOut,
     InitiativePatch,
 )
-from mpcontribs_api.scope import Owned, Public, RoleIn, Scope
+from mpcontribs_api.scope import Granted, Owned, Public, Scope
 
 
 class MongoDbInitiativeRepository(
@@ -17,5 +18,5 @@ class MongoDbInitiativeRepository(
     document_model = Initiative
     out_model = InitiativeOut
     # Visible when public+approved, owned by the caller, or granted any role on the initiative via a
-    # ``mpcontribs:initiative:<slug>=<role>`` grant (keyed on ``slug``). Admins bypass scope.
-    read_scope = Scope(Public(approved=True), Owned(), RoleIn("slug", "initiative_groups"))
+    # ``mpcontribs:initiatives/<slug>=<role>`` grant (keyed on ``slug``). Admins bypass scope.
+    read_scope = Scope(Public(approved=True), Owned(), Granted("slug", INITIATIVE_PATH))

--- a/mpcontribs-api/src/mpcontribs_api/domains/initiatives/service.py
+++ b/mpcontribs-api/src/mpcontribs_api/domains/initiatives/service.py
@@ -1,6 +1,6 @@
 from typing import Any
 
-from mpcontribs_api.authz import User
+from mpcontribs_api.authz import INITIATIVE_PATH, ROOT_PATH, User
 from mpcontribs_api.config import get_settings
 from mpcontribs_api.domains._shared.models import DeleteResponse
 from mpcontribs_api.domains.initiatives.models import (
@@ -63,7 +63,7 @@ class InitiativeService:
         if self._user.username is None:
             raise PermissionError(required_role="authenticated")
 
-        if not self._user.is_admin:
+        if not self._user.is_admin(*ROOT_PATH):
             # Unscoped: the per-owner unapproved cap counts every one of the owner's unapproved
             # initiatives, regardless of what the current caller can see.
             unapproved = await self._initiatives.count_matching(
@@ -92,11 +92,10 @@ class InitiativeService:
         existing = await self._initiatives.read_one(identifiers)
         if existing is None:
             raise NotFoundError("Initiative not found", slug=slug)
-        if not (self._user.can_manage(id=slug, resource="initiative") or self._user.username == existing.owner):
-            raise PermissionError(required_role="initiative-owner-collaborator-or-admin")
+        self._user.require_manage(*INITIATIVE_PATH, slug, doc_owner=existing.owner)
 
         data = update.model_dump(exclude_unset=True)
-        if "is_approved" in data and not self._user.is_admin:
+        if "is_approved" in data and not self._user.is_admin(*ROOT_PATH):
             raise PermissionError("only admins can set `is_approved`", required_role="admin")
 
         resulting_approved = data.get("is_approved", existing.is_approved)
@@ -116,7 +115,7 @@ class InitiativeService:
         existing = await self._initiatives.read_one(identifiers)
         if existing is None:
             raise NotFoundError("Initiative not found", **identifiers)
-        if not (self._user.is_admin or existing.owner == self._user.username):
+        if not (self._user.is_admin(*ROOT_PATH) or existing.owner == self._user.username):
             raise PermissionError(required_role="owner-or-admin")
         response = await self._initiatives.delete_one(identifiers)
         if existing.id is not None:

--- a/mpcontribs-api/src/mpcontribs_api/domains/project_groups/repository.py
+++ b/mpcontribs-api/src/mpcontribs_api/domains/project_groups/repository.py
@@ -3,6 +3,7 @@ from beanie.operators import AddToSet, Pull
 from bson import DBRef
 from pymongo.asynchronous.client_session import AsyncClientSession
 
+from mpcontribs_api.authz import PROJECT_GROUP_PATH
 from mpcontribs_api.domains._shared.repository import MongoDbRepository
 from mpcontribs_api.domains._shared.types import ShortStr
 from mpcontribs_api.domains.project_groups.models import (
@@ -12,7 +13,7 @@ from mpcontribs_api.domains.project_groups.models import (
     ProjectGroupOut,
     ProjectGroupPatch,
 )
-from mpcontribs_api.scope import Owned, Public, RoleIn, Scope
+from mpcontribs_api.scope import Granted, Owned, Public, Scope
 
 
 class MongoDbProjectGroupRepository(
@@ -23,10 +24,10 @@ class MongoDbProjectGroupRepository(
     document_model = ProjectGroup
     out_model = ProjectGroupOut
     # Visible when public, owned by the caller, or granted any role via a
-    # ``mpcontribs:project-group:<oid>=<role>`` grant (keyed on ``_id``). Project groups have no
+    # ``mpcontribs:project-groups/<oid>=<role>`` grant (keyed on ``_id``). Project groups have no
     # approval flag. Grant ids arrive as raw hex strings, so the id clause coerces each to
-    # ``PydanticObjectId`` (malformed values are dropped by ``RoleIn``). Admins bypass scope.
-    read_scope = Scope(Public(), Owned(), RoleIn("_id", "project_group_groups", coerce=PydanticObjectId))
+    # ``PydanticObjectId`` (malformed values are dropped by ``Granted``). Admins bypass scope.
+    read_scope = Scope(Public(), Owned(), Granted("_id", PROJECT_GROUP_PATH, coerce=PydanticObjectId))
 
     async def add_project_refs(
         self,

--- a/mpcontribs-api/src/mpcontribs_api/domains/project_groups/repository.py
+++ b/mpcontribs-api/src/mpcontribs_api/domains/project_groups/repository.py
@@ -22,11 +22,11 @@ class MongoDbProjectGroupRepository(
 
     document_model = ProjectGroup
     out_model = ProjectGroupOut
-    # Visible when public, owned by the caller, or granted via a ``project-group:<oid>`` role (keyed
-    # on ``_id``). Project groups have no approval flag. Roles arrive as raw hex strings, so the id
-    # clause coerces each to ``PydanticObjectId`` (malformed values are dropped by ``RoleIn``). Admins
-    # bypass scope (handled by ``Scope``).
-    read_scope = Scope(Public(), Owned(), RoleIn("_id", "project_group_roles", coerce=PydanticObjectId))
+    # Visible when public, owned by the caller, or granted any role via a
+    # ``mpcontribs:project-group:<oid>=<role>`` grant (keyed on ``_id``). Project groups have no
+    # approval flag. Grant ids arrive as raw hex strings, so the id clause coerces each to
+    # ``PydanticObjectId`` (malformed values are dropped by ``RoleIn``). Admins bypass scope.
+    read_scope = Scope(Public(), Owned(), RoleIn("_id", "project_group_groups", coerce=PydanticObjectId))
 
     async def add_project_refs(
         self,

--- a/mpcontribs-api/src/mpcontribs_api/domains/project_groups/service.py
+++ b/mpcontribs-api/src/mpcontribs_api/domains/project_groups/service.py
@@ -2,7 +2,7 @@ from typing import Any
 
 from beanie import Link
 
-from mpcontribs_api.authz import User
+from mpcontribs_api.authz import ROOT_PATH, User
 from mpcontribs_api.domains._shared.bulk import BulkFailure, BulkWriteSummary
 from mpcontribs_api.domains._shared.models import DeleteResponse
 from mpcontribs_api.domains._shared.types import ShortStr
@@ -54,7 +54,7 @@ class ProjectGroupService:
 
         Non-admins are set as owner automatically, while admins can specify owners.
         """
-        if not self._user.is_admin:
+        if not self._user.is_admin(*ROOT_PATH):
             project_group = project_group.model_copy(update={"owner": self._user.username})
         existing = await self._projects.existing_ids(list(project_group.projects), scoped=True)
         missing = [pid for pid in project_group.projects if pid not in existing]
@@ -79,7 +79,7 @@ class ProjectGroupService:
         A non-admin's bulk delete is scoped to their own groups (overriding any ``owner`` in the
         filter) so it can never remove public groups belonging to others.
         """
-        if not self._user.is_admin:
+        if not self._user.is_admin(*ROOT_PATH):
             filter.owner = self._user.username
         return await self._groups.delete_many(filter=filter)
 
@@ -88,7 +88,7 @@ class ProjectGroupService:
         group = await self._groups.read_one(identifiers, fields=frozenset({"id", "owner"}))
         if group is None:
             raise NotFoundError("ProjectGroup not found", **identifiers)
-        if not (self._user.is_admin or group.owner == self._user.username):
+        if not (self._user.is_admin(*ROOT_PATH) or group.owner == self._user.username):
             raise PermissionError(required_role="owner-or-admin")
         return await self._groups.update_one(identifiers, update)
 
@@ -102,7 +102,7 @@ class ProjectGroupService:
         group = await self._groups.read_one(identifiers, fields=frozenset({"id", "owner"}))
         if group is None:
             raise NotFoundError("ProjectGroup not found", **identifiers)
-        if not (self._user.is_admin or group.owner == self._user.username):
+        if not (self._user.is_admin(*ROOT_PATH) or group.owner == self._user.username):
             raise PermissionError(required_role="owner-or-admin")
         return await self._groups.delete_one(identifiers)
 
@@ -116,7 +116,7 @@ class ProjectGroupService:
         group = await self._groups.read_one(identifiers, fields=_GROUP_FIELDS)
         if group is None:
             raise NotFoundError("ProjectGroup not found", **identifiers)
-        if not (self._user.is_admin or group.owner == self._user.username):
+        if not (self._user.is_admin(*ROOT_PATH) or group.owner == self._user.username):
             raise PermissionError(required_role="owner-or-admin")
         return group  # pyright: ignore[reportReturnType]  # projected reads return the out model
 

--- a/mpcontribs-api/src/mpcontribs_api/domains/projects/repository.py
+++ b/mpcontribs-api/src/mpcontribs_api/domains/projects/repository.py
@@ -3,6 +3,7 @@ from typing import Any
 from beanie import PydanticObjectId
 from pymongo import UpdateOne
 
+from mpcontribs_api.authz import PROJECT_PATH
 from mpcontribs_api.domains._shared.repository import MongoDbRepository
 from mpcontribs_api.domains.projects.models import (
     Column,
@@ -13,7 +14,7 @@ from mpcontribs_api.domains.projects.models import (
     ProjectPatch,
     Stats,
 )
-from mpcontribs_api.scope import Owned, Public, RoleIn, Scope
+from mpcontribs_api.scope import Granted, Owned, Public, Scope
 
 
 class MongoDbProjectRepository(MongoDbRepository[Project, ProjectIn, ProjectOut, ProjectFilter, ProjectPatch]):
@@ -28,7 +29,7 @@ class MongoDbProjectRepository(MongoDbRepository[Project, ProjectIn, ProjectOut,
     out_model = ProjectOut
     # Visible when public+approved, owned by the caller, or granted any role on the project (keyed on
     # its ``_id``). Admins bypass scope (handled by ``Scope``).
-    read_scope = Scope(Public(approved=True), Owned(), RoleIn("_id", "project_groups"))
+    read_scope = Scope(Public(approved=True), Owned(), Granted("_id", PROJECT_PATH))
 
     async def find_by_id_unscoped(self, id: str) -> Project | None:
         """Return the project with ``id`` regardless of user scope, or ``None`` if absent.

--- a/mpcontribs-api/src/mpcontribs_api/domains/projects/repository.py
+++ b/mpcontribs-api/src/mpcontribs_api/domains/projects/repository.py
@@ -26,9 +26,9 @@ class MongoDbProjectRepository(MongoDbRepository[Project, ProjectIn, ProjectOut,
 
     document_model = Project
     out_model = ProjectOut
-    # Visible when public+approved, owned by the caller, or granted as a bare project role (its
-    # ``_id``). Admins bypass scope (handled by ``Scope``).
-    read_scope = Scope(Public(approved=True), Owned(), RoleIn("_id", "project_roles"))
+    # Visible when public+approved, owned by the caller, or granted any role on the project (keyed on
+    # its ``_id``). Admins bypass scope (handled by ``Scope``).
+    read_scope = Scope(Public(approved=True), Owned(), RoleIn("_id", "project_groups"))
 
     async def find_by_id_unscoped(self, id: str) -> Project | None:
         """Return the project with ``id`` regardless of user scope, or ``None`` if absent.

--- a/mpcontribs-api/src/mpcontribs_api/domains/projects/service.py
+++ b/mpcontribs-api/src/mpcontribs_api/domains/projects/service.py
@@ -2,7 +2,7 @@ from typing import Any
 
 from bson import DBRef
 
-from mpcontribs_api.authz import User
+from mpcontribs_api.authz import INITIATIVE_PATH, ROOT_PATH, User
 from mpcontribs_api.config import get_settings
 from mpcontribs_api.domains._shared.models import DeleteResponse
 from mpcontribs_api.domains.consumers.models import ConsumerSettings
@@ -64,7 +64,7 @@ class ProjectService:
         project = self._projects.document_model.from_input_model(data, id=id)
 
         if existing is not None:
-            if not (self._user.is_admin or existing.owner == self._user.username):
+            if not (self._user.is_admin(*ROOT_PATH) or existing.owner == self._user.username):
                 raise PermissionError(required_role="owner-or-admin")
             # Ownership is immutable via upsert; keep the original owner.
             project.owner = existing.owner
@@ -75,13 +75,13 @@ class ProjectService:
             project.stats = existing.stats
             project.columns = existing.columns
             # Approval is an admin-only flag
-            if not self._user.is_admin:
+            if not self._user.is_admin(*ROOT_PATH):
                 project.is_approved = existing.is_approved
         else:
             # New project: the caller owns it, regardless of the submitted owner.
             project.owner = self._user.username
             # Approval is admin-only; a non-admin's new project always starts unapproved.
-            if not self._user.is_admin:
+            if not self._user.is_admin(*ROOT_PATH):
                 project.is_approved = False
             await self._enforce_project_cap(self._user.username)
 
@@ -119,7 +119,7 @@ class ProjectService:
         existing = await self._projects.read_one(identifiers)
         if existing is None:
             raise NotFoundError("Project not found", **identifiers)
-        if not (self._user.is_admin or existing.owner == self._user.username):
+        if not (self._user.is_admin(*ROOT_PATH) or existing.owner == self._user.username):
             raise PermissionError(required_role="owner-or-admin")
         return await self._projects.delete_one(identifiers)
 
@@ -152,13 +152,13 @@ class ProjectService:
         can see the project but does not own it gets a ``PermissionError`` (403).
         """
         data = update.model_dump(exclude_unset=True)
-        if "is_approved" in data and not self._user.is_admin:
+        if "is_approved" in data and not self._user.is_admin(*ROOT_PATH):
             raise PermissionError(required_role="admin")
 
         existing = await self._projects.read_one({"id": id})
         if existing is None:
             raise NotFoundError("Project not found", id=id)
-        if not (self._user.is_admin or existing.owner == self._user.username):
+        if not (self._user.is_admin(*ROOT_PATH) or existing.owner == self._user.username):
             raise PermissionError(required_role="owner-or-admin")
 
         resulting_approved = data.get("is_approved", existing.is_approved)
@@ -180,12 +180,7 @@ class ProjectService:
         if initiative is None or initiative.id is None:
             raise NotFoundError("Initiative not found or not visible", slug=slug)
 
-        if not (self._user.can_manage(id=slug, resource="initiative") or initiative.owner == self._user.username):
-            raise PermissionError(
-                message="user does not have adequate acceess to this resource",
-                required_role="initiative-owner-collaborator-or-admin",
-                resource_id=slug,
-            )
+        self._user.require_manage(*INITIATIVE_PATH, slug, doc_owner=initiative.owner)
 
         if not initiative.is_approved:
             # Unscoped integrity count: the member cap must see every project assigned to the

--- a/mpcontribs-api/src/mpcontribs_api/scope.py
+++ b/mpcontribs-api/src/mpcontribs_api/scope.py
@@ -2,7 +2,8 @@ from collections.abc import Callable, Collection
 from dataclasses import dataclass
 from typing import Any, Protocol, runtime_checkable
 
-from mpcontribs_api.authz import User
+from mpcontribs_api.authz import ROOT_PATH, User
+from mpcontribs_api.authz_core import Role
 
 
 @runtime_checkable
@@ -50,21 +51,28 @@ class Owned:
 
 
 @dataclass(frozen=True)
-class RoleIn:
-    """Visibility granted by the caller's roles, as a ``{field: {"$in": [...]}}`` membership test.
+class Granted:
+    """Visibility granted by the caller's role grants, as a ``{field: {"$in": [...]}}`` membership test.
 
-    ``source`` is the ``User`` atrtribute holding the granted ids (ie. ``"project_groups"``). Any role
-    assignment grants readability.
+    ``path`` is the full ARN prefix whose direct grants apply (e.g. ``("mpcontribs", "projects")``); the
+    clause reads them straight off the user's grant trie. ``min_role`` is the least-privileged role that
+    still grants read visibility — the default ``viewer`` means any grant counts (read is
+    presence-based); raise it to restrict visibility to writers/owners. ``coerce`` optionally maps each
+    granted id to the collection's id type (e.g. ``ObjectId``); a value whose coercion fails is
+    **dropped** (fail-closed). The clause drops out entirely when no grant qualifies.
     """
 
     field: str
-    source: str
+    path: tuple[str, ...]
+    min_role: Role = Role.viewer
     # TODO: Remove once _id -> PydanticObjectId coercion handling is improved
     coerce: Callable[[Any], Any] | None = None
 
     def to_query(self, user: User) -> dict[str, Any] | None:
-        raw: Collection[Any] = getattr(user, self.source)
-        values = self._coerce(raw)
+        ids = [
+            rid for rid, role in user.grants_in(*self.path).items() if isinstance(role, Role) and role >= self.min_role
+        ]
+        values = self._coerce(ids)
         if not values:
             return None
         return {self.field: {"$in": sorted(values)}}
@@ -86,16 +94,16 @@ class Scope:
     """A collection's read-visibility rule as a composition of :class:`ScopeClause` terms.
 
     :meth:`query` turns a ``User`` into the MongoDB filter injected into every scoped read. Admins
-    bypass read scope everywhere (a global rule, matching ``User.is_admin``). A ``Scope`` with no
-    clauses filters nothing — the explicit "unscoped collection" case (components, consumers), whose
-    visibility is gated elsewhere or not at all.
+    bypass read scope everywhere (a global rule, matching ``User.is_admin(*ROOT_PATH)``). A ``Scope``
+    with no clauses filters nothing — the explicit "unscoped collection" case (components, consumers),
+    whose visibility is gated elsewhere or not at all.
     """
 
     def __init__(self, *clauses: ScopeClause) -> None:
         self.clauses: tuple[ScopeClause, ...] = clauses
 
     def query(self, user: User) -> dict[str, Any]:
-        if user.is_admin:
+        if user.is_admin(*ROOT_PATH):
             return {}
         ors = [fragment for clause in self.clauses if (fragment := clause.to_query(user)) is not None]
         return {"$or": ors} if ors else {}

--- a/mpcontribs-api/src/mpcontribs_api/scope.py
+++ b/mpcontribs-api/src/mpcontribs_api/scope.py
@@ -53,11 +53,8 @@ class Owned:
 class RoleIn:
     """Visibility granted by the caller's roles, as a ``{field: {"$in": [...]}}`` membership test.
 
-    ``source`` names the ``User`` attribute holding the granted ids (e.g. ``"project_roles"``).
-    ``coerce`` optionally maps each raw role value to the collection's id type (e.g. ``ObjectId`` for
-    an ObjectId ``_id``); a value whose coercion fails is **dropped** — scope is fail-closed, so an
-    uncoercible (malformed) role grant is simply not honored. The clause is dropped entirely when the
-    caller holds no (usable) roles.
+    ``source`` is the ``User`` atrtribute holding the granted ids (ie. ``"project_groups"``). Any role
+    assignment grants readability.
     """
 
     field: str

--- a/mpcontribs-api/tests/conftest.py
+++ b/mpcontribs-api/tests/conftest.py
@@ -14,5 +14,7 @@ os.environ.setdefault("MPCONTRIBS_REDIS__ADDRESS", "redis://localhost:6379")
 os.environ.setdefault("MPCONTRIBS_REDIS__URL", "redis://localhost:6379")
 os.environ.setdefault("MPCONTRIBS_MAIL_DEFAULT_SENDER", "test@example.com")
 os.environ.setdefault("MPCONTRIBS_VERSION", "0.0.0-test")
+# Authz domain is required (no default) — each server declares the domain it enforces.
+os.environ.setdefault("MPCONTRIBS_AUTHZ__DOMAIN", "mpcontribs")
 # No OTLP collector in tests: keep telemetry off so the suite doesn't register providers or export.
 os.environ.setdefault("MPCONTRIBS_OTEL__ENABLED", "false")

--- a/mpcontribs-api/tests/integration/db/test_initiatives_repository.py
+++ b/mpcontribs-api/tests/integration/db/test_initiatives_repository.py
@@ -44,7 +44,7 @@ def _repo(user: User) -> MongoDbInitiativeRepository:
 
 def _collaborator(slug: str, username: str = BOB_EMAIL) -> User:
     """A user whose role grants them collaborator rights on ``slug``."""
-    return User(username=username, groups=frozenset({f"initiative:{slug}"}))
+    return User(username=username, groups=[f"mpcontribs:initiative:{slug}=owner"])
 
 
 async def _insert(slug: str, owner_user: User = ALICE, name: str = "An Initiative") -> Initiative:

--- a/mpcontribs-api/tests/integration/db/test_initiatives_repository.py
+++ b/mpcontribs-api/tests/integration/db/test_initiatives_repository.py
@@ -44,7 +44,7 @@ def _repo(user: User) -> MongoDbInitiativeRepository:
 
 def _collaborator(slug: str, username: str = BOB_EMAIL) -> User:
     """A user whose role grants them collaborator rights on ``slug``."""
-    return User(username=username, groups=[f"mpcontribs:initiative:{slug}=owner"])
+    return User(username=username, groups=[f"mpcontribs:initiatives/{slug}=owner"])
 
 
 async def _insert(slug: str, owner_user: User = ALICE, name: str = "An Initiative") -> Initiative:

--- a/mpcontribs-api/tests/integration/db/test_initiatives_service.py
+++ b/mpcontribs-api/tests/integration/db/test_initiatives_service.py
@@ -37,7 +37,7 @@ def _service(user: User) -> ProjectService:
 
 
 def _collaborator(slug: str, username: str = BOB_EMAIL) -> User:
-    return User(username=username, groups=[f"mpcontribs:initiative:{slug}=owner"])
+    return User(username=username, groups=[f"mpcontribs:initiatives/{slug}=owner"])
 
 
 async def _insert_project(pid: str, owner: str = ALICE_EMAIL) -> Project:

--- a/mpcontribs-api/tests/integration/db/test_initiatives_service.py
+++ b/mpcontribs-api/tests/integration/db/test_initiatives_service.py
@@ -37,7 +37,7 @@ def _service(user: User) -> ProjectService:
 
 
 def _collaborator(slug: str, username: str = BOB_EMAIL) -> User:
-    return User(username=username, groups=frozenset({f"initiative:{slug}"}))
+    return User(username=username, groups=[f"mpcontribs:initiative:{slug}=owner"])
 
 
 async def _insert_project(pid: str, owner: str = ALICE_EMAIL) -> Project:

--- a/mpcontribs-api/tests/integration/db/test_project_groups_repository.py
+++ b/mpcontribs-api/tests/integration/db/test_project_groups_repository.py
@@ -74,13 +74,13 @@ class TestGetOne:
 
 
 # ---------------------------------------------------------------------------
-# mpcontribs:project-group:<oid>=<role> scoping
+# mpcontribs:project-groups/<oid>=<role> scoping
 # ---------------------------------------------------------------------------
 
 
 def _role_user(group_id, username: str = "google:carol@example.com") -> User:
     """A non-owner authenticated user granted access to one group via a project-group grant."""
-    return User(username=username, groups=[f"mpcontribs:project-group:{group_id}=owner"])
+    return User(username=username, groups=[f"mpcontribs:project-groups/{group_id}=owner"])
 
 
 class TestGroupRoleScope:
@@ -97,7 +97,7 @@ class TestGroupRoleScope:
 
     async def test_malformed_role_is_ignored(self, db):
         await _insert("role-bad")
-        member = User(username="google:carol@example.com", groups=["mpcontribs:project-group:not-an-oid=owner"])
+        member = User(username="google:carol@example.com", groups=["mpcontribs:project-groups/not-an-oid=owner"])
         # A malformed role id must not raise; it simply grants nothing.
         found = await _repo(member).read_one({"name": "role-bad", "owner": ALICE_EMAIL}, fields=None)
         assert found is None

--- a/mpcontribs-api/tests/integration/db/test_project_groups_repository.py
+++ b/mpcontribs-api/tests/integration/db/test_project_groups_repository.py
@@ -74,13 +74,13 @@ class TestGetOne:
 
 
 # ---------------------------------------------------------------------------
-# project-group:<oid> role scoping
+# mpcontribs:project-group:<oid>=<role> scoping
 # ---------------------------------------------------------------------------
 
 
 def _role_user(group_id, username: str = "google:carol@example.com") -> User:
-    """A non-owner authenticated user granted access to one group via its project-group role."""
-    return User(username=username, groups=frozenset({f"project-group:{group_id}"}))
+    """A non-owner authenticated user granted access to one group via a project-group grant."""
+    return User(username=username, groups=[f"mpcontribs:project-group:{group_id}=owner"])
 
 
 class TestGroupRoleScope:
@@ -97,7 +97,7 @@ class TestGroupRoleScope:
 
     async def test_malformed_role_is_ignored(self, db):
         await _insert("role-bad")
-        member = User(username="google:carol@example.com", groups=frozenset({"project-group:not-an-oid"}))
+        member = User(username="google:carol@example.com", groups=["mpcontribs:project-group:not-an-oid=owner"])
         # A malformed role id must not raise; it simply grants nothing.
         found = await _repo(member).read_one({"name": "role-bad", "owner": ALICE_EMAIL}, fields=None)
         assert found is None

--- a/mpcontribs-api/tests/integration/db/test_project_groups_service.py
+++ b/mpcontribs-api/tests/integration/db/test_project_groups_service.py
@@ -36,7 +36,7 @@ def _service(user: User = ADMIN) -> ProjectGroupService:
 
 def _role_user(group_id, username: str = "google:carol@example.com") -> User:
     """A non-owner authenticated user granted access to one group via its project-group role."""
-    return User(username=username, groups=frozenset({f"project-group:{group_id}"}))
+    return User(username=username, groups=[f"mpcontribs:project-group:{group_id}=owner"])
 
 
 async def _insert_project(pid: str, owner: str = ALICE_EMAIL, **overrides):

--- a/mpcontribs-api/tests/integration/db/test_project_groups_service.py
+++ b/mpcontribs-api/tests/integration/db/test_project_groups_service.py
@@ -36,7 +36,7 @@ def _service(user: User = ADMIN) -> ProjectGroupService:
 
 def _role_user(group_id, username: str = "google:carol@example.com") -> User:
     """A non-owner authenticated user granted access to one group via its project-group role."""
-    return User(username=username, groups=[f"mpcontribs:project-group:{group_id}=owner"])
+    return User(username=username, groups=[f"mpcontribs:project-groups/{group_id}=owner"])
 
 
 async def _insert_project(pid: str, owner: str = ALICE_EMAIL, **overrides):

--- a/mpcontribs-api/tests/unit/domains/test_contribution_service.py
+++ b/mpcontribs-api/tests/unit/domains/test_contribution_service.py
@@ -7,7 +7,8 @@ from beanie import PydanticObjectId
 from pymatgen.core import Element
 from pymongo.errors import BulkWriteError
 
-from mpcontribs_api.authz import ADMIN_ROLE, User
+from mpcontribs_api.authz import User
+from mpcontribs_api.authz_core import ADMIN_ROLE
 from mpcontribs_api.config import MongoSettings, get_settings
 from mpcontribs_api.domains.attachments.models import Attachment, AttachmentIn
 from mpcontribs_api.domains.contributions.models import (

--- a/mpcontribs-api/tests/unit/domains/test_contribution_service.py
+++ b/mpcontribs-api/tests/unit/domains/test_contribution_service.py
@@ -7,7 +7,7 @@ from beanie import PydanticObjectId
 from pymatgen.core import Element
 from pymongo.errors import BulkWriteError
 
-from mpcontribs_api.authz import ADMIN_GROUP, User
+from mpcontribs_api.authz import ADMIN_ROLE, User
 from mpcontribs_api.config import MongoSettings, get_settings
 from mpcontribs_api.domains.attachments.models import Attachment, AttachmentIn
 from mpcontribs_api.domains.contributions.models import (
@@ -180,7 +180,7 @@ def _make_fake_client() -> tuple[AsyncMock, MagicMock]:
 def _admin_user() -> User:
     """An admin user — bypasses project write authorization, so tests not exercising authz
     keep their previous behavior."""
-    return User(username="admin", groups=frozenset({ADMIN_GROUP}))
+    return User(username="admin", groups=[ADMIN_ROLE])
 
 
 def _make_service(

--- a/mpcontribs-api/tests/unit/domains/test_contribution_service.py
+++ b/mpcontribs-api/tests/unit/domains/test_contribution_service.py
@@ -8,7 +8,7 @@ from pymatgen.core import Element
 from pymongo.errors import BulkWriteError
 
 from mpcontribs_api.authz import User
-from mpcontribs_api.authz_core import ADMIN_ROLE
+from mpcontribs_api.authz_core import ReservedRole
 from mpcontribs_api.config import MongoSettings, get_settings
 from mpcontribs_api.domains.attachments.models import Attachment, AttachmentIn
 from mpcontribs_api.domains.contributions.models import (
@@ -181,7 +181,7 @@ def _make_fake_client() -> tuple[AsyncMock, MagicMock]:
 def _admin_user() -> User:
     """An admin user — bypasses project write authorization, so tests not exercising authz
     keep their previous behavior."""
-    return User(username="admin", groups=[ADMIN_ROLE])
+    return User(username="admin", groups=[ReservedRole.admin])
 
 
 def _make_service(

--- a/mpcontribs-api/tests/unit/domains/test_initiative_service.py
+++ b/mpcontribs-api/tests/unit/domains/test_initiative_service.py
@@ -29,7 +29,7 @@ ALICE_EMAIL = "google:alice@example.com"
 
 
 def _collaborator(slug: str, username: str = "google:bob@example.com") -> User:
-    return User(username=username, groups=[f"mpcontribs:initiative:{slug}=owner"])
+    return User(username=username, groups=[f"mpcontribs:initiatives/{slug}=owner"])
 
 
 def _existing(owner: str = ALICE_EMAIL, *, is_public: bool = False, is_approved: bool = False):

--- a/mpcontribs-api/tests/unit/domains/test_initiative_service.py
+++ b/mpcontribs-api/tests/unit/domains/test_initiative_service.py
@@ -29,7 +29,7 @@ ALICE_EMAIL = "google:alice@example.com"
 
 
 def _collaborator(slug: str, username: str = "google:bob@example.com") -> User:
-    return User(username=username, groups=frozenset({f"initiative:{slug}"}))
+    return User(username=username, groups=[f"mpcontribs:initiative:{slug}=owner"])
 
 
 def _existing(owner: str = ALICE_EMAIL, *, is_public: bool = False, is_approved: bool = False):

--- a/mpcontribs-api/tests/unit/test_auth.py
+++ b/mpcontribs-api/tests/unit/test_auth.py
@@ -1,6 +1,17 @@
 import pytest
 
-from mpcontribs_api.authz import ADMIN_ROLE, PERSSON_ROLE, User, UserGroup
+from mpcontribs_api.authz import (
+    ADMIN_ROLE,
+    INITIATIVE_PATH,
+    PERSSON_ROLE,
+    PROJECT_GROUP_PATH,
+    PROJECT_PATH,
+    ROOT_PATH,
+    User,
+    UserGroup,
+    parse_grant,
+)
+from mpcontribs_api.exceptions import PermissionError
 
 ALICE = "google:alice@example.com"
 
@@ -24,15 +35,15 @@ class TestUserGroupParse:
         assert grant.role == "admin"
 
     def test_arn_depth_three(self):
-        grant = UserGroup.parse("mpcontribs:project:mp-a=editor")
+        grant = UserGroup.parse("mpcontribs:projects/mp-a=editor")
         assert grant is not None
-        assert grant.path == ("mpcontribs", "project", "mp-a")
+        assert grant.path == ("mpcontribs", "projects", "mp-a")
         assert grant.role == "editor"
 
     def test_arn_arbitrary_depth(self):
-        grant = UserGroup.parse("mpcontribs:project:name:something:some_name=owner")
+        grant = UserGroup.parse("mpcontribs:projects/name/something/some_name=owner")
         assert grant is not None
-        assert grant.path == ("mpcontribs", "project", "name", "something", "some_name")
+        assert grant.path == ("mpcontribs", "projects", "name", "something", "some_name")
         assert grant.role == "owner"
 
     @pytest.mark.parametrize(
@@ -40,68 +51,73 @@ class TestUserGroupParse:
         [
             "",
             "   ",
-            "mpcontribs:project:mp-a=",  # empty role
-            "mpcontribs::mp-a=owner",  # empty segment
-            "initiative:solar",  # prefixed legacy, no '=' -> no longer supported
-            "project-group:deadbeef",  # prefixed legacy, no '=' -> no longer supported
+            "mpcontribs:projects/mp-a=",  # empty role
+            "mpcontribs:/mp-a=owner",  # empty segment
+            "initiatives/solar",  # no '=' -> rejected
+            "project-groups/deadbeef",  # no '=' -> rejected
         ],
     )
     def test_malformed_is_dropped(self, raw: str):
         assert UserGroup.parse(raw) is None
 
+    def test_core_parse_rejects_legacy_forms(self):
+        # The domain-neutral grammar (UserGroup.parse) understands ARN tokens only; the `=`-less
+        # legacy forms are a server concern handled by ``parse_grant``, not the core.
+        assert UserGroup.parse("mp-team") is None
+        assert UserGroup.parse(ADMIN_ROLE) is None
+        assert UserGroup.parse(PERSSON_ROLE) is None
+
     def test_legacy_bare_id_becomes_project_owner(self):
-        grant = UserGroup.parse("mp-team")
+        grant = parse_grant("mp-team")
         assert grant is not None
-        assert grant.path == ("mpcontribs", "project", "mp-team")
+        assert grant.path == ("mpcontribs", "projects", "mp-team")
         assert grant.role == "owner"
 
     def test_legacy_admin_sentinel(self):
-        grant = UserGroup.parse(ADMIN_ROLE)
+        grant = parse_grant(ADMIN_ROLE)
         assert grant is not None
         assert grant.path == ("mpcontribs",)
         assert grant.role == ADMIN_ROLE
 
     def test_legacy_persson_sentinel(self):
-        grant = UserGroup.parse(PERSSON_ROLE)
+        grant = parse_grant(PERSSON_ROLE)
         assert grant is not None
         assert grant.role == PERSSON_ROLE
 
     def test_str_round_trips_through_parse(self):
-        grant = UserGroup.parse("mpcontribs:project:mp-a=viewer")
+        grant = UserGroup.parse("mpcontribs:projects/mp-a=viewer")
         assert grant is not None
-        assert str(grant) == "mpcontribs:project:mp-a=viewer"
+        assert str(grant) == "mpcontribs:projects/mp-a=viewer"
         assert UserGroup.parse(str(grant)) == grant
 
-    def test_role_value_with_equals_uses_last(self):
-        # rsplit on the last '=' keeps a stray '=' inside a segment out of the role.
-        grant = UserGroup.parse("mpcontribs:project:a=b=owner")
-        assert grant is not None
-        assert grant.path == ("mpcontribs", "project", "a=b")
-        assert grant.role == "owner"
+    def test_equals_in_name_is_rejected(self):
+        # '=' is banned from names, so a stray '=' before the role suffix fails closed rather than
+        # being swallowed into a segment (the role suffix stays unambiguous).
+        assert UserGroup.parse("mpcontribs:projects/a=b=owner") is None
 
 
 class TestUserIsAdmin:
     def test_no_groups_not_admin(self):
-        assert User(username=ALICE).is_admin is False
+        assert User(username=ALICE).is_admin(*ROOT_PATH) is False
 
     def test_admin_arn_is_admin(self):
-        assert User(username=ALICE, groups=["mpcontribs=admin"]).is_admin is True
+        assert User(username=ALICE, groups=["mpcontribs=admin"]).is_admin(*ROOT_PATH) is True
 
     def test_legacy_admin_sentinel_is_admin(self):
-        assert User(username=ALICE, groups=[ADMIN_ROLE]).is_admin is True
+        assert User(username=ALICE, groups=[ADMIN_ROLE]).is_admin(*ROOT_PATH) is True
 
     def test_project_role_is_not_admin(self):
-        assert User(username=ALICE, groups=["mpcontribs:project:mp-a=owner"]).is_admin is False
+        assert User(username=ALICE, groups=["mpcontribs:projects/mp-a=owner"]).is_admin(*ROOT_PATH) is False
 
     def test_admin_among_many_is_admin(self):
-        user = User(username=ALICE, groups=["mpcontribs:project:mp-a=owner", "mpcontribs=admin"])
-        assert user.is_admin is True
+        user = User(username=ALICE, groups=["mpcontribs:projects/mp-a=owner", "mpcontribs=admin"])
+        assert user.is_admin(*ROOT_PATH) is True
 
     def test_anonymous_admin_grant_is_stripped(self):
         # A reserved grant on an anonymous caller (no username) must never confer admin.
         user = User(groups=["mpcontribs=admin"])
         assert user.is_anonymous is True
-        assert user.is_admin is False
+        assert user.is_admin(*ROOT_PATH) is False
         assert user.groups == ()
 
     def test_anonymous_persson_grant_is_stripped(self):
@@ -111,100 +127,169 @@ class TestUserIsAdmin:
 
 class TestTrieLookups:
     def test_role_for_exact_path(self):
-        user = User(username=ALICE, groups=["mpcontribs:project:mp-a=editor"])
-        assert user.role_for("mpcontribs", "project", "mp-a") == "editor"
-        assert user.role_for("mpcontribs", "project", "mp-b") is None
+        user = User(username=ALICE, groups=["mpcontribs:projects/mp-a=editor"])
+        assert user.role_for("mpcontribs", "projects", "mp-a") == "editor"
+        assert user.role_for("mpcontribs", "projects", "mp-b") is None
 
     def test_role_for_deep_path(self):
-        user = User(username=ALICE, groups=["mpcontribs:project:name:sub:leaf=owner"])
-        assert user.role_for("mpcontribs", "project", "name", "sub", "leaf") == "owner"
+        user = User(username=ALICE, groups=["mpcontribs:projects/name/sub/leaf=owner"])
+        assert user.role_for("mpcontribs", "projects", "name", "sub", "leaf") == "owner"
         # An intermediate node carries no role of its own.
-        assert user.role_for("mpcontribs", "project", "name") is None
+        assert user.role_for("mpcontribs", "projects", "name") is None
 
     def test_has_grant_prefix(self):
-        user = User(username=ALICE, groups=["mpcontribs:project:name:sub:leaf=owner"])
-        assert user.has_grant("mpcontribs", "project", "name") is True
-        assert user.has_grant("mpcontribs", "project", "other") is False
+        user = User(username=ALICE, groups=["mpcontribs:projects/name/sub/leaf=owner"])
+        assert user.has_grant("mpcontribs", "projects", "name") is True
+        assert user.has_grant("mpcontribs", "projects", "other") is False
 
 
 class TestResourceMappings:
-    def test_project_groups_maps_id_to_role(self):
+    def test_grants_in_project_maps_id_to_role(self):
         user = User(
             username=ALICE,
-            groups=["mpcontribs:project:mp-a=owner", "mpcontribs:project:mp-b=viewer"],
+            groups=["mpcontribs:projects/mp-a=owner", "mpcontribs:projects/mp-b=viewer"],
         )
-        assert user.project_groups == {"mp-a": "owner", "mp-b": "viewer"}
+        assert user.grants_in(*PROJECT_PATH) == {"mp-a": "owner", "mp-b": "viewer"}
 
-    def test_initiative_and_project_group_scopes(self):
+    def test_grants_in_initiative_and_project_group_scopes(self):
         user = User(
             username=ALICE,
             groups=[
-                "mpcontribs:initiative:solar=editor",
-                "mpcontribs:project-group:deadbeef=viewer",
+                "mpcontribs:initiatives/solar=editor",
+                "mpcontribs:project-groups/deadbeef=viewer",
             ],
         )
-        assert user.initiative_groups == {"solar": "editor"}
-        assert user.project_group_groups == {"deadbeef": "viewer"}
+        assert user.grants_in(*INITIATIVE_PATH) == {"solar": "editor"}
+        assert user.grants_in(*PROJECT_GROUP_PATH) == {"deadbeef": "viewer"}
 
     def test_deeper_grant_not_surfaced_as_resource(self):
         # A grant strictly beneath a project id is stored but not a direct project grant yet.
-        user = User(username=ALICE, groups=["mpcontribs:project:mp-a:sub=owner"])
-        assert user.project_groups == {}
-        assert user.has_grant("mpcontribs", "project", "mp-a") is True
+        user = User(username=ALICE, groups=["mpcontribs:projects/mp-a/sub=owner"])
+        assert user.grants_in(*PROJECT_PATH) == {}
+        assert user.has_grant("mpcontribs", "projects", "mp-a") is True
 
 
 class TestReadWriteRoles:
-    def test_readable_includes_viewer(self):
+    def test_any_role_is_present_for_read(self):
+        # Read is presence-based: every granted role shows up in grants_in regardless of rank.
         user = User(
             username=ALICE,
-            groups=["mpcontribs:project:mp-a=viewer", "mpcontribs:project:mp-b=editor"],
+            groups=["mpcontribs:projects/mp-a=viewer", "mpcontribs:projects/mp-b=editor"],
         )
-        assert user.readable_projects == frozenset({"mp-a", "mp-b"})
+        assert set(user.grants_in(*PROJECT_PATH)) == {"mp-a", "mp-b"}
 
     def test_writable_excludes_viewer(self):
         user = User(
             username=ALICE,
             groups=[
-                "mpcontribs:project:mp-a=viewer",
-                "mpcontribs:project:mp-b=editor",
-                "mpcontribs:project:mp-c=owner",
+                "mpcontribs:projects/mp-a=viewer",
+                "mpcontribs:projects/mp-b=editor",
+                "mpcontribs:projects/mp-c=owner",
             ],
         )
-        assert user.writable_projects == frozenset({"mp-b", "mp-c"})
+        assert user.writable(*PROJECT_PATH) == frozenset({"mp-b", "mp-c"})
 
     def test_can_write_owner_and_editor_only(self):
         user = User(
             username=ALICE,
-            groups=["mpcontribs:project:mp-a=viewer", "mpcontribs:project:mp-b=editor"],
+            groups=["mpcontribs:projects/mp-a=viewer", "mpcontribs:projects/mp-b=editor"],
         )
-        assert user.can_write("mp-a") is False
-        assert user.can_write("mp-b") is True
+        assert user.can_write(*PROJECT_PATH, "mp-a") is False
+        assert user.can_write(*PROJECT_PATH, "mp-b") is True
 
     def test_admin_can_write_any_project(self):
-        assert User(username=ALICE, groups=["mpcontribs=admin"]).can_write("anything") is True
+        assert User(username=ALICE, groups=["mpcontribs=admin"]).can_write(*PROJECT_PATH, "anything") is True
 
-    def test_anonymous_has_no_writable_or_readable(self):
+    def test_anonymous_has_no_writable(self):
         user = User()
-        assert user.writable_projects == frozenset()
-        assert user.readable_projects == frozenset()
+        assert user.writable(*PROJECT_PATH) == frozenset()
 
 
 class TestCanManage:
     def test_owner_can_manage(self):
-        user = User(username=ALICE, groups=["mpcontribs:initiative:solar=owner"])
-        assert user.can_manage("solar", "initiative") is True
+        user = User(username=ALICE, groups=["mpcontribs:initiatives/solar=owner"])
+        assert user.can_manage(*INITIATIVE_PATH, "solar") is True
 
     def test_editor_and_viewer_cannot_manage(self):
-        editor = User(username=ALICE, groups=["mpcontribs:initiative:solar=editor"])
-        viewer = User(username=ALICE, groups=["mpcontribs:initiative:solar=viewer"])
-        assert editor.can_manage("solar", "initiative") is False
-        assert viewer.can_manage("solar", "initiative") is False
+        editor = User(username=ALICE, groups=["mpcontribs:initiatives/solar=editor"])
+        viewer = User(username=ALICE, groups=["mpcontribs:initiatives/solar=viewer"])
+        assert editor.can_manage(*INITIATIVE_PATH, "solar") is False
+        assert viewer.can_manage(*INITIATIVE_PATH, "solar") is False
 
     def test_admin_can_manage_anything(self):
-        assert User(username=ALICE, groups=["mpcontribs=admin"]).can_manage("solar", "initiative") is True
+        assert User(username=ALICE, groups=["mpcontribs=admin"]).can_manage(*INITIATIVE_PATH, "solar") is True
 
     def test_anonymous_cannot_manage(self):
-        assert User().can_manage("solar", "initiative") is False
+        assert User().can_manage(*INITIATIVE_PATH, "solar") is False
+
+    def test_doc_owner_can_manage_without_role(self):
+        # The document's own owner manages it even with no ARN role grant.
+        user = User(username=ALICE, groups=[])
+        assert user.can_manage(*INITIATIVE_PATH, "solar", doc_owner=ALICE) is True
+        assert user.can_manage(*INITIATIVE_PATH, "solar", doc_owner="someone-else") is False
+
+
+class TestRequireGates:
+    def test_require_write_passes_for_editor(self):
+        user = User(username=ALICE, groups=["mpcontribs:projects/mp-a=editor"])
+        user.require_write(*PROJECT_PATH, "mp-a")  # does not raise
+
+    def test_require_write_raises_for_viewer(self):
+        user = User(username=ALICE, groups=["mpcontribs:projects/mp-a=viewer"])
+        with pytest.raises(PermissionError):
+            user.require_write(*PROJECT_PATH, "mp-a")
+
+    def test_require_write_denies_none_project(self):
+        user = User(username=ALICE, groups=["mpcontribs=admin"])
+        with pytest.raises(PermissionError):
+            user.require_write(*PROJECT_PATH, None)
+
+    def test_require_manage_passes_for_owner_role(self):
+        user = User(username=ALICE, groups=["mpcontribs:initiatives/solar=owner"])
+        user.require_manage(*INITIATIVE_PATH, "solar")  # does not raise
+
+    def test_require_manage_passes_for_doc_owner(self):
+        user = User(username=ALICE, groups=[])
+        user.require_manage(*INITIATIVE_PATH, "solar", doc_owner=ALICE)  # does not raise
+
+    def test_require_manage_raises_for_editor(self):
+        user = User(username=ALICE, groups=["mpcontribs:initiatives/solar=editor"])
+        with pytest.raises(PermissionError):
+            user.require_manage(*INITIATIVE_PATH, "solar")
+
+
+class TestCrossDomainPaths:
+    """"Domain" is just path[0]: a grant under one root is invisible when a different root is asked.
+
+    Two servers share the same users; a grant in another server's domain is carried on the trie but is
+    invisible to this server's ``mpcontribs``-rooted paths unless that other root is named explicitly.
+    """
+
+    def test_grant_under_other_root_hidden(self):
+        user = User(username=ALICE, groups=["core:projects/x=editor"])
+        assert user.grants_in(*PROJECT_PATH) == {}
+        assert user.grants_in("core", "projects") == {"x": "editor"}
+
+    def test_can_write_respects_root(self):
+        user = User(username=ALICE, groups=["core:projects/x=editor"])
+        assert user.can_write(*PROJECT_PATH, "x") is False
+        assert user.can_write("core", "projects", "x") is True
+
+    def test_writable_respects_root(self):
+        user = User(username=ALICE, groups=["core:projects/x=owner", "mpcontribs:projects/y=owner"])
+        assert user.writable(*PROJECT_PATH) == frozenset({"y"})
+        assert user.writable("core", "projects") == frozenset({"x"})
+
+    def test_is_admin_respects_root(self):
+        user = User(username=ALICE, groups=["core=admin"])
+        # Admin under the "core" root is not admin under this server's mpcontribs root.
+        assert user.is_admin(*ROOT_PATH) is False
+        assert user.is_admin("core") is True
+
+    def test_can_manage_respects_root(self):
+        user = User(username=ALICE, groups=["core:initiatives/solar=owner"])
+        assert user.can_manage(*INITIATIVE_PATH, "solar") is False
+        assert user.can_manage("core", "initiatives", "solar") is True
 
 
 class TestUserImmutability:
@@ -214,7 +299,7 @@ class TestUserImmutability:
             user.username = "google:bob@example.com"  # type: ignore[misc]
 
     def test_user_is_hashable(self):
-        user = User(username=ALICE, groups=["mpcontribs:project:mp-a=owner"])
+        user = User(username=ALICE, groups=["mpcontribs:projects/mp-a=owner"])
         assert isinstance(hash(user), int)
 
     def test_groups_default_empty(self):
@@ -229,15 +314,15 @@ class TestUserConstruction:
         user = User(
             consumer_id="kong-consumer-123",
             username=ALICE,
-            groups=["mpcontribs:project:mp-team=editor"],
+            groups=["mpcontribs:projects/mp-team=editor"],
         )
         assert user.consumer_id == "kong-consumer-123"
         assert user.username == ALICE
-        assert user.can_write("mp-team") is True
-        assert user.is_admin is False
+        assert user.can_write(*PROJECT_PATH, "mp-team") is True
+        assert user.is_admin(*ROOT_PATH) is False
         assert user.is_anonymous is False
 
     def test_accepts_prebuilt_usergroup(self):
-        grant = UserGroup(path=("mpcontribs", "project", "mp-a"), role="owner")
+        grant = UserGroup(path=("mpcontribs", "projects", "mp-a"), role="owner")
         user = User(username=ALICE, groups=[grant])
-        assert user.can_write("mp-a") is True
+        assert user.can_write(*PROJECT_PATH, "mp-a") is True

--- a/mpcontribs-api/tests/unit/test_auth.py
+++ b/mpcontribs-api/tests/unit/test_auth.py
@@ -1,12 +1,11 @@
 import pytest
 
 from mpcontribs_api.authz import (
-    ADMIN_ROLE,
     INITIATIVE_PATH,
-    PERSSON_ROLE,
     PROJECT_GROUP_PATH,
     PROJECT_PATH,
     ROOT_PATH,
+    ReservedRole,
     User,
     UserGroup,
     parse_grant,
@@ -64,8 +63,8 @@ class TestUserGroupParse:
         # The domain-neutral grammar (UserGroup.parse) understands ARN tokens only; the `=`-less
         # legacy forms are a server concern handled by ``parse_grant``, not the core.
         assert UserGroup.parse("mp-team") is None
-        assert UserGroup.parse(ADMIN_ROLE) is None
-        assert UserGroup.parse(PERSSON_ROLE) is None
+        assert UserGroup.parse(ReservedRole.admin) is None
+        assert UserGroup.parse(ReservedRole.persson_group) is None
 
     def test_legacy_bare_id_becomes_project_owner(self):
         grant = parse_grant("mp-team")
@@ -74,15 +73,15 @@ class TestUserGroupParse:
         assert grant.role == "owner"
 
     def test_legacy_admin_sentinel(self):
-        grant = parse_grant(ADMIN_ROLE)
+        grant = parse_grant(ReservedRole.admin)
         assert grant is not None
         assert grant.path == ("mpcontribs",)
-        assert grant.role == ADMIN_ROLE
+        assert grant.role == ReservedRole.admin
 
     def test_legacy_persson_sentinel(self):
-        grant = parse_grant(PERSSON_ROLE)
+        grant = parse_grant(ReservedRole.persson_group)
         assert grant is not None
-        assert grant.role == PERSSON_ROLE
+        assert grant.role == ReservedRole.persson_group
 
     def test_str_round_trips_through_parse(self):
         grant = UserGroup.parse("mpcontribs:projects/mp-a=viewer")
@@ -104,7 +103,7 @@ class TestUserIsAdmin:
         assert User(username=ALICE, groups=["mpcontribs=admin"]).is_admin(*ROOT_PATH) is True
 
     def test_legacy_admin_sentinel_is_admin(self):
-        assert User(username=ALICE, groups=[ADMIN_ROLE]).is_admin(*ROOT_PATH) is True
+        assert User(username=ALICE, groups=[ReservedRole.admin]).is_admin(*ROOT_PATH) is True
 
     def test_project_role_is_not_admin(self):
         assert User(username=ALICE, groups=["mpcontribs:projects/mp-a=owner"]).is_admin(*ROOT_PATH) is False
@@ -121,7 +120,7 @@ class TestUserIsAdmin:
         assert user.groups == ()
 
     def test_anonymous_persson_grant_is_stripped(self):
-        user = User(groups=[PERSSON_ROLE])
+        user = User(groups=[ReservedRole.persson_group])
         assert user.groups == ()
 
 

--- a/mpcontribs-api/tests/unit/test_auth.py
+++ b/mpcontribs-api/tests/unit/test_auth.py
@@ -1,91 +1,243 @@
 import pytest
 
-from mpcontribs_api.authz import ADMIN_GROUP, User
+from mpcontribs_api.authz import ADMIN_ROLE, PERSSON_ROLE, User, UserGroup
+
+ALICE = "google:alice@example.com"
 
 
 class TestUserIsAnonymous:
     def test_no_username_is_anonymous(self):
-        user = User()
-        assert user.is_anonymous is True
+        assert User().is_anonymous is True
 
     def test_username_none_is_anonymous(self):
-        user = User(username=None)
-        assert user.is_anonymous is True
+        assert User(username=None).is_anonymous is True
 
     def test_with_username_not_anonymous(self):
-        user = User(username="google:alice@example.com")
-        assert user.is_anonymous is False
+        assert User(username=ALICE).is_anonymous is False
+
+
+class TestUserGroupParse:
+    def test_arn_depth_one(self):
+        grant = UserGroup.parse("mpcontribs=admin")
+        assert grant is not None
+        assert grant.path == ("mpcontribs",)
+        assert grant.role == "admin"
+
+    def test_arn_depth_three(self):
+        grant = UserGroup.parse("mpcontribs:project:mp-a=editor")
+        assert grant is not None
+        assert grant.path == ("mpcontribs", "project", "mp-a")
+        assert grant.role == "editor"
+
+    def test_arn_arbitrary_depth(self):
+        grant = UserGroup.parse("mpcontribs:project:name:something:some_name=owner")
+        assert grant is not None
+        assert grant.path == ("mpcontribs", "project", "name", "something", "some_name")
+        assert grant.role == "owner"
+
+    @pytest.mark.parametrize(
+        "raw",
+        [
+            "",
+            "   ",
+            "mpcontribs:project:mp-a=",  # empty role
+            "mpcontribs::mp-a=owner",  # empty segment
+            "initiative:solar",  # prefixed legacy, no '=' -> no longer supported
+            "project-group:deadbeef",  # prefixed legacy, no '=' -> no longer supported
+        ],
+    )
+    def test_malformed_is_dropped(self, raw: str):
+        assert UserGroup.parse(raw) is None
+
+    def test_legacy_bare_id_becomes_project_owner(self):
+        grant = UserGroup.parse("mp-team")
+        assert grant is not None
+        assert grant.path == ("mpcontribs", "project", "mp-team")
+        assert grant.role == "owner"
+
+    def test_legacy_admin_sentinel(self):
+        grant = UserGroup.parse(ADMIN_ROLE)
+        assert grant is not None
+        assert grant.path == ("mpcontribs",)
+        assert grant.role == ADMIN_ROLE
+
+    def test_legacy_persson_sentinel(self):
+        grant = UserGroup.parse(PERSSON_ROLE)
+        assert grant is not None
+        assert grant.role == PERSSON_ROLE
+
+    def test_str_round_trips_through_parse(self):
+        grant = UserGroup.parse("mpcontribs:project:mp-a=viewer")
+        assert grant is not None
+        assert str(grant) == "mpcontribs:project:mp-a=viewer"
+        assert UserGroup.parse(str(grant)) == grant
+
+    def test_role_value_with_equals_uses_last(self):
+        # rsplit on the last '=' keeps a stray '=' inside a segment out of the role.
+        grant = UserGroup.parse("mpcontribs:project:a=b=owner")
+        assert grant is not None
+        assert grant.path == ("mpcontribs", "project", "a=b")
+        assert grant.role == "owner"
 
 
 class TestUserIsAdmin:
     def test_no_groups_not_admin(self):
-        user = User(username="google:alice@example.com")
-        assert user.is_admin is False
+        assert User(username=ALICE).is_admin is False
 
-    def test_admin_group_is_admin(self):
-        user = User(username="google:alice@example.com", groups=frozenset({ADMIN_GROUP}))
+    def test_admin_arn_is_admin(self):
+        assert User(username=ALICE, groups=["mpcontribs=admin"]).is_admin is True
+
+    def test_legacy_admin_sentinel_is_admin(self):
+        assert User(username=ALICE, groups=[ADMIN_ROLE]).is_admin is True
+
+    def test_project_role_is_not_admin(self):
+        assert User(username=ALICE, groups=["mpcontribs:project:mp-a=owner"]).is_admin is False
+
+    def test_admin_among_many_is_admin(self):
+        user = User(username=ALICE, groups=["mpcontribs:project:mp-a=owner", "mpcontribs=admin"])
         assert user.is_admin is True
 
-    def test_other_group_not_admin(self):
-        user = User(username="google:alice@example.com", groups=frozenset({"editors"}))
-        assert user.is_admin is False
-
-    def test_admin_group_among_many_is_admin(self):
-        user = User(username="google:alice@example.com", groups=frozenset({"editors", ADMIN_GROUP, "viewers"}))
-        assert user.is_admin is True
-
-    def test_anonymous_cannot_be_admin(self):
-        # Even if groups include admin, anonymous user (no username) is still anonymous
-        user = User(groups=frozenset({ADMIN_GROUP}))
+    def test_anonymous_admin_grant_is_stripped(self):
+        # A reserved grant on an anonymous caller (no username) must never confer admin.
+        user = User(groups=["mpcontribs=admin"])
         assert user.is_anonymous is True
-        # But is_admin only checks groups, not username
         assert user.is_admin is False
+        assert user.groups == ()
+
+    def test_anonymous_persson_grant_is_stripped(self):
+        user = User(groups=[PERSSON_ROLE])
+        assert user.groups == ()
 
 
-class TestUserHasRole:
-    def test_has_role_in_groups(self):
-        user = User(username="google:alice@example.com", groups=frozenset({"editors", "viewers"}))
-        assert user.has_role("editors") is True
+class TestTrieLookups:
+    def test_role_for_exact_path(self):
+        user = User(username=ALICE, groups=["mpcontribs:project:mp-a=editor"])
+        assert user.role_for("mpcontribs", "project", "mp-a") == "editor"
+        assert user.role_for("mpcontribs", "project", "mp-b") is None
 
-    def test_has_role_not_in_groups(self):
-        user = User(username="google:alice@example.com", groups=frozenset({"editors"}))
-        assert user.has_role("viewers") is False
+    def test_role_for_deep_path(self):
+        user = User(username=ALICE, groups=["mpcontribs:project:name:sub:leaf=owner"])
+        assert user.role_for("mpcontribs", "project", "name", "sub", "leaf") == "owner"
+        # An intermediate node carries no role of its own.
+        assert user.role_for("mpcontribs", "project", "name") is None
 
-    def test_has_role_empty_groups(self):
-        user = User(username="google:alice@example.com")
-        assert user.has_role("editors") is False
+    def test_has_grant_prefix(self):
+        user = User(username=ALICE, groups=["mpcontribs:project:name:sub:leaf=owner"])
+        assert user.has_grant("mpcontribs", "project", "name") is True
+        assert user.has_grant("mpcontribs", "project", "other") is False
 
-    def test_has_role_case_sensitive(self):
-        user = User(username="google:alice@example.com", groups=frozenset({"Editors"}))
-        assert user.has_role("editors") is False
-        assert user.has_role("Editors") is True
+
+class TestResourceMappings:
+    def test_project_groups_maps_id_to_role(self):
+        user = User(
+            username=ALICE,
+            groups=["mpcontribs:project:mp-a=owner", "mpcontribs:project:mp-b=viewer"],
+        )
+        assert user.project_groups == {"mp-a": "owner", "mp-b": "viewer"}
+
+    def test_initiative_and_project_group_scopes(self):
+        user = User(
+            username=ALICE,
+            groups=[
+                "mpcontribs:initiative:solar=editor",
+                "mpcontribs:project-group:deadbeef=viewer",
+            ],
+        )
+        assert user.initiative_groups == {"solar": "editor"}
+        assert user.project_group_groups == {"deadbeef": "viewer"}
+
+    def test_deeper_grant_not_surfaced_as_resource(self):
+        # A grant strictly beneath a project id is stored but not a direct project grant yet.
+        user = User(username=ALICE, groups=["mpcontribs:project:mp-a:sub=owner"])
+        assert user.project_groups == {}
+        assert user.has_grant("mpcontribs", "project", "mp-a") is True
+
+
+class TestReadWriteRoles:
+    def test_readable_includes_viewer(self):
+        user = User(
+            username=ALICE,
+            groups=["mpcontribs:project:mp-a=viewer", "mpcontribs:project:mp-b=editor"],
+        )
+        assert user.readable_projects == frozenset({"mp-a", "mp-b"})
+
+    def test_writable_excludes_viewer(self):
+        user = User(
+            username=ALICE,
+            groups=[
+                "mpcontribs:project:mp-a=viewer",
+                "mpcontribs:project:mp-b=editor",
+                "mpcontribs:project:mp-c=owner",
+            ],
+        )
+        assert user.writable_projects == frozenset({"mp-b", "mp-c"})
+
+    def test_can_write_owner_and_editor_only(self):
+        user = User(
+            username=ALICE,
+            groups=["mpcontribs:project:mp-a=viewer", "mpcontribs:project:mp-b=editor"],
+        )
+        assert user.can_write("mp-a") is False
+        assert user.can_write("mp-b") is True
+
+    def test_admin_can_write_any_project(self):
+        assert User(username=ALICE, groups=["mpcontribs=admin"]).can_write("anything") is True
+
+    def test_anonymous_has_no_writable_or_readable(self):
+        user = User()
+        assert user.writable_projects == frozenset()
+        assert user.readable_projects == frozenset()
+
+
+class TestCanManage:
+    def test_owner_can_manage(self):
+        user = User(username=ALICE, groups=["mpcontribs:initiative:solar=owner"])
+        assert user.can_manage("solar", "initiative") is True
+
+    def test_editor_and_viewer_cannot_manage(self):
+        editor = User(username=ALICE, groups=["mpcontribs:initiative:solar=editor"])
+        viewer = User(username=ALICE, groups=["mpcontribs:initiative:solar=viewer"])
+        assert editor.can_manage("solar", "initiative") is False
+        assert viewer.can_manage("solar", "initiative") is False
+
+    def test_admin_can_manage_anything(self):
+        assert User(username=ALICE, groups=["mpcontribs=admin"]).can_manage("solar", "initiative") is True
+
+    def test_anonymous_cannot_manage(self):
+        assert User().can_manage("solar", "initiative") is False
 
 
 class TestUserImmutability:
     def test_user_is_frozen(self):
-        user = User(username="google:alice@example.com")
+        user = User(username=ALICE)
         with pytest.raises(Exception):
             user.username = "google:bob@example.com"  # type: ignore[misc]
 
-    def test_groups_default_empty_frozenset(self):
-        user = User()
-        assert user.groups == frozenset()
+    def test_user_is_hashable(self):
+        user = User(username=ALICE, groups=["mpcontribs:project:mp-a=owner"])
+        assert isinstance(hash(user), int)
+
+    def test_groups_default_empty(self):
+        assert User().groups == ()
 
     def test_consumer_id_default_none(self):
-        user = User()
-        assert user.consumer_id is None
+        assert User().consumer_id is None
 
 
 class TestUserConstruction:
     def test_full_user(self):
         user = User(
             consumer_id="kong-consumer-123",
-            username="google:alice@example.com",
-            groups=frozenset({"editors", "mp-team"}),
+            username=ALICE,
+            groups=["mpcontribs:project:mp-team=editor"],
         )
         assert user.consumer_id == "kong-consumer-123"
-        assert user.username == "google:alice@example.com"
-        assert "editors" in user.groups
-        assert "admin" not in user.groups
+        assert user.username == ALICE
+        assert user.can_write("mp-team") is True
         assert user.is_admin is False
         assert user.is_anonymous is False
+
+    def test_accepts_prebuilt_usergroup(self):
+        grant = UserGroup(path=("mpcontribs", "project", "mp-a"), role="owner")
+        user = User(username=ALICE, groups=[grant])
+        assert user.can_write("mp-a") is True

--- a/mpcontribs-api/tests/unit/test_authz_core.py
+++ b/mpcontribs-api/tests/unit/test_authz_core.py
@@ -1,0 +1,184 @@
+"""Unit tests for the domain-agnostic authorization core (``mpcontribs_api.authz_core``).
+
+This is the shared grant-validation contract both API servers rely on: pure ARN grammar, the role
+hierarchy, and a :class:`User` whose accessors are **path-based** — they take a generic ``*path`` of
+ARN segments and give the first segment ("the domain") no special meaning beyond being where an admin
+grant sits. ``ADMIN_ROLE``/``PERSSON_ROLE`` are the globally reserved keywords bound as the core's
+defaults; a local subclass shows those hooks can be re-bound.
+"""
+
+from typing import ClassVar
+
+import pytest
+
+from mpcontribs_api.authz_core import ADMIN_ROLE, PERSSON_ROLE, ReservedRole, Role, User, UserGroup
+from mpcontribs_api.exceptions import PermissionError
+
+ALICE = "google:alice@example.com"
+
+
+class CoreUser(User):
+    """Re-binds the core's admin hook to a *different* reserved role, proving the hook is overridable.
+
+    The default admin role is ``ReservedRole.admin``; this subclass makes ``persson_group`` the role
+    that confers admin instead (and the only role stripped from anonymous callers), so its ``=admin``
+    grants are ordinary while its ``=persson_group`` grants are the elevated ones.
+    """
+
+    admin_role: ClassVar[ReservedRole | None] = ReservedRole.persson_group
+    reserved_roles: ClassVar[frozenset[ReservedRole]] = frozenset({ReservedRole.persson_group})
+
+
+class TestRole:
+    def test_hierarchy_order(self):
+        assert Role.viewer < Role.editor < Role.owner
+        assert Role.owner >= Role.editor >= Role.viewer
+
+    def test_parse_known_and_unknown(self):
+        assert Role.parse("editor") is Role.editor
+        assert Role.parse("root") is None  # reserved/unknown roles never rank
+        assert Role.parse(None) is None
+
+
+class TestUserGroupGrammar:
+    def test_parses_arbitrary_depth(self):
+        grant = UserGroup.parse("d:a/b/c=owner")
+        assert grant is not None
+        assert grant.path == ("d", "a", "b", "c")
+        assert grant.role == "owner"
+        assert grant.domain == "d"
+
+    def test_rejects_equals_in_name(self):
+        # '=' is banned from names, so a stray '=' before the role suffix fails closed rather than
+        # being swallowed into a segment (the delimiter role suffix stays unambiguous).
+        assert UserGroup.parse("d:proj/a=b=owner") is None
+
+    def test_str_round_trips(self):
+        grant = UserGroup.parse("d:proj/mp-a=viewer")
+        assert grant is not None
+        assert str(grant) == "d:proj/mp-a=viewer"
+        assert UserGroup.parse(str(grant)) == grant
+
+    def test_domain_root_grant_round_trips(self):
+        grant = UserGroup.parse("d=admin")
+        assert grant is not None
+        assert grant.path == ("d",)
+        assert str(grant) == "d=admin"
+
+    @pytest.mark.parametrize(
+        "raw",
+        [
+            "",
+            "   ",
+            "d:proj/mp-a=",  # empty role
+            "d:/mp-a=owner",  # empty segment
+            "mp-team",  # no '=': legacy form is a server concern, not the neutral grammar
+            "root",  # bare sentinel: also '='-less, rejected by the core
+            "d:proj/mp-a",  # no '='
+        ],
+    )
+    def test_rejects_non_arn(self, raw: str):
+        assert UserGroup.parse(raw) is None
+
+
+class TestTrieLookups:
+    def test_role_for_and_has_grant(self):
+        user = CoreUser(username=ALICE, groups=["d:proj/name/sub=owner"])
+        assert user.role_for("d", "proj", "name", "sub") == "owner"
+        assert user.role_for("d", "proj", "name") is None  # intermediate node carries no role
+        assert user.has_grant("d", "proj", "name") is True
+        assert user.has_grant("d", "proj", "other") is False
+
+    def test_grants_in_by_path(self):
+        user = CoreUser(username=ALICE, groups=["d:proj/mp-a=owner", "d:proj/mp-b=viewer"])
+        assert user.grants_in("d", "proj") == {"mp-a": "owner", "mp-b": "viewer"}
+        assert user.grants_in("other", "proj") == {}
+
+
+class TestPathBasedAccessors:
+    def test_is_admin_is_per_path(self):
+        user = CoreUser(username=ALICE, groups=["d=persson_group"])
+        assert user.is_admin("d") is True
+        assert user.is_admin("other") is False
+
+    def test_bare_core_uses_global_admin_role(self):
+        # The core binds ADMIN_ROLE ("admin") as the default admin role; another valid role is not admin.
+        assert User(username=ALICE, groups=["d=admin"]).is_admin("d") is True
+        assert User(username=ALICE, groups=["d=owner"]).is_admin("d") is False
+
+    def test_writable_and_can_write(self):
+        user = CoreUser(
+            username=ALICE,
+            groups=["d:proj/a=viewer", "d:proj/b=editor", "d:proj/c=owner"],
+        )
+        assert user.writable("d", "proj") == frozenset({"b", "c"})
+        assert user.can_write("d", "proj", "a") is False
+        assert user.can_write("d", "proj", "b") is True
+
+    def test_admin_can_write_anything_under_its_root(self):
+        user = CoreUser(username=ALICE, groups=["d=persson_group"])
+        assert user.can_write("d", "proj", "anything") is True
+        assert user.can_write("other", "proj", "anything") is False
+
+    def test_can_write_denies_none_segment_even_for_admin(self):
+        user = CoreUser(username=ALICE, groups=["d=persson_group"])
+        assert user.can_write("d", "proj", None) is False
+
+    def test_can_manage_owner_and_doc_owner(self):
+        owner = CoreUser(username=ALICE, groups=["d:init/solar=owner"])
+        assert owner.can_manage("d", "init", "solar") is True
+        editor = CoreUser(username=ALICE, groups=["d:init/solar=editor"])
+        assert editor.can_manage("d", "init", "solar") is False
+        # The document's own owner manages it with no role grant at all.
+        plain = CoreUser(username=ALICE, groups=[])
+        assert plain.can_manage("d", "init", "solar", doc_owner=ALICE) is True
+        assert plain.can_manage("d", "init", "solar", doc_owner="someone-else") is False
+
+    def test_cross_domain_isolation(self):
+        # "domain" is just path[0]: a grant under one root is invisible when a different root is asked.
+        user = CoreUser(username=ALICE, groups=["core:proj/x=owner"])
+        assert user.writable("mpcontribs", "proj") == frozenset()
+        assert user.writable("core", "proj") == frozenset({"x"})
+        assert user.can_write("mpcontribs", "proj", "x") is False
+        assert user.can_write("core", "proj", "x") is True
+
+
+class TestRequireGates:
+    def test_require_write_raises_for_viewer(self):
+        user = CoreUser(username=ALICE, groups=["d:proj/a=viewer"])
+        with pytest.raises(PermissionError):
+            user.require_write("d", "proj", "a")
+
+    def test_require_write_denies_none_segment(self):
+        user = CoreUser(username=ALICE, groups=["d=persson_group"])
+        with pytest.raises(PermissionError):
+            user.require_write("d", "proj", None)
+
+    def test_require_manage_passes_for_owner(self):
+        user = CoreUser(username=ALICE, groups=["d:init/solar=owner"])
+        user.require_manage("d", "init", "solar")  # does not raise
+
+    def test_require_manage_raises_for_editor(self):
+        user = CoreUser(username=ALICE, groups=["d:init/solar=editor"])
+        with pytest.raises(PermissionError):
+            user.require_manage("d", "init", "solar")
+
+
+class TestReservedRoleStripping:
+    def test_anonymous_reserved_grant_stripped(self):
+        # A reserved-role grant (CoreUser's admin sentinel) must never survive on an anonymous caller.
+        user = CoreUser(groups=["d=persson_group"])
+        assert user.is_anonymous is True
+        assert user.groups == ()
+        assert user.is_admin("d") is False
+
+    def test_authenticated_reserved_grant_kept(self):
+        user = CoreUser(username=ALICE, groups=["d=persson_group"])
+        assert user.is_admin("d") is True
+
+    def test_globally_reserved_roles_are_stripped_from_anonymous(self):
+        # The core reserves ADMIN_ROLE/PERSSON_ROLE globally: neither survives on an anonymous caller.
+        assert User(groups=[f"d={ADMIN_ROLE}"]).groups == ()
+        assert User(groups=[f"d={PERSSON_ROLE}"]).groups == ()
+        # A non-reserved role is kept even when anonymous.
+        assert User(groups=["d:proj/x=owner"]).groups != ()

--- a/mpcontribs-api/tests/unit/test_authz_core.py
+++ b/mpcontribs-api/tests/unit/test_authz_core.py
@@ -3,7 +3,7 @@
 This is the shared grant-validation contract both API servers rely on: pure ARN grammar, the role
 hierarchy, and a :class:`User` whose accessors are **path-based** — they take a generic ``*path`` of
 ARN segments and give the first segment ("the domain") no special meaning beyond being where an admin
-grant sits. ``ADMIN_ROLE``/``PERSSON_ROLE`` are the globally reserved keywords bound as the core's
+grant sits. ``ReservedRole.admin``/``ReservedRole.persson_group`` are the globally reserved keywords bound as the core's
 defaults; a local subclass shows those hooks can be re-bound.
 """
 
@@ -11,7 +11,7 @@ from typing import ClassVar
 
 import pytest
 
-from mpcontribs_api.authz_core import ADMIN_ROLE, PERSSON_ROLE, ReservedRole, Role, User, UserGroup
+from mpcontribs_api.authz_core import ReservedRole, Role, User, UserGroup
 from mpcontribs_api.exceptions import PermissionError
 
 ALICE = "google:alice@example.com"
@@ -102,7 +102,7 @@ class TestPathBasedAccessors:
         assert user.is_admin("other") is False
 
     def test_bare_core_uses_global_admin_role(self):
-        # The core binds ADMIN_ROLE ("admin") as the default admin role; another valid role is not admin.
+        # The core binds ReservedRole.admin ("admin") as the default admin role; another valid role is not admin.
         assert User(username=ALICE, groups=["d=admin"]).is_admin("d") is True
         assert User(username=ALICE, groups=["d=owner"]).is_admin("d") is False
 
@@ -177,8 +177,8 @@ class TestReservedRoleStripping:
         assert user.is_admin("d") is True
 
     def test_globally_reserved_roles_are_stripped_from_anonymous(self):
-        # The core reserves ADMIN_ROLE/PERSSON_ROLE globally: neither survives on an anonymous caller.
-        assert User(groups=[f"d={ADMIN_ROLE}"]).groups == ()
-        assert User(groups=[f"d={PERSSON_ROLE}"]).groups == ()
+        # The core reserves every ReservedRole globally: none survives on an anonymous caller.
+        assert User(groups=[f"d={ReservedRole.admin}"]).groups == ()
+        assert User(groups=[f"d={ReservedRole.persson_group}"]).groups == ()
         # A non-reserved role is kept even when anonymous.
         assert User(groups=["d:proj/x=owner"]).groups != ()

--- a/mpcontribs-api/tests/unit/test_dependencies.py
+++ b/mpcontribs-api/tests/unit/test_dependencies.py
@@ -78,14 +78,14 @@ class TestGetUser:
         assert user.is_anonymous is False
         assert user.username == "google:alice@example.com"
         assert user.consumer_id == "kong-123"
-        assert "editors" in user.groups
-        assert "mp-team" in user.groups
+        # Bare legacy tokens from either header become project grants (default owner role).
+        assert user.project_groups == {"editors": "owner", "mp-team": "owner"}
 
     def test_authenticated_user_no_groups(self):
         request = _make_request(**{"x-consumer-username": "google:alice@example.com"})
         user = get_user(request)
         assert user.is_anonymous is False
-        assert user.groups == frozenset()
+        assert user.groups == ()
 
     def test_groups_merged_from_both_headers(self):
         request = _make_request(
@@ -96,7 +96,7 @@ class TestGetUser:
             }
         )
         user = get_user(request)
-        assert user.groups == frozenset({"a", "b", "c", "d"})
+        assert user.project_groups == {"a": "owner", "b": "owner", "c": "owner", "d": "owner"}
 
     def test_missing_username_returns_anonymous(self):
         request = _make_request(**{"x-consumer-id": "kong-123"})
@@ -111,7 +111,7 @@ class TestGetUser:
 
 class TestRequireUser:
     def test_authenticated_user_passes_through(self):
-        authed = User(username="google:alice@example.com", groups=frozenset())
+        authed = User(username="google:alice@example.com", groups=[])
         result = require_user(authed)
         assert result is authed
 

--- a/mpcontribs-api/tests/unit/test_dependencies.py
+++ b/mpcontribs-api/tests/unit/test_dependencies.py
@@ -2,7 +2,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from mpcontribs_api.authz import User
+from mpcontribs_api.authz import PROJECT_PATH, User
 from mpcontribs_api.dependencies import _split, get_user, require_user
 from mpcontribs_api.exceptions import AuthenticationError
 
@@ -79,7 +79,20 @@ class TestGetUser:
         assert user.username == "google:alice@example.com"
         assert user.consumer_id == "kong-123"
         # Bare legacy tokens from either header become project grants (default owner role).
-        assert user.project_groups == {"editors": "owner", "mp-team": "owner"}
+        assert user.grants_in(*PROJECT_PATH) == {"editors": "owner", "mp-team": "owner"}
+
+    def test_full_arn_grant_from_header(self):
+        # A full new-format ARN string (not a bare legacy token) arriving via Kong headers parses
+        # end-to-end through the comma-split and grant parser, keeping its own role.
+        request = _make_request(
+            **{
+                "x-consumer-username": "google:alice@example.com",
+                "x-authenticated-groups": "mpcontribs:projects/mp-a=editor",
+            }
+        )
+        user = get_user(request)
+        assert user.grants_in(*PROJECT_PATH) == {"mp-a": "editor"}
+        assert user.can_write(*PROJECT_PATH, "mp-a") is True
 
     def test_authenticated_user_no_groups(self):
         request = _make_request(**{"x-consumer-username": "google:alice@example.com"})
@@ -96,7 +109,7 @@ class TestGetUser:
             }
         )
         user = get_user(request)
-        assert user.project_groups == {"a": "owner", "b": "owner", "c": "owner", "d": "owner"}
+        assert user.grants_in(*PROJECT_PATH) == {"a": "owner", "b": "owner", "c": "owner", "d": "owner"}
 
     def test_missing_username_returns_anonymous(self):
         request = _make_request(**{"x-consumer-id": "kong-123"})

--- a/mpcontribs-api/tests/unit/test_scope.py
+++ b/mpcontribs-api/tests/unit/test_scope.py
@@ -10,20 +10,16 @@ Pure and DB-free. Two layers:
 
 from beanie import PydanticObjectId
 
-from mpcontribs_api.authz import (
-    INITIATIVE_ROLE_PREFIX,
-    PROJECT_GROUP_ROLE_PREFIX,
-    User,
-)
+from mpcontribs_api.authz import User
 from mpcontribs_api.domains.contributions.repository import MongoDbContributionRepository
 from mpcontribs_api.domains.initiatives.repository import MongoDbInitiativeRepository
 from mpcontribs_api.domains.project_groups.repository import MongoDbProjectGroupRepository
 from mpcontribs_api.domains.projects.repository import MongoDbProjectRepository
 from mpcontribs_api.scope import Owned, Public, RoleIn, Scope
 
-ADMIN = User(username="google:admin@example.com", groups=frozenset({"admin"}))
+ADMIN = User(username="google:admin@example.com", groups=["mpcontribs=admin"])
 ANON = User()
-ALICE = User(username="google:alice@example.com", groups=frozenset())
+ALICE = User(username="google:alice@example.com", groups=[])
 
 
 def _clauses(scope: dict) -> list[dict]:
@@ -63,32 +59,32 @@ class TestOwnedClause:
 
 class TestRoleInClause:
     def test_membership_test_sorted(self):
-        user = User(username="u@x.com", groups=frozenset({"mp-b", "mp-a"}))
-        assert RoleIn("_id", "project_roles").to_query(user) == {"_id": {"$in": ["mp-a", "mp-b"]}}
+        user = User(username="u@x.com", groups=["mpcontribs:project:mp-b=owner", "mpcontribs:project:mp-a=viewer"])
+        assert RoleIn("_id", "project_groups").to_query(user) == {"_id": {"$in": ["mp-a", "mp-b"]}}
 
     def test_no_roles_is_inapplicable(self):
-        user = User(username="u@x.com", groups=frozenset())
-        assert RoleIn("_id", "project_roles").to_query(user) is None
+        user = User(username="u@x.com", groups=[])
+        assert RoleIn("_id", "project_groups").to_query(user) is None
 
     def test_coerce_maps_each_value(self):
         oid = "a" * 24
-        user = User(username="u@x.com", groups=frozenset({f"{PROJECT_GROUP_ROLE_PREFIX}{oid}"}))
-        clause = RoleIn("_id", "project_group_roles", coerce=PydanticObjectId)
+        user = User(username="u@x.com", groups=[f"mpcontribs:project-group:{oid}=viewer"])
+        clause = RoleIn("_id", "project_group_groups", coerce=PydanticObjectId)
         assert clause.to_query(user) == {"_id": {"$in": [PydanticObjectId(oid)]}}
 
     def test_coerce_drops_invalid_values(self):
         oid = "a" * 24
         user = User(
             username="u@x.com",
-            groups=frozenset({f"{PROJECT_GROUP_ROLE_PREFIX}{oid}", f"{PROJECT_GROUP_ROLE_PREFIX}not-an-oid"}),
+            groups=[f"mpcontribs:project-group:{oid}=viewer", "mpcontribs:project-group:not-an-oid=viewer"],
         )
-        clause = RoleIn("_id", "project_group_roles", coerce=PydanticObjectId)
+        clause = RoleIn("_id", "project_group_groups", coerce=PydanticObjectId)
         # The malformed hex string is fail-closed dropped; only the valid ObjectId survives.
         assert clause.to_query(user) == {"_id": {"$in": [PydanticObjectId(oid)]}}
 
     def test_coerce_all_invalid_is_inapplicable(self):
-        user = User(username="u@x.com", groups=frozenset({f"{PROJECT_GROUP_ROLE_PREFIX}nope"}))
-        clause = RoleIn("_id", "project_group_roles", coerce=PydanticObjectId)
+        user = User(username="u@x.com", groups=["mpcontribs:project-group:nope=viewer"])
+        clause = RoleIn("_id", "project_group_groups", coerce=PydanticObjectId)
         assert clause.to_query(user) is None
 
 
@@ -98,7 +94,7 @@ class TestRoleInClause:
 
 
 class TestScopeQuery:
-    scope = Scope(Public(approved=True), Owned(), RoleIn("_id", "project_roles"))
+    scope = Scope(Public(approved=True), Owned(), RoleIn("_id", "project_groups"))
 
     def test_admin_bypasses_scope(self):
         assert self.scope.query(ADMIN) == {}
@@ -113,7 +109,7 @@ class TestScopeQuery:
         assert self.scope.query(ANON) == {"$or": [{"is_public": True, "is_approved": True}]}
 
     def test_clause_order_preserved(self):
-        user = User(username="alice@x.com", groups=frozenset({"mp-a"}))
+        user = User(username="alice@x.com", groups=["mpcontribs:project:mp-a=owner"])
         assert _clauses(self.scope.query(user)) == [
             {"is_public": True, "is_approved": True},
             {"owner": "alice@x.com"},
@@ -132,18 +128,22 @@ class TestProjectScope:
     def test_admin_unfiltered(self):
         assert self.scope.query(ADMIN) == {}
 
-    def test_public_approved_owner_and_bare_project_ids(self):
-        user = User(username="alice@x.com", groups=frozenset({"mp-a", "mp-b"}))
+    def test_public_approved_owner_and_project_ids(self):
+        user = User(username="alice@x.com", groups=["mpcontribs:project:mp-a=owner", "mpcontribs:project:mp-b=viewer"])
         clauses = _clauses(self.scope.query(user))
         assert {"is_public": True, "is_approved": True} in clauses
         assert {"owner": "alice@x.com"} in clauses
         assert {"_id": {"$in": ["mp-a", "mp-b"]}} in clauses
 
-    def test_prefixed_and_admin_roles_excluded_from_id_clause(self):
-        # Only bare project ids may key the _id clause; resource-scoped/admin roles must not leak in.
+    def test_other_scopes_excluded_from_id_clause(self):
+        # Only project-scoped grants may key the _id clause; other scopes/admin must not leak in.
         user = User(
             username="alice@x.com",
-            groups=frozenset({"mp-a", f"{INITIATIVE_ROLE_PREFIX}foo", f"{PROJECT_GROUP_ROLE_PREFIX}deadbeef"}),
+            groups=[
+                "mpcontribs:project:mp-a=owner",
+                "mpcontribs:initiative:foo=owner",
+                "mpcontribs:project-group:deadbeef=owner",
+            ],
         )
         role_clause = next(c for c in _clauses(self.scope.query(user)) if "_id" in c)
         assert role_clause == {"_id": {"$in": ["mp-a"]}}
@@ -156,7 +156,7 @@ class TestInitiativeScope:
         assert self.scope.query(ADMIN) == {}
 
     def test_public_approved_owner_and_slug_roles(self):
-        user = User(username="alice@x.com", groups=frozenset({f"{INITIATIVE_ROLE_PREFIX}solar"}))
+        user = User(username="alice@x.com", groups=["mpcontribs:initiative:solar=viewer"])
         clauses = _clauses(self.scope.query(user))
         assert {"is_public": True, "is_approved": True} in clauses
         assert {"owner": "alice@x.com"} in clauses
@@ -178,7 +178,7 @@ class TestProjectGroupScope:
         oid = "a" * 24
         user = User(
             username="alice@x.com",
-            groups=frozenset({f"{PROJECT_GROUP_ROLE_PREFIX}{oid}", f"{PROJECT_GROUP_ROLE_PREFIX}not-an-oid"}),
+            groups=[f"mpcontribs:project-group:{oid}=viewer", "mpcontribs:project-group:not-an-oid=viewer"],
         )
         role_clause = next(c for c in _clauses(self.scope.query(user)) if "_id" in c)
         assert role_clause == {"_id": {"$in": [PydanticObjectId(oid)]}}
@@ -191,10 +191,16 @@ class TestContributionScope:
         assert self.scope.query(ADMIN) == {}
 
     def test_no_owner_clause_and_public_unapproved(self):
-        user = User(username="alice@x.com", groups=frozenset({"mp-a"}))
+        user = User(username="alice@x.com", groups=["mpcontribs:project:mp-a=owner"])
         clauses = _clauses(self.scope.query(user))
         assert {"is_public": True} in clauses
         assert all("owner" not in c for c in clauses)
+        assert {"project": {"$in": ["mp-a"]}} in clauses
+
+    def test_viewer_can_read_contributions(self):
+        # Read visibility is presence-based: a project viewer sees the project's contributions.
+        user = User(username="alice@x.com", groups=["mpcontribs:project:mp-a=viewer"])
+        clauses = _clauses(self.scope.query(user))
         assert {"project": {"$in": ["mp-a"]}} in clauses
 
     def test_anonymous_only_public(self):

--- a/mpcontribs-api/tests/unit/test_scope.py
+++ b/mpcontribs-api/tests/unit/test_scope.py
@@ -10,12 +10,13 @@ Pure and DB-free. Two layers:
 
 from beanie import PydanticObjectId
 
-from mpcontribs_api.authz import User
+from mpcontribs_api.authz import PROJECT_GROUP_PATH, PROJECT_PATH, User
+from mpcontribs_api.authz_core import Role
 from mpcontribs_api.domains.contributions.repository import MongoDbContributionRepository
 from mpcontribs_api.domains.initiatives.repository import MongoDbInitiativeRepository
 from mpcontribs_api.domains.project_groups.repository import MongoDbProjectGroupRepository
 from mpcontribs_api.domains.projects.repository import MongoDbProjectRepository
-from mpcontribs_api.scope import Owned, Public, RoleIn, Scope
+from mpcontribs_api.scope import Granted, Owned, Public, Scope
 
 ADMIN = User(username="google:admin@example.com", groups=["mpcontribs=admin"])
 ANON = User()
@@ -57,35 +58,51 @@ class TestOwnedClause:
         assert Owned().to_query(ANON) is None
 
 
-class TestRoleInClause:
+class TestGrantedClause:
     def test_membership_test_sorted(self):
-        user = User(username="u@x.com", groups=["mpcontribs:project:mp-b=owner", "mpcontribs:project:mp-a=viewer"])
-        assert RoleIn("_id", "project_groups").to_query(user) == {"_id": {"$in": ["mp-a", "mp-b"]}}
+        user = User(username="u@x.com", groups=["mpcontribs:projects/mp-b=owner", "mpcontribs:projects/mp-a=viewer"])
+        assert Granted("_id", PROJECT_PATH).to_query(user) == {"_id": {"$in": ["mp-a", "mp-b"]}}
 
     def test_no_roles_is_inapplicable(self):
         user = User(username="u@x.com", groups=[])
-        assert RoleIn("_id", "project_groups").to_query(user) is None
+        assert Granted("_id", PROJECT_PATH).to_query(user) is None
+
+    def test_min_role_filters_below_threshold(self):
+        # Default min_role is viewer (presence); raising it drops lower roles from visibility.
+        user = User(username="u@x.com", groups=["mpcontribs:projects/mp-a=viewer", "mpcontribs:projects/mp-b=editor"])
+        assert Granted("_id", PROJECT_PATH).to_query(user) == {"_id": {"$in": ["mp-a", "mp-b"]}}
+        assert Granted("_id", PROJECT_PATH, min_role=Role.editor).to_query(user) == {"_id": {"$in": ["mp-b"]}}
+        assert Granted("_id", PROJECT_PATH, min_role=Role.owner).to_query(user) is None
 
     def test_coerce_maps_each_value(self):
         oid = "a" * 24
-        user = User(username="u@x.com", groups=[f"mpcontribs:project-group:{oid}=viewer"])
-        clause = RoleIn("_id", "project_group_groups", coerce=PydanticObjectId)
+        user = User(username="u@x.com", groups=[f"mpcontribs:project-groups/{oid}=viewer"])
+        clause = Granted("_id", PROJECT_GROUP_PATH, coerce=PydanticObjectId)
         assert clause.to_query(user) == {"_id": {"$in": [PydanticObjectId(oid)]}}
 
     def test_coerce_drops_invalid_values(self):
         oid = "a" * 24
         user = User(
             username="u@x.com",
-            groups=[f"mpcontribs:project-group:{oid}=viewer", "mpcontribs:project-group:not-an-oid=viewer"],
+            groups=[f"mpcontribs:project-groups/{oid}=viewer", "mpcontribs:project-groups/not-an-oid=viewer"],
         )
-        clause = RoleIn("_id", "project_group_groups", coerce=PydanticObjectId)
+        clause = Granted("_id", PROJECT_GROUP_PATH, coerce=PydanticObjectId)
         # The malformed hex string is fail-closed dropped; only the valid ObjectId survives.
         assert clause.to_query(user) == {"_id": {"$in": [PydanticObjectId(oid)]}}
 
     def test_coerce_all_invalid_is_inapplicable(self):
-        user = User(username="u@x.com", groups=["mpcontribs:project-group:nope=viewer"])
-        clause = RoleIn("_id", "project_group_groups", coerce=PydanticObjectId)
+        user = User(username="u@x.com", groups=["mpcontribs:project-groups/nope=viewer"])
+        clause = Granted("_id", PROJECT_GROUP_PATH, coerce=PydanticObjectId)
         assert clause.to_query(user) is None
+
+    def test_path_selects_grant_source(self):
+        # A clause reads grants under its own path prefix; a different root's grants are invisible to it.
+        user = User(
+            username="u@x.com",
+            groups=["mpcontribs:projects/mp-a=owner", "core:projects/mp-b=owner"],
+        )
+        assert Granted("_id", PROJECT_PATH).to_query(user) == {"_id": {"$in": ["mp-a"]}}
+        assert Granted("_id", ("core", "projects")).to_query(user) == {"_id": {"$in": ["mp-b"]}}
 
 
 # ---------------------------------------------------------------------------
@@ -94,7 +111,7 @@ class TestRoleInClause:
 
 
 class TestScopeQuery:
-    scope = Scope(Public(approved=True), Owned(), RoleIn("_id", "project_groups"))
+    scope = Scope(Public(approved=True), Owned(), Granted("_id", PROJECT_PATH))
 
     def test_admin_bypasses_scope(self):
         assert self.scope.query(ADMIN) == {}
@@ -109,7 +126,7 @@ class TestScopeQuery:
         assert self.scope.query(ANON) == {"$or": [{"is_public": True, "is_approved": True}]}
 
     def test_clause_order_preserved(self):
-        user = User(username="alice@x.com", groups=["mpcontribs:project:mp-a=owner"])
+        user = User(username="alice@x.com", groups=["mpcontribs:projects/mp-a=owner"])
         assert _clauses(self.scope.query(user)) == [
             {"is_public": True, "is_approved": True},
             {"owner": "alice@x.com"},
@@ -129,7 +146,7 @@ class TestProjectScope:
         assert self.scope.query(ADMIN) == {}
 
     def test_public_approved_owner_and_project_ids(self):
-        user = User(username="alice@x.com", groups=["mpcontribs:project:mp-a=owner", "mpcontribs:project:mp-b=viewer"])
+        user = User(username="alice@x.com", groups=["mpcontribs:projects/mp-a=owner", "mpcontribs:projects/mp-b=viewer"])
         clauses = _clauses(self.scope.query(user))
         assert {"is_public": True, "is_approved": True} in clauses
         assert {"owner": "alice@x.com"} in clauses
@@ -140,9 +157,9 @@ class TestProjectScope:
         user = User(
             username="alice@x.com",
             groups=[
-                "mpcontribs:project:mp-a=owner",
-                "mpcontribs:initiative:foo=owner",
-                "mpcontribs:project-group:deadbeef=owner",
+                "mpcontribs:projects/mp-a=owner",
+                "mpcontribs:initiatives/foo=owner",
+                "mpcontribs:project-groups/deadbeef=owner",
             ],
         )
         role_clause = next(c for c in _clauses(self.scope.query(user)) if "_id" in c)
@@ -156,7 +173,7 @@ class TestInitiativeScope:
         assert self.scope.query(ADMIN) == {}
 
     def test_public_approved_owner_and_slug_roles(self):
-        user = User(username="alice@x.com", groups=["mpcontribs:initiative:solar=viewer"])
+        user = User(username="alice@x.com", groups=["mpcontribs:initiatives/solar=viewer"])
         clauses = _clauses(self.scope.query(user))
         assert {"is_public": True, "is_approved": True} in clauses
         assert {"owner": "alice@x.com"} in clauses
@@ -178,7 +195,7 @@ class TestProjectGroupScope:
         oid = "a" * 24
         user = User(
             username="alice@x.com",
-            groups=[f"mpcontribs:project-group:{oid}=viewer", "mpcontribs:project-group:not-an-oid=viewer"],
+            groups=[f"mpcontribs:project-groups/{oid}=viewer", "mpcontribs:project-groups/not-an-oid=viewer"],
         )
         role_clause = next(c for c in _clauses(self.scope.query(user)) if "_id" in c)
         assert role_clause == {"_id": {"$in": [PydanticObjectId(oid)]}}
@@ -191,7 +208,7 @@ class TestContributionScope:
         assert self.scope.query(ADMIN) == {}
 
     def test_no_owner_clause_and_public_unapproved(self):
-        user = User(username="alice@x.com", groups=["mpcontribs:project:mp-a=owner"])
+        user = User(username="alice@x.com", groups=["mpcontribs:projects/mp-a=owner"])
         clauses = _clauses(self.scope.query(user))
         assert {"is_public": True} in clauses
         assert all("owner" not in c for c in clauses)
@@ -199,7 +216,7 @@ class TestContributionScope:
 
     def test_viewer_can_read_contributions(self):
         # Read visibility is presence-based: a project viewer sees the project's contributions.
-        user = User(username="alice@x.com", groups=["mpcontribs:project:mp-a=viewer"])
+        user = User(username="alice@x.com", groups=["mpcontribs:projects/mp-a=viewer"])
         clauses = _clauses(self.scope.query(user))
         assert {"project": {"$in": ["mp-a"]}} in clauses
 


### PR DESCRIPTION
## Summary
Solidified how Users are defined and handle grants coming from Kong. Expects ARN formatted ACLs, but built in a shim to handle conversion from legacy format.

## Major Changes
- Extracted general User logic into authz_core.py in anticipation of extraction to a shared repo
- Expects ARN formatted grants like: 
`"domain:resource_type/resource_name=role,domain:resource_type/resource_name=role,..."`